### PR TITLE
Fix radiative and convective BCs

### DIFF
--- a/source/ThermalOperator.cc
+++ b/source/ThermalOperator.cc
@@ -210,12 +210,13 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::vmult_add(
             {
               for (unsigned int q = 0; q < n_face_q_points; ++q)
               {
-                cell_dst[i] -=
-                    inv_rho_cp *
-                    (conv_heat_transfer_coef + rad_heat_transfer_coef) *
-                    fe_face_values.shape_value(i, q) *
-                    fe_face_values.shape_value(j, q) * cell_src[j] *
-                    fe_face_values.JxW(q);
+                cell_dst[i] -= inv_rho_cp * fe_face_values.shape_value(i, q) *
+                               fe_face_values.shape_value(j, q) *
+                               (conv_heat_transfer_coef *
+                                    (cell_src[j] - conv_temperature_infty) +
+                                rad_heat_transfer_coef *
+                                    (cell_src[j] - rad_temperature_infty)) *
+                               fe_face_values.JxW(q);
               }
             }
           }

--- a/tests/test_thermal_operator.cc
+++ b/tests/test_thermal_operator.cc
@@ -236,8 +236,8 @@ BOOST_AUTO_TEST_CASE(spmv_rad)
   mat_prop_database.put("material_0.solid.convection_heat_transfer_coef", 1.);
   mat_prop_database.put("material_0.powder.convection_heat_transfer_coef", 1.);
   mat_prop_database.put("material_0.liquid.convection_heat_transfer_coef", 1.);
-  mat_prop_database.put("material_0.radiation_temperature_infty", 0.5);
-  mat_prop_database.put("material_0.convection_temperature_infty", 0.5);
+  mat_prop_database.put("material_0.radiation_temperature_infty", 0.0);
+  mat_prop_database.put("material_0.convection_temperature_infty", 0.0);
   std::shared_ptr<adamantine::MaterialProperty<2>> mat_properties(
       new adamantine::MaterialProperty<2>(
           communicator, geometry.get_triangulation(), mat_prop_database));
@@ -276,11 +276,12 @@ BOOST_AUTO_TEST_CASE(spmv_rad)
                                              dealii::update_quadrature_points |
                                              dealii::update_JxW_values);
   double const heat_transfer_coeff =
-      1. * adamantine::Constant::stefan_boltzmann * 1.5 * 1.25;
+      1. * adamantine::Constant::stefan_boltzmann * 1. * 1.;
   std::cout << heat_transfer_coeff << std::endl;
   unsigned int const dofs_per_cell = fe.n_dofs_per_cell();
   dealii::FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
   std::vector<dealii::types::global_dof_index> local_dof_indices(dofs_per_cell);
+
   for (auto const &cell : dof_handler.active_cell_iterators())
   {
     if (cell->at_boundary())

--- a/tests/test_thermal_physics.cc
+++ b/tests/test_thermal_physics.cc
@@ -56,3 +56,13 @@ BOOST_AUTO_TEST_CASE(energy_conservation_host)
 {
   energy_conservation<dealii::MemorySpace::Host>();
 }
+
+BOOST_AUTO_TEST_CASE(radiation_bcs_host)
+{
+  radiation_bcs<dealii::MemorySpace::Host>();
+}
+
+BOOST_AUTO_TEST_CASE(convection_bcs_host)
+{
+  convection_bcs<dealii::MemorySpace::Host>();
+}

--- a/tests/test_thermal_physics.hh
+++ b/tests/test_thermal_physics.hh
@@ -289,3 +289,183 @@ void energy_conservation()
   BOOST_CHECK_CLOSE(solution.mean_value(), final_temperature, tolerance);
   BOOST_CHECK_CLOSE(min, max, tolerance);
 }
