### PR TITLE
Add radiative and convective boundary conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ valid as `input.info`.
 
 ### Input file
 The following options are available:
+* boundary:
+  * type: type of boundary: adiabatic, radiative, or convective. Multiple types
+  can be chosen simultaneously by separating them by comma
 * discretization:
   * fe\_degree: degree of the finite element used
   * quadrature: quadrature used: gauss or lobatto (default value: gauss)
@@ -61,10 +64,10 @@ The following options are available:
   * material\_deposition: material is deposed during the simulation: true or
   false (default value: false)
   * if material\_deposition is true:
-    * material\_deposition\_method: file, scan_paths
+    * material\_deposition\_method: file, scan\_paths
     * if material\_deposition\_method is file:
         * material\_deposition\_file: material deposition filename
-    * if material\_deposition\_method is scan_paths:
+    * if material\_deposition\_method is scan\_paths:
         * deposition\_length: length of material deposition boxes along the scan direction
         * deposition\_width: width of material deposition boxes (in the plane of the material, normal to the scan direction, 3D only)
         * deposition\_height: height of material deposition boxes (out of the plane of the material)
@@ -88,10 +91,12 @@ The following options are available:
   * material\_X: property tree for the material with number X
   * material\_X.Y: property tree where Y is either liquid, powder, or solid
   (optional)
-  * material\_X.Y.Z: Z is either density in kg/m^3, specific\_heat in J/(K\*kg), or
-  thermal\_conductivity in W/(m\*K) (optional)
-  * material\_X.A: A is either solidus in kelvin, liquidus in kelvin, or latent\_heat
-  in J/kg (optional)
+  * material\_X.Y.Z: Z is either density in kg/m^3, specific\_heat in J/(K\*kg),
+  thermal\_conductivity in W/(m\*K), emissivity, or convection\_heat\_transfer\_coef
+  in W/(m^2\*K) (optional)
+  * material\_X.A: A is either solidus in kelvin, liquidus in kelvin, latent\_heat
+  in J/kg, radiation\_temperature\_infty in kelvin, or convection\_temperature\_infty
+  in kelvin (optional)
 * memory\_space: device (use GPU) or host (use CPU) (default value: host)
 * post\_processor:
   * filename\_prefix: prefix of output files

--- a/application/input.info
+++ b/application/input.info
@@ -8,6 +8,11 @@ geometry
   height_divisions 10 ; Number of cell layers in the height direction
 }
 
