### PR TITLE
Fix bug when adding material based on the scan path

### DIFF
--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -127,6 +127,7 @@ inline void initialize_timers(MPI_Comm const &communicator,
   timers.push_back(adamantine::Timer(communicator, "Main"));
   timers.push_back(adamantine::Timer(communicator, "Refinement"));
   timers.push_back(adamantine::Timer(communicator, "Add Material"));
+  timers.push_back(adamantine::Timer(communicator, "Activate Added Material"));
   timers.push_back(adamantine::Timer(communicator, "Evolve One Time Step"));
   timers.push_back(adamantine::Timer(
       communicator, "Evolve One Time Step: evaluate_thermal_physics"));
@@ -744,7 +745,7 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
     // We use an epsilon to get the "expected" behavior when the deposition time
     // and the time match should match exactly but don't because of floating
     // point accuracy.
-    timers[adamantine::add_material].start();
+    timers[adamantine::activate_added_material].start();
     double const eps = time_step / 1e12;
     auto activation_start =
         std::lower_bound(deposition_times.begin(), deposition_times.end(),
@@ -767,7 +768,7 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
                                elements_to_activate.begin() + activation_end);
     deposition_times.erase(deposition_times.begin() + activation_start,
                            deposition_times.begin() + activation_end);
-    timers[adamantine::add_material].stop();
+    timers[adamantine::activate_added_material].stop();
 
     // Time can be different than time + time_step if an embedded scheme is
     // used. Note that this is a problem when adding material because it means

--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -126,8 +126,8 @@ inline void initialize_timers(MPI_Comm const &communicator,
 {
   timers.push_back(adamantine::Timer(communicator, "Main"));
   timers.push_back(adamantine::Timer(communicator, "Refinement"));
-  timers.push_back(adamantine::Timer(communicator, "Add Material"));
-  timers.push_back(adamantine::Timer(communicator, "Activate Added Material"));
+  timers.push_back(adamantine::Timer(communicator, "Add Material, Search"));
+  timers.push_back(adamantine::Timer(communicator, "Add Material, Activate"));
   timers.push_back(adamantine::Timer(communicator, "Evolve One Time Step"));
   timers.push_back(adamantine::Timer(
       communicator, "Evolve One Time Step: evaluate_thermal_physics"));
@@ -702,10 +702,10 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
   // Unless we use an embedded method, we know in advance the time step.
   // Thus we can get for each time step, the list of elements that we will need
   // to activate. This list will be invalidated every time we refine the mesh.
-  timers[adamantine::add_material].start();
+  timers[adamantine::add_material_search].start();
   auto elements_to_activate = adamantine::get_elements_to_activate(
       thermal_physics->get_dof_handler(), material_deposition_boxes);
-  timers[adamantine::add_material].stop();
+  timers[adamantine::add_material_search].stop();
 
 #ifdef ADAMANTINE_WITH_CALIPER
   CALI_CXX_MARK_LOOP_BEGIN(main_loop_id, "main_loop");
@@ -735,17 +735,17 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
         std::cout << "n_dofs: " << thermal_physics->get_dof_handler().n_dofs()
                   << std::endl;
 
-      timers[adamantine::add_material].start();
+      timers[adamantine::add_material_search].start();
       elements_to_activate = adamantine::get_elements_to_activate(
           thermal_physics->get_dof_handler(), material_deposition_boxes);
-      timers[adamantine::add_material].stop();
+      timers[adamantine::add_material_search].stop();
     }
 
     // Add material if necessary.
     // We use an epsilon to get the "expected" behavior when the deposition time
     // and the time match should match exactly but don't because of floating
     // point accuracy.
-    timers[adamantine::activate_added_material].start();
+    timers[adamantine::add_material_activate].start();
     double const eps = time_step / 1e12;
     auto activation_start =
         std::lower_bound(deposition_times.begin(), deposition_times.end(),
@@ -768,7 +768,7 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
                                elements_to_activate.begin() + activation_end);
     deposition_times.erase(deposition_times.begin() + activation_start,
                            deposition_times.begin() + activation_end);
-    timers[adamantine::activate_added_material].stop();
+    timers[adamantine::add_material_activate].stop();
 
     // Time can be different than time + time_step if an embedded scheme is
     // used. Note that this is a problem when adding material because it means

--- a/source/material_deposition.cc
+++ b/source/material_deposition.cc
@@ -181,9 +181,16 @@ deposition_along_scan_path(boost::property_tree::ptree const &geometry_database,
             std::abs(segment_end_point(0) - segment_start_point(0));
         double distance_y =
             std::abs(segment_end_point(1) - segment_start_point(1));
+
         ASSERT_THROW(!((distance_x > eps) && (distance_y > eps)),
                      "Error: For automated material deposition, scan path "
-                     "segments must align with the coordinate system.");
+                     "segments must align with the coordinate system. Starting "
+                     "point: (" +
+                         std::to_string(segment_start_point(0)) + ", " +
+                         std::to_string(segment_start_point(1)) +
+                         "), Ending point: (" +
+                         std::to_string(segment_end_point(0)) + ", " +
+                         std::to_string(segment_end_point(1)) + ")");
 
         if (distance_x > eps)
           segment_along_x = true;

--- a/source/material_deposition.cc
+++ b/source/material_deposition.cc
@@ -177,8 +177,10 @@ deposition_along_scan_path(boost::property_tree::ptree const &geometry_database,
         segment_along_x = true;
       else
       {
-        double distance_x = segment_end_point(0) - segment_start_point(0);
-        double distance_y = segment_end_point(1) - segment_start_point(1);
+        double distance_x =
+            std::abs(segment_end_point(0) - segment_start_point(0));
+        double distance_y =
+            std::abs(segment_end_point(1) - segment_start_point(1));
         ASSERT_THROW(!((distance_x > eps) && (distance_y > eps)),
                      "Error: For automated material deposition, scan path "
                      "segments must align with the coordinate system.");
@@ -260,11 +262,19 @@ deposition_along_scan_path(boost::property_tree::ptree const &geometry_database,
 
           if (segment_along_x)
           {
-            center(0) = center(0) + center_increment;
+            double increment_sign = 1.;
+            if (segment_end_point[0] < segment_start_point[0])
+              increment_sign = -1.;
+
+            center(0) = center(0) + increment_sign * center_increment;
           }
           else
           {
-            center(1) = center(1) + center_increment;
+            double increment_sign = 1.;
+            if (segment_end_point[1] < segment_start_point[1])
+              increment_sign = -1.;
+
+            center(1) = center(1) + increment_sign * center_increment;
           }
         }
       }

--- a/source/types.hh
+++ b/source/types.hh
@@ -71,6 +71,7 @@ enum Timing
   main,
   refine,
   add_material,
+  activate_added_material,
   evol_time,
   evol_time_eval_th_ph,
   evol_time_J_inv,

--- a/source/types.hh
+++ b/source/types.hh
@@ -70,8 +70,8 @@ enum Timing
 {
   main,
   refine,
-  add_material,
-  activate_added_material,
+  add_material_search,
+  add_material_activate,
   evol_time,
   evol_time_eval_th_ph,
   evol_time_J_inv,


### PR DESCRIPTION
There were a few sign errors in the code to determine the material to add from the scan path. I also split the add material timers into to (one to decide which material to add, one to actual activate it).