+
+template <typename MemorySpaceType>
+void radiation_bcs()
+{
+  MPI_Comm communicator = MPI_COMM_WORLD;
+
+  // Geometry database
+  boost::property_tree::ptree geometry_database;
+  geometry_database.put("import_mesh", false);
+  geometry_database.put("length", 5);
+  geometry_database.put("length_divisions", 5);
+  geometry_database.put("height", 5);
+  geometry_database.put("height_divisions", 5);
+  // Build Geometry
+  adamantine::Geometry<2> geometry(communicator, geometry_database);
+  boost::property_tree::ptree database;
+  // Material property
+  database.put("materials.property_format", "polynomial");
+  database.put("materials.n_materials", 1);
+  database.put("materials.material_0.solid.density", 1.);
+  database.put("materials.material_0.powder.density", 1.);
+  database.put("materials.material_0.liquid.density", 1.);
+  database.put("materials.material_0.solid.specific_heat", 1.);
+  database.put("materials.material_0.powder.specific_heat", 1.);
+  database.put("materials.material_0.liquid.specific_heat", 1.);
+  database.put("materials.material_0.solid.thermal_conductivity", 1.);
+  database.put("materials.material_0.powder.thermal_conductivity", 1.);
+  database.put("materials.material_0.liquid.thermal_conductivity", 1.);
+  database.put("materials.material_0.solid.emissivity", 1.);
+  database.put("materials.material_0.powder.emissivity", 1.);
+  database.put("materials.material_0.liquid.emissivity", 1.);
+  database.put("materials.material_0.solid.radiation_heat_transfer_coef", 1.);
+  database.put("materials.material_0.powder.radiation_heat_transfer_coef", 1.);
+  database.put("materials.material_0.liquid.radiation_heat_transfer_coef", 1.);
+  database.put("materials.material_0.solid.convection_heat_transfer_coef", 1.);
+  database.put("materials.material_0.powder.convection_heat_transfer_coef", 1.);
+  database.put("materials.material_0.liquid.convection_heat_transfer_coef", 1.);
+  database.put("materials.material_0.radiation_temperature_infty", 20.0);
+  database.put("materials.material_0.convection_temperature_infty", 0.0);
+  // Source database
+  database.put("sources.n_beams", 0);
+  // Time-stepping database
+  database.put("time_stepping.method", "forward_euler");
+  // Boundary database
+  database.put("boundary.type", "radiative");
+  // Build ThermalPhysics
+  adamantine::ThermalPhysics<2, 2, dealii::MemorySpace::Host, dealii::QGauss<1>>
+      physics(communicator, database, geometry);
+  physics.setup_dofs();
+  physics.compute_inverse_mass_matrix();
+
+  dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> solution;
+  double constexpr initial_temperature = 10;
+  physics.initialize_dof_vector(initial_temperature, solution);
+  std::vector<adamantine::Timer> timers(adamantine::Timing::n_timers);
+  double time = 0;
+  while (time < 100)
+  {
+    time = physics.evolve_one_time_step(time, 0.05, solution, timers);
+  }
+
+  double max = -1;
+  double min = 1e4;
+  if (std::is_same<MemorySpaceType, dealii::MemorySpace::Host>::value)
+  {
+    for (auto v : solution)
+    {
+      if (max < v)
+        max = v;
+      if (min > v)
+        min = v;
+    }
+  }
+  else
+  {
+    dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host>
+        solution_host(solution.get_partitioner());
+    solution_host.import(solution, dealii::VectorOperation::insert);
+    for (auto v : solution_host)
+    {
+      if (max < v)
+        max = v;
+      if (min > v)
+        min = v;
+    }
+  }
+
+  BOOST_CHECK(min >= 10. && min <= 20.);
+  BOOST_CHECK(max > 10. && max <= 20.);
+}
+
+template <typename MemorySpaceType>
+void convection_bcs()
+{
+  MPI_Comm communicator = MPI_COMM_WORLD;
+
+  // Geometry database
+  boost::property_tree::ptree geometry_database;
+  geometry_database.put("import_mesh", false);
+  geometry_database.put("length", 5);
+  geometry_database.put("length_divisions", 5);
+  geometry_database.put("height", 5);
+  geometry_database.put("height_divisions", 5);
+  // Build Geometry
+  adamantine::Geometry<2> geometry(communicator, geometry_database);
+  boost::property_tree::ptree database;
+  // Material property
+  database.put("materials.property_format", "polynomial");
+  database.put("materials.n_materials", 1);
+  database.put("materials.material_0.solid.density", 1.);
+  database.put("materials.material_0.powder.density", 1.);
+  database.put("materials.material_0.liquid.density", 1.);
+  database.put("materials.material_0.solid.specific_heat", 1.);
+  database.put("materials.material_0.powder.specific_heat", 1.);
+  database.put("materials.material_0.liquid.specific_heat", 1.);
+  database.put("materials.material_0.solid.thermal_conductivity", 1.);
+  database.put("materials.material_0.powder.thermal_conductivity", 1.);
+  database.put("materials.material_0.liquid.thermal_conductivity", 1.);
+  database.put("materials.material_0.solid.emissivity", 1.);
+  database.put("materials.material_0.powder.emissivity", 1.);
+  database.put("materials.material_0.liquid.emissivity", 1.);
+  database.put("materials.material_0.solid.radiation_heat_transfer_coef", 1.);
+  database.put("materials.material_0.powder.radiation_heat_transfer_coef", 1.);
+  database.put("materials.material_0.liquid.radiation_heat_transfer_coef", 1.);
+  database.put("materials.material_0.solid.convection_heat_transfer_coef", 1.);
+  database.put("materials.material_0.powder.convection_heat_transfer_coef", 1.);
+  database.put("materials.material_0.liquid.convection_heat_transfer_coef", 1.);
+  database.put("materials.material_0.radiation_temperature_infty", 0.0);
+  database.put("materials.material_0.convection_temperature_infty", 20.0);
+  // Source database
+  database.put("sources.n_beams", 0);
+  // Time-stepping database
+  database.put("time_stepping.method", "forward_euler");
+  // Boundary database
+  database.put("boundary.type", "convective");
+  // Build ThermalPhysics
+  adamantine::ThermalPhysics<2, 2, dealii::MemorySpace::Host, dealii::QGauss<1>>
+      physics(communicator, database, geometry);
+  physics.setup_dofs();
+  physics.compute_inverse_mass_matrix();
+
+  dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> solution;
+  double constexpr initial_temperature = 10;
+  physics.initialize_dof_vector(initial_temperature, solution);
+  std::vector<adamantine::Timer> timers(adamantine::Timing::n_timers);
+  double time = 0;
+  while (time < 10)
+  {
+    time = physics.evolve_one_time_step(time, 0.05, solution, timers);
+  }
+
+  double max = -1;
+  double min = 1e4;
+  if (std::is_same<MemorySpaceType, dealii::MemorySpace::Host>::value)
+  {
+    for (auto v : solution)
+    {
+      if (max < v)
+        max = v;
+      if (min > v)
+        min = v;
+    }
+  }
+  else
+  {
+    dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host>
+        solution_host(solution.get_partitioner());
+    solution_host.import(solution, dealii::VectorOperation::insert);
+    for (auto v : solution_host)
+    {
+      if (max < v)
+        max = v;
+      if (min > v)
+        min = v;
+    }
+  }
+
+  BOOST_CHECK(min >= 10. && min <= 20.);
+  BOOST_CHECK(max > 10. && max <= 20.);
+}


### PR DESCRIPTION
Before this, `ThermalOperator::vmult_add` did not include the the reference temperature for convective or radiative boundary conditions. Therefore those boundary conditions drove the temperature of the system to 0 K.

This PR modifies `ThermalOperator::vmult_add` for non-zero reference temperatures (`conv_temperature_infty` and `rad_temperature_infty`).

Two new tests were added for `ThermalPhysics` to show that a block of material cooler than its environment will increase in temperature closer to the environmental temperature. 

The "spmv_rad" test for `ThermalOperator` was also modified. The reference solution assumes `rad_temperature_infty=0` (even though `rad_temperature_infty` is set to a non-zero value) and so it failed with the fix to `ThermalOperator::vmult_add`.  With some loss of generality, I set `rad_temperature_infty=0` for the test so that the old reference solution was still valid.