+boundary
+{
+  type adiabatic
+}
+
 refinement
 {
   n_heat_refinements 0 ; Number of coarsening/refinement executed (uses Kelly's

--- a/source/MaterialProperty.hh
+++ b/source/MaterialProperty.hh
@@ -36,17 +36,6 @@ class MaterialProperty
 public:
   /**
    * Constructor.
-   * \param[in] database requires the following entries:
-   *   - <B>n_materials</B>: unsigned int in \f$(0,\infty)\f$
-   *   - <B>material_X</B>: property tree associated with material_X
-   *   where X is a number
-   *   - <B>material_X.Y</B>: property_tree where Y is either liquid, powder, or
-   *   solid [optional]
-   *   - <B>material_X.Y.Z</B>: string where Z is either density, specific_heat,
-   *   or thermal_conductivity, describe the behavior of the property as a
-   *   function of the temperatur (e.g. "2.*T") [optional]
-   *   - <B>material.X.A</B>: A is either solidus, liquidus, or latent heat
-   * [optional]
    */
   MaterialProperty(
       MPI_Comm const &communicator,

--- a/source/ThermalOperator.hh
+++ b/source/ThermalOperator.hh
@@ -24,7 +24,8 @@ class ThermalOperator final : public ThermalOperatorBase<dim, MemorySpaceType>
 {
 public:
   ThermalOperator(MPI_Comm const &communicator,
-                  std::shared_ptr<MaterialProperty<dim>> material_properties);
+                  std::shared_ptr<MaterialProperty<dim>> material_properties,
+                  BoundaryType boundary_type);
 
   /**
    * Associate the AffineConstraints<double> and the MatrixFree objects to the
@@ -105,7 +106,7 @@ private:
   /**
    * Apply the operator on a given set of quadrature points.
    */
-  void local_apply(
+  void cell_local_apply(
       dealii::MatrixFree<dim, double> const &data,
       dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
       dealii::LA::distributed::Vector<double, MemorySpaceType> const &src,
@@ -132,13 +133,21 @@ private:
    */
   std::shared_ptr<MaterialProperty<dim>> _material_properties;
   /**
+   * Type of boundary.
+   */
+  BoundaryType _boundary_type;
+  /**
    * Underlying MatrixFree object.
    */
   dealii::MatrixFree<dim, double> _matrix_free;
   /**
-   * The inverse of the mass matrix is computed using an inexact Gauss-Lobatto
-   * quadrature. This inexact quadrature makes the mass matrix and therefore
-   * also its inverse, a diagonal matrix.
+   * Non-owning pointer to the AffineConstraints from ThermalPhysics.
+   */
+  dealii::AffineConstraints<double> const *_affine_constraints;
+  /**
+   * The inverse of the mass matrix is computed using an inexact
+   * Gauss-Lobatto quadrature. This inexact quadrature makes the mass matrix
+   * and therefore also its inverse, a diagonal matrix.
    */
   std::shared_ptr<dealii::LA::distributed::Vector<double, MemorySpaceType>>
       _inverse_mass_matrix;

--- a/source/ThermalPhysics.hh
+++ b/source/ThermalPhysics.hh
@@ -166,6 +166,10 @@ private:
    */
   double _current_source_height = 0.;
   /**
+   * Type of boundary.
+   */
+  BoundaryType _boundary_type;
+  /**
    * Associated geometry.
    */
   Geometry<dim> &_geometry;

--- a/source/types.hh
+++ b/source/types.hh
@@ -43,6 +43,9 @@ enum class StateProperty
   density,
   specific_heat,
   thermal_conductivity,
+  emissivity,
+  radiation_heat_transfer_coef,
+  convection_heat_transfer_coef,
   SIZE
 };
 
@@ -55,6 +58,8 @@ enum class Property
   liquidus,
   solidus,
   latent_heat,
+  radiation_temperature_infty,
+  convection_temperature_infty,
   SIZE
 };
 
@@ -72,6 +77,17 @@ enum Timing
   evol_time_eval_mat_prop,
   output,
   n_timers
+};
+
+/**
+ * Structure that stores constants.
+ */
+struct Constant
+{
+  /**
+   * Stefan-Boltzmann constant. Value from NIST [w/(m^2 k^4)].
+   */
+  static double constexpr stefan_boltzmann = 5.670374419e-8;
 };
 
 /**
@@ -99,6 +115,65 @@ struct axis<3>
   static int constexpr y = 1;
   static int constexpr z = 2;
 };
+
+/**
+ * Enum on the different types of boundary condition supported. Some of them can
+ * be combined, for example radiative and convective.
+ */
+enum BoundaryType
+{
+  invalid = 0,
+  adiabatic = 0x1,
+  radiative = 0x2,
+  convective = 0x4,
+};
+
+/**
+ * Global operator which returns an object in which all bits are set which are
+ * either set in the first or the second argument. This operator exists since if
+ * it did not then the result of the bit-or operator | would be an integer which
+ * would in turn trigger a compiler warning when we tried to assign it to an
+ * object of type BoundaryType.
+ */
+inline BoundaryType operator|(const BoundaryType b1, const BoundaryType b2)
+{
+  return static_cast<BoundaryType>(static_cast<unsigned int>(b1) |
+                                   static_cast<unsigned int>(b2));
+}
+
+/**
+ * Global operator which sets the bits from the second argument also in the
+ * first one.
+ */
+inline BoundaryType &operator|=(BoundaryType &b1, const BoundaryType b2)
+{
+  b1 = b1 | b2;
+  return b1;
+}
+
+/**
+ * Global operator which returns an object in which all bits are set which are
+ * set in the first as well as the second argument. This operator exists since
+ * if it did not then the result of the bit-and operator & would be an integer
+ * which would in turn trigger a compiler warning when we tried to assign it to
+ * an object of type BoundaryType.
+ */
+inline BoundaryType operator&(const BoundaryType b1, const BoundaryType b2)
+{
+  return static_cast<BoundaryType>(static_cast<unsigned int>(b1) &
+                                   static_cast<unsigned int>(b2));
+}
+
+/**
+ * Global operator which clears all the bits in the first argument if they are
+ * not also set in the second argument.
+ */
+inline BoundaryType &operator&=(BoundaryType &b1, const BoundaryType b2)
+{
+  b1 = b1 & b2;
+  return b1;
+}
+
 } // namespace adamantine
 
 #endif

--- a/tests/data/integration_2d.info
+++ b/tests/data/integration_2d.info
@@ -91,3 +91,8 @@ discretization
   fe_degree 3
   quadrature gauss ; Optional parameter. Possibilities: gauss or lobatto
 }
