### PR TITLE
WIP: Internal Dirichlet BCs

### DIFF
--- a/source/ThermalPhysics.hh
+++ b/source/ThermalPhysics.hh
@@ -115,6 +115,13 @@ public:
    */
   double get_current_source_height() const;
 
+  /**
+   * Sets constraints for fixed temperature values
+   */
+  void set_internal_dirichlet_bcs(
+      dealii::LinearAlgebra::distributed::Vector<double> &solution,
+      dealii::LinearAlgebra::distributed::Vector<double> &imposed_temperature);
+
 private:
   using LA_Vector =
       typename dealii::LA::distributed::Vector<double, MemorySpaceType>;

--- a/source/ThermalPhysics.templates.hh
+++ b/source/ThermalPhysics.templates.hh
@@ -750,6 +750,8 @@ void ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::
 {
   // Loop over the faces looking for the interface between the two FE
   // types or the top of the domain
+  _affine_constraints.clear();
+
   for (auto const &cell : dealii::filter_iterators(
            _dof_handler.active_cell_iterators(),
            dealii::IteratorFilters::LocallyOwnedCell(),
@@ -778,8 +780,9 @@ void ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::
     }
   }
 
-  _affine_constraints.close();
+  solution.update_ghost_values();
 
+  _affine_constraints.close();
   _thermal_operator->reinit(_dof_handler, _affine_constraints, _q_collection);
 }
 

--- a/tests/test_thermal_physics.cc
+++ b/tests/test_thermal_physics.cc
@@ -56,3 +56,8 @@ BOOST_AUTO_TEST_CASE(energy_conservation_host)
 {
   energy_conservation<dealii::MemorySpace::Host>();
 }
+
+BOOST_AUTO_TEST_CASE(internal_dirichlet_host)
+{
+  internal_dirichlet<dealii::MemorySpace::Host>();
+}

--- a/tests/test_thermal_physics.cc
+++ b/tests/test_thermal_physics.cc
@@ -59,5 +59,15 @@ BOOST_AUTO_TEST_CASE(energy_conservation_host)
 
 BOOST_AUTO_TEST_CASE(internal_dirichlet_host)
 {
-  internal_dirichlet<dealii::MemorySpace::Host>();
+  double interface_height = 6.;
+  double initial_bulk_temperature = 1000.;
+  double imposed_interface_temperature = 1.;
+  internal_dirichlet<dealii::MemorySpace::Host>(interface_height,
+                                                initial_bulk_temperature,
+                                                imposed_interface_temperature);
+
+  imposed_interface_temperature = 1000.;
+  internal_dirichlet<dealii::MemorySpace::Host>(interface_height,
+                                                initial_bulk_temperature,
+                                                imposed_interface_temperature);
 }


### PR DESCRIPTION
This PR adds the capability to ThermalPhysics to set a Dirichlet BC along the active/nonactive element boundary based on an input temperature field.

@Rombur, would you mind taking a quick look at this to see if this is along the lines of what you were expecting? I'm not happy with the test -- it just checks that the L1 norm decreases when the a Dirichlet BC of a lower value than the initial solution is applied. I'm also looking into a potential bug visible in the output file from the test case I added. I'll keep working on it, but I wanted to make sure that my general approach was sound.