+
+boundary
+{
+  type adiabatic
+}

--- a/tests/test_implicit_operator.cc
+++ b/tests/test_implicit_operator.cc
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(implicit_operator)
   std::shared_ptr<adamantine::ThermalOperator<2, 2, dealii::MemorySpace::Host>>
       thermal_operator = std::make_shared<
           adamantine::ThermalOperator<2, 2, dealii::MemorySpace::Host>>(
-          communicator, mat_properties);
+          communicator, mat_properties, adamantine::BoundaryType::adiabatic);
   thermal_operator->reinit(dof_handler, affine_constraints, q_collection);
   thermal_operator->compute_inverse_mass_matrix(dof_handler, affine_constraints,
                                                 fe_collection);

--- a/tests/test_material_deposition.cc
+++ b/tests/test_material_deposition.cc
@@ -257,6 +257,8 @@ BOOST_AUTO_TEST_CASE(material_deposition)
   database.put("sources.n_beams", 0);
   // Time-stepping database
   database.put("time_stepping.method", "forward_euler");
+  // Boundary database
+  database.put("boundary.type", "radiative");
 
   // Build ThermalPhysics
   adamantine::ThermalPhysics<dim, dim, dealii::MemorySpace::Host,

--- a/tests/test_post_processor.cc
+++ b/tests/test_post_processor.cc
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(post_processor)
 
   // Initialize the ThermalOperator
   adamantine::ThermalOperator<2, 2, dealii::MemorySpace::Host> thermal_operator(
-      communicator, mat_properties);
+      communicator, mat_properties, adamantine::BoundaryType::adiabatic);
   thermal_operator.reinit(dof_handler, affine_constraints, q_collection);
   thermal_operator.compute_inverse_mass_matrix(dof_handler, affine_constraints,
                                                fe_collection);

--- a/tests/test_thermal_operator.cc
+++ b/tests/test_thermal_operator.cc
@@ -13,6 +13,7 @@
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/fe/fe_nothing.h>
 #include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/numerics/matrix_tools.h>
@@ -64,7 +65,7 @@ BOOST_AUTO_TEST_CASE(thermal_operator)
 
   // Initialize the ThermalOperator
   adamantine::ThermalOperator<2, 2, dealii::MemorySpace::Host> thermal_operator(
-      communicator, mat_properties);
+      communicator, mat_properties, adamantine::BoundaryType::adiabatic);
   thermal_operator.reinit(dof_handler, affine_constraints, q_collection);
   thermal_operator.compute_inverse_mass_matrix(dof_handler, affine_constraints,
                                                fe_collection);
@@ -147,7 +148,7 @@ BOOST_AUTO_TEST_CASE(spmv)
 
   // Initialize the ThermalOperator
   adamantine::ThermalOperator<2, 2, dealii::MemorySpace::Host> thermal_operator(
-      communicator, mat_properties);
+      communicator, mat_properties, adamantine::BoundaryType::adiabatic);
   thermal_operator.reinit(dof_handler, affine_constraints, q_collection);
   thermal_operator.compute_inverse_mass_matrix(dof_handler, affine_constraints,
                                                fe_collection);
@@ -165,6 +166,146 @@ BOOST_AUTO_TEST_CASE(spmv)
   dealii::SparseMatrix<double> sparse_matrix(sparsity_pattern);
   dealii::MatrixCreator::create_laplace_matrix(
       dof_handler, dealii::QGauss<2>(3), sparse_matrix);
+
+  // Compare vmult using matrix free and building the matrix
+  double const tolerance = 1e-12;
+  dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> src;
+  dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> dst_1;
+  dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> dst_2;
+
+  dealii::MatrixFree<2, double> const &matrix_free =
+      thermal_operator.get_matrix_free();
+  matrix_free.initialize_dof_vector(src);
+  matrix_free.initialize_dof_vector(dst_1);
+  matrix_free.initialize_dof_vector(dst_2);
+
+  for (unsigned int i = 0; i < thermal_operator.m(); ++i)
+  {
+    src = 0.;
+    src[i] = 1;
+    thermal_operator.vmult(dst_1, src);
+    sparse_matrix.vmult(dst_2, src);
+    for (unsigned int j = 0; j < thermal_operator.m(); ++j)
+      BOOST_CHECK_CLOSE(dst_1[j], -dst_2[j], tolerance);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(spmv_rad)
+{
+  MPI_Comm communicator = MPI_COMM_WORLD;
+
+  // Create the Geometry
+  boost::property_tree::ptree geometry_database;
+  geometry_database.put("import_mesh", false);
+  geometry_database.put("length", 12);
+  geometry_database.put("length_divisions", 4);
+  geometry_database.put("height", 6);
+  geometry_database.put("height_divisions", 5);
+  adamantine::Geometry<2> geometry(communicator, geometry_database);
+  // Create the DoFHandler
+  dealii::hp::FECollection<2> fe_collection;
+  fe_collection.push_back(dealii::FE_Q<2>(2));
+  fe_collection.push_back(dealii::FE_Nothing<2>());
+  dealii::DoFHandler<2> dof_handler(geometry.get_triangulation());
+  dof_handler.distribute_dofs(fe_collection);
+  dealii::AffineConstraints<double> affine_constraints;
+  affine_constraints.close();
+  dealii::hp::QCollection<1> q_collection;
+  q_collection.push_back(dealii::QGauss<1>(3));
+  q_collection.push_back(dealii::QGauss<1>(1));
+
+  // Create the MaterialProperty
+  boost::property_tree::ptree mat_prop_database;
+  mat_prop_database.put("property_format", "polynomial");
+  mat_prop_database.put("n_materials", 1);
+  mat_prop_database.put("material_0.solid.density", 1.);
+  mat_prop_database.put("material_0.powder.density", 1.);
+  mat_prop_database.put("material_0.liquid.density", 1.);
+  mat_prop_database.put("material_0.solid.specific_heat", 1.);
+  mat_prop_database.put("material_0.powder.specific_heat", 1.);
+  mat_prop_database.put("material_0.liquid.specific_heat", 1.);
+  mat_prop_database.put("material_0.solid.thermal_conductivity", 1.);
+  mat_prop_database.put("material_0.powder.thermal_conductivity", 1.);
+  mat_prop_database.put("material_0.liquid.thermal_conductivity", 1.);
+  mat_prop_database.put("material_0.solid.emissivity", 1.);
+  mat_prop_database.put("material_0.powder.emissivity", 1.);
+  mat_prop_database.put("material_0.liquid.emissivity", 1.);
+  mat_prop_database.put("material_0.solid.radiation_heat_transfer_coef", 1.);
+  mat_prop_database.put("material_0.powder.radiation_heat_transfer_coef", 1.);
+  mat_prop_database.put("material_0.liquid.radiation_heat_transfer_coef", 1.);
+  mat_prop_database.put("material_0.solid.convection_heat_transfer_coef", 1.);
+  mat_prop_database.put("material_0.powder.convection_heat_transfer_coef", 1.);
+  mat_prop_database.put("material_0.liquid.convection_heat_transfer_coef", 1.);
+  mat_prop_database.put("material_0.radiation_temperature_infty", 0.5);
+  mat_prop_database.put("material_0.convection_temperature_infty", 0.5);
+  std::shared_ptr<adamantine::MaterialProperty<2>> mat_properties(
+      new adamantine::MaterialProperty<2>(
+          communicator, geometry.get_triangulation(), mat_prop_database));
+
+  // Initialize the ThermalOperator
+  adamantine::ThermalOperator<2, 2, dealii::MemorySpace::Host> thermal_operator(
+      communicator, mat_properties, adamantine::BoundaryType::radiative);
+  thermal_operator.reinit(dof_handler, affine_constraints, q_collection);
+  thermal_operator.compute_inverse_mass_matrix(dof_handler, affine_constraints,
+                                               fe_collection);
+  dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host>
+      temperature(thermal_operator.m());
+  for (unsigned int i = 0; i < temperature.local_size(); ++i)
+  {
+    temperature.local_element(i) = 1.;
+  }
+  thermal_operator.evaluate_material_properties(temperature);
+  BOOST_CHECK(thermal_operator.m() == 99);
+  BOOST_CHECK(thermal_operator.m() == thermal_operator.n());
+
+  // Build the matrix. This only works in serial.
+  dealii::DynamicSparsityPattern dsp(dof_handler.n_dofs());
+  dealii::DoFTools::make_sparsity_pattern(dof_handler, dsp, affine_constraints);
+  dealii::SparsityPattern sparsity_pattern;
+  sparsity_pattern.copy_from(dsp);
+  dealii::SparseMatrix<double> sparse_matrix(sparsity_pattern);
+  dealii::MatrixCreator::create_laplace_matrix(
+      dof_handler, dealii::QGauss<2>(3), sparse_matrix);
+  // Take care of the boundary condition
+  unsigned int const fe_degree = 2;
+  dealii::FE_Q<2> fe(fe_degree);
+  dealii::QGauss<1> face_quadrature_formula(fe_degree + 1);
+  unsigned int const n_face_q_points = face_quadrature_formula.size();
+  dealii::FEFaceValues<2> fe_face_values(fe, face_quadrature_formula,
+                                         dealii::update_values |
+                                             dealii::update_quadrature_points |
+                                             dealii::update_JxW_values);
+  double const heat_transfer_coeff =
+      1. * adamantine::Constant::stefan_boltzmann * 1.5 * 1.25;
+  std::cout << heat_transfer_coeff << std::endl;
+  unsigned int const dofs_per_cell = fe.n_dofs_per_cell();
+  dealii::FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
+  std::vector<dealii::types::global_dof_index> local_dof_indices(dofs_per_cell);
+  for (auto const &cell : dof_handler.active_cell_iterators())
+  {
+    if (cell->at_boundary())
+    {
+      cell_matrix = 0.;
+      for (auto const &face : cell->face_iterators())
+      {
+        if (face->at_boundary())
+        {
+          fe_face_values.reinit(cell, face);
+          for (unsigned int q = 0; q < n_face_q_points; ++q)
+            for (unsigned i = 0; i < dofs_per_cell; ++i)
+              for (unsigned j = 0; j < dofs_per_cell; ++j)
+              {
+                cell_matrix(i, j) +=
+                    heat_transfer_coeff * fe_face_values.shape_value(i, q) *
+                    fe_face_values.shape_value(j, q) * fe_face_values.JxW(q);
+              }
+        }
+      }
+      cell->get_dof_indices(local_dof_indices);
+      affine_constraints.distribute_local_to_global(
+          cell_matrix, local_dof_indices, sparse_matrix);
+    }
+  }
 
   // Compare vmult using matrix free and building the matrix
   double const tolerance = 1e-12;

--- a/tests/test_thermal_operator_device.cu
+++ b/tests/test_thermal_operator_device.cu
@@ -254,7 +254,8 @@ BOOST_AUTO_TEST_CASE(mf_spmv)
   BOOST_CHECK(thermal_operator_dev.m() == thermal_operator_dev.n());
 
   adamantine::ThermalOperator<2, 2, dealii::MemorySpace::Host>
-      thermal_operator_host(communicator, mat_properties);
+      thermal_operator_host(communicator, mat_properties,
+                            adamantine::BoundaryType::adiabatic);
   thermal_operator_host.compute_inverse_mass_matrix(
       dof_handler, affine_constraints, fe_collection);
   thermal_operator_host.reinit(dof_handler, affine_constraints, q_collection);

--- a/tests/test_thermal_physics.hh
+++ b/tests/test_thermal_physics.hh
@@ -46,6 +46,8 @@ void thermal_2d(boost::property_tree::ptree &database, double time_step)
   database.put("sources.beam_0.scan_path_file",
                "scan_path_test_thermal_physics.txt");
   database.put("sources.beam_0.scan_path_file_format", "segment");
+  // Boundary database
+  database.put("boundary.type", "adiabatic");
 
   // Build ThermalPhysics
   adamantine::ThermalPhysics<2, 2, MemorySpaceType, dealii::QGauss<1>> physics(
@@ -107,6 +109,8 @@ void thermal_2d_manufactured_solution()
                "scan_path_test_thermal_physics.txt");
   database.put("sources.beam_0.type", "electron_beam");
   database.put("sources.beam_0.scan_path_file_format", "segment");
+  // Boundary database
+  database.put("boundary.type", "adiabatic");
 
   // Time-stepping database
   database.put("time_stepping.method", "rk_fourth_order");
@@ -181,6 +185,8 @@ void initial_temperature()
   database.put("sources.beam_0.scan_path_file",
                "scan_path_test_thermal_physics.txt");
   database.put("sources.beam_0.scan_path_file_format", "segment");
+  // Boundary database
+  database.put("boundary.type", "adiabatic");
 
   // Time-stepping database
   database.put("time_stepping.method", "rk_fourth_order");
@@ -234,6 +240,8 @@ void energy_conservation()
   database.put("sources.beam_0.max_y", 6);
   // Time-stepping database
   database.put("time_stepping.method", "forward_euler");
+  // Boundary database
+  database.put("boundary.type", "adiabatic");
   // Build ThermalPhysics
   adamantine::ThermalPhysics<2, 2, dealii::MemorySpace::Host, dealii::QGauss<1>>
       physics(communicator, database, geometry);


### PR DESCRIPTION
This adds support for radiative and convective boundary condition. I had to treat the boundary outside the MatrixFree framework because of the element activation. We are still deciding how we will treat that case in deal.II