### PR TITLE
Add array for CPU and GPU

### DIFF
--- a/source/ArrayMD.hh
+++ b/source/ArrayMD.hh
@@ -1,0 +1,1224 @@
+/* Copyright (c) 2021, the adamantine authors.
+ *
+ * This file is subject to the Modified BSD License and may not be distributed
+ * without copyright and license information. Please refer to the file LICENSE
+ * for the text and further information on this license.
+ */
+
+#ifndef MDARRAY_HH
+#define MDARRAY_HH
+
+#include <utils.hh>
+
+// This file contains multiple arrays of different dimensions. The size of the
+// arrays can be set at compile-time or at runtime, similar to a Kokkos::View.
+// Note that the use case of these arrays is very different than Kokkos::View.
+// The goal here is to store data on the host or the device but not to loop over
+// the data store. This means that the memory layout is not as important.
+// Another difference with Kokkos::View is that copies of the arrays are not
+// owning, i.e. the lifetime of the underlying data is determined by the
+// original object.
+namespace adamantine
+{
+/**
+ * Two-dimensional array with both dimensions set at compile time.
+ */
+template <int dim_0, int dim_1, typename MemorySpaceType>
+class Array2D
+{
+public:
+  static_assert(dim_0 > 0, "dim_0 should be greater than 0.");
+  static_assert(dim_1 > 0, "dim_1 should be greater than 0.");
+
+  /**
+   * Default constructor.
+   */
+  Array2D();
+
+  /**
+   * Copy constructor. The copy is non-owning, i.e., the lifetime of the
+   * underlying data is determined by the original object.
+   */
+  Array2D(Array2D<dim_0, dim_1, MemorySpaceType> const &other);
+
+  /**
+   * Destructor.
+   */
+  ~Array2D();
+
+  /**
+   * Set the data to zero.
+   */
+  void set_zero();
+
+  /**
+   * Dimension `i` of the array.
+   */
+  ADAMANTINE_HOST_DEV unsigned int extent(unsigned int i) const;
+
+  /**
+   * Access element `(i,j)` of the array.
+   */
+  ADAMANTINE_HOST_DEV double &operator()(unsigned int i, unsigned int j);
+
+  /**
+   * Access element `(i,j)` of the array.
+   */
+  ADAMANTINE_HOST_DEV double const &operator()(unsigned int i,
+                                               unsigned int j) const;
+
+private:
+  /**
+   * Owning flag true if owning and false otherwise.
+   */
+  bool _owning = true;
+  /**
+   * Pointer to data.
+   */
+  double *_values = nullptr;
+};
+
+template <int dim_0, int dim_1, typename MemorySpaceType>
+Array2D<dim_0, dim_1, MemorySpaceType>::Array2D()
+    : _values(Memory<double, MemorySpaceType>::allocate_data(dim_0 * dim_1))
+{
+}
+
+template <int dim_0, int dim_1, typename MemorySpaceType>
+Array2D<dim_0, dim_1, MemorySpaceType>::Array2D(
+    Array2D<dim_0, dim_1, MemorySpaceType> const &other)
+    : _owning(false), _values(other._values)
+{
+}
+
+template <int dim_0, int dim_1, typename MemorySpaceType>
+Array2D<dim_0, dim_1, MemorySpaceType>::~Array2D()
+{
+  if (_owning && _values)
+  {
+    Memory<double, MemorySpaceType>::delete_data(_values);
+  }
+  _values = nullptr;
+}
+
+template <int dim_0, int dim_1, typename MemorySpaceType>
+void Array2D<dim_0, dim_1, MemorySpaceType>::set_zero()
+{
+
+  Memory<double, MemorySpaceType>::set_zero(_values, dim_0 * dim_1);
+}
+
+template <int dim_0, int dim_1, typename MemorySpaceType>
+ADAMANTINE_HOST_DEV unsigned int
+Array2D<dim_0, dim_1, MemorySpaceType>::extent(unsigned int i) const
+{
+  if (i == 0)
+    return dim_0;
+  else if (i == 1)
+    return dim_1;
+  else
+    return 0;
+}
+
+template <int dim_0, int dim_1, typename MemorySpaceType>
+ADAMANTINE_HOST_DEV double &
+Array2D<dim_0, dim_1, MemorySpaceType>::operator()(unsigned int i,
+                                                   unsigned int j)
+{
+  return _values[i * dim_1 + j];
+}
+
+template <int dim_0, int dim_1, typename MemorySpaceType>
+ADAMANTINE_HOST_DEV double const &
+Array2D<dim_0, dim_1, MemorySpaceType>::operator()(unsigned int i,
+                                                   unsigned int j) const
+{
+  return _values[i * dim_1 + j];
+}
+
+/**
+ * Two-dimensional array with the first dimension set at runtime and the second
+ * dimension set at compile-time.
+ */
+template <int dim_1, typename MemorySpaceType>
+class Array2D<-1, dim_1, MemorySpaceType>
+{
+public:
+  static_assert(dim_1 > 0, "dim_1 should be greater than 0.");
+
+  /**
+   * Default constructor.
+   */
+  Array2D() = default;
+
+  /**
+   * Constructor. Set the first dimension to `size_0`.
+   */
+  Array2D(unsigned int size_0);
+
+  /**
+   * Copy constructor. The copy is non-owning, i.e., the lifetime of the
+   * underlying data is determined by the original object.
+   */
+  Array2D(Array2D<-1, dim_1, MemorySpaceType> const &other);
+
+  /**
+   * Destructor.
+   */
+  ~Array2D();
+
+  /**
+   * Reinitialize the data using `size_0` for the first dimension. The initial
+   * data is cleared.
+   */
+  void reinit(unsigned int size_0);
+
+  /**
+   * Set the data to zero.
+   */
+  void set_zero();
+
+  /**
+   * Dimension `i` of the array.
+   */
+  ADAMANTINE_HOST_DEV unsigned int extent(unsigned int i) const;
+
+  /**
+   * Access element `(i,j)` of the array.
+   */
+  ADAMANTINE_HOST_DEV double &operator()(unsigned int i, unsigned int j);
+
+  /**
+   * Access element `(i,j)` of the array.
+   */
+  ADAMANTINE_HOST_DEV double const &operator()(unsigned int i,
+                                               unsigned int j) const;
+
+private:
+  /**
+   * Owning flag true if owning and false otherwise.
+   */
+  bool _owning = true;
+  /**
+   * Dimension zero of the array.
+   */
+  unsigned int _dim_0 = 0;
+  /**
+   * Pointer to data.
+   */
+  double *_values = nullptr;
+};
+
+template <int dim_1, typename MemorySpaceType>
+Array2D<-1, dim_1, MemorySpaceType>::Array2D(unsigned int size_0)
+    : _dim_0(size_0),
+      _values(Memory<double, MemorySpaceType>::allocate_data(_dim_0 * dim_1))
+{
+}
+
+template <int dim_1, typename MemorySpaceType>
+Array2D<-1, dim_1, MemorySpaceType>::Array2D(
+    Array2D<-1, dim_1, MemorySpaceType> const &other)
+    : _owning(false), _dim_0(other._dim_0), _values(other._values)
+{
+}
+
+template <int dim_1, typename MemorySpaceType>
+Array2D<-1, dim_1, MemorySpaceType>::~Array2D()
+{
+  if (_owning && _values)
+  {
+    Memory<double, MemorySpaceType>::delete_data(_values);
+  }
+  _values = nullptr;
+}
+
+template <int dim_1, typename MemorySpaceType>
+void Array2D<-1, dim_1, MemorySpaceType>::reinit(unsigned int size_0)
+{
+  // Free memory if necessary
+  if (_owning && _values)
+  {
+    Memory<double, MemorySpaceType>::delete_data(_values);
+  }
+
+  _dim_0 = size_0;
+  _values = Memory<double, MemorySpaceType>::allocate_data(_dim_0 * dim_1);
+}
+
+template <int dim_1, typename MemorySpaceType>
+void Array2D<-1, dim_1, MemorySpaceType>::set_zero()
+{
+
+  Memory<double, MemorySpaceType>::set_zero(_values, _dim_0 * dim_1);
+}
+
+template <int dim_1, typename MemorySpaceType>
+ADAMANTINE_HOST_DEV unsigned int
+Array2D<-1, dim_1, MemorySpaceType>::extent(unsigned int i) const
+{
+  if (i == 0)
+    return _dim_0;
+  else if (i == 1)
+    return dim_1;
+  else
+    return 0;
+}
+
+template <int dim_1, typename MemorySpaceType>
+ADAMANTINE_HOST_DEV double &
+Array2D<-1, dim_1, MemorySpaceType>::operator()(unsigned int i, unsigned int j)
+{
+  return _values[i * dim_1 + j];
+}
+
+template <int dim_1, typename MemorySpaceType>
+ADAMANTINE_HOST_DEV double const &
+Array2D<-1, dim_1, MemorySpaceType>::operator()(unsigned int i,
+                                                unsigned int j) const
+{
+  return _values[i * dim_1 + j];
+}
+
+/**
+ * Four-dimensional array with all the dimension set at compile-time.
+ */
+template <int dim_0, int dim_1, int dim_2, int dim_3, typename MemorySpaceType>
+class Array4D
+{
+public:
+  static_assert(dim_0 > 0, "dim_0 should be greater than 0.");
+  static_assert(dim_1 > 0, "dim_1 should be greater than 0.");
+  static_assert(dim_2 > 0, "dim_2 should be greater than 0.");
+  static_assert(dim_3 > 0, "dim_3 should be greater than 0.");
+
+  /**
+   * Default constructor.
+   */
+  Array4D();
+
+  /**
+   * Copy constructor. The copy is non-owning, i.e., the lifetime of the
+   * underlying data is determined by the original object.
+   */
+  Array4D(Array4D<dim_0, dim_1, dim_2, dim_3, MemorySpaceType> const &other);
+
+  /**
+   * Destructor.
+   */
+  ~Array4D();
+
+  /**
+   * Set the data to zero.
+   */
+  void set_zero();
+
+  /**
+   * Dimension `i` of the array.
+   */
+  ADAMANTINE_HOST_DEV unsigned int extent(unsigned int i) const;
+
+  /**
+   * Access element `(i,j,k,l)` of the array.
+   */
+  ADAMANTINE_HOST_DEV double &operator()(unsigned int i, unsigned int j,
+                                         unsigned int k, unsigned int l);
+
+  /**
+   * Access element `(i,j,k,l)` of the array.
+   */
+  ADAMANTINE_HOST_DEV double const &operator()(unsigned int i, unsigned int j,
+                                               unsigned int k,
+                                               unsigned int l) const;
+
+private:
+  /**
+   * Owning flag true if owning and false otherwise.
+   */
+  bool _owning = true;
+  /**
+   * Pointer to data.
+   */
+  double *_values = nullptr;
+};
+
+template <int dim_0, int dim_1, int dim_2, int dim_3, typename MemorySpaceType>
+Array4D<dim_0, dim_1, dim_2, dim_3, MemorySpaceType>::Array4D()
+    : _values(Memory<double, MemorySpaceType>::allocate_data(dim_0 * dim_1 *
+                                                             dim_2 * dim_3))
+{
+}
+
+template <int dim_0, int dim_1, int dim_2, int dim_3, typename MemorySpaceType>
+Array4D<dim_0, dim_1, dim_2, dim_3, MemorySpaceType>::Array4D(
+    Array4D<dim_0, dim_1, dim_2, dim_3, MemorySpaceType> const &other)
+    : _owning(false), _values(other._values)
+{
+}
+
+template <int dim_0, int dim_1, int dim_2, int dim_3, typename MemorySpaceType>
+Array4D<dim_0, dim_1, dim_2, dim_3, MemorySpaceType>::~Array4D()
+{
+  if (_owning && _values)
+  {
+    Memory<double, MemorySpaceType>::delete_data(_values);
+  }
+  _values = nullptr;
+}
+
+template <int dim_0, int dim_1, int dim_2, int dim_3, typename MemorySpaceType>
+void Array4D<dim_0, dim_1, dim_2, dim_3, MemorySpaceType>::set_zero()
+{
+
+  Memory<double, MemorySpaceType>::set_zero(_values,
+                                            dim_0 * dim_1 * dim_2 * dim_3);
+}
+
+template <int dim_0, int dim_1, int dim_2, int dim_3, typename MemorySpaceType>
+ADAMANTINE_HOST_DEV unsigned int
+Array4D<dim_0, dim_1, dim_2, dim_3, MemorySpaceType>::extent(
+    unsigned int i) const
+{
+  if (i == 0)
+    return dim_0;
+  else if (i == 1)
+    return dim_1;
+  else if (i == 2)
+    return dim_2;
+  else if (i == 3)
+    return dim_3;
+  else
+    return 0;
+}
+
+template <int dim_0, int dim_1, int dim_2, int dim_3, typename MemorySpaceType>
+ADAMANTINE_HOST_DEV double &
+Array4D<dim_0, dim_1, dim_2, dim_3, MemorySpaceType>::operator()(unsigned int i,
+                                                                 unsigned int j,
+                                                                 unsigned int k,
+                                                                 unsigned int l)
+{
+  return _values[i * (dim_1 * dim_2 * dim_3) + j * (dim_2 * dim_3) + k * dim_3 +
+                 l];
+}
+
+template <int dim_0, int dim_1, int dim_2, int dim_3, typename MemorySpaceType>
+ADAMANTINE_HOST_DEV double const &
+Array4D<dim_0, dim_1, dim_2, dim_3, MemorySpaceType>::operator()(
+    unsigned int i, unsigned int j, unsigned int k, unsigned int l) const
+{
+  return _values[i * (dim_1 * dim_2 * dim_3) + j * (dim_2 * dim_3) + k * dim_3 +
+                 l];
+}
+
+/**
+ * Four-dimensional array with the first dimension set at runtime and the other
+ * dimensions set at compile-time.
+ */
+template <int dim_1, int dim_2, int dim_3, typename MemorySpaceType>
+class Array4D<-1, dim_1, dim_2, dim_3, MemorySpaceType>
+{
+public:
+  static_assert(dim_1 > 0, "dim_0 should be greater than 0.");
+  static_assert(dim_2 > 0, "dim_1 should be greater than 0.");
+  static_assert(dim_3 > 0, "dim_2 should be greater than 0.");
+
+  /**
+   * Default constructor.
+   */
+  Array4D() = default;
+
+  /**
+   * Constructor. Set the first dimension to `size_0`.
+   */
+  Array4D(unsigned int size_0);
+
+  /**
+   * Copy constructor. The copy is non-owning, i.e., the lifetime of the
+   * underlying data is determined by the original object.
+   */
+  Array4D(Array4D<-1, dim_1, dim_2, dim_3, MemorySpaceType> const &other);
+
+  /**
+   * Destructor.
+   */
+  ~Array4D();
+
+  /**
+   * Reinitialize the data using `size_0` for the first dimension. The initial
+   * data is cleared.
+   */
+  void reinit(unsigned int size_0);
+
+  /**
+   * Set the data to zero.
+   */
+  void set_zero();
+
+  /**
+   * Dimension `i` of the array.
+   */
+  ADAMANTINE_HOST_DEV unsigned int extent(unsigned int i) const;
+
+  /**
+   * Access element `(i,j,k,l)` of the array.
+   */
+  ADAMANTINE_HOST_DEV double &operator()(unsigned int i, unsigned int j,
+                                         unsigned int k, unsigned int l);
+
+  /**
+   * Access element `(i,j,k,l)` of the array.
+   */
+  ADAMANTINE_HOST_DEV double const &operator()(unsigned int i, unsigned int j,
+                                               unsigned int k,
+                                               unsigned int l) const;
+
+private:
+  /**
+   * Owning flag true if owning and false otherwise.
+   */
+  bool _owning = true;
+  /**
+   * Dimension zero of the array.
+   */
+  unsigned int _dim_0 = 0;
+  /**
+   * Pointer to data.
+   */
+  double *_values = nullptr;
+};
+
+template <int dim_1, int dim_2, int dim_3, typename MemorySpaceType>
+Array4D<-1, dim_1, dim_2, dim_3, MemorySpaceType>::Array4D(unsigned int size_0)
+    : _dim_0(size_0), _values(Memory<double, MemorySpaceType>::allocate_data(
+                          _dim_0 * dim_1 * dim_2 * dim_3))
+{
+}
+
+template <int dim_1, int dim_2, int dim_3, typename MemorySpaceType>
+Array4D<-1, dim_1, dim_2, dim_3, MemorySpaceType>::Array4D(
+    Array4D<-1, dim_1, dim_2, dim_3, MemorySpaceType> const &other)
+    : _owning(false), _dim_0(other._dim_0), _values(other._values)
+{
+}
+
+template <int dim_1, int dim_2, int dim_3, typename MemorySpaceType>
+Array4D<-1, dim_1, dim_2, dim_3, MemorySpaceType>::~Array4D()
+{
+  if (_owning && _values)
+  {
+    Memory<double, MemorySpaceType>::delete_data(_values);
+  }
+  _values = nullptr;
+}
+
+template <int dim_1, int dim_2, int dim_3, typename MemorySpaceType>
+void Array4D<-1, dim_1, dim_2, dim_3, MemorySpaceType>::reinit(
+    unsigned int size_0)
+{
+  // Free memory if necessary
+  if (_owning && _values)
+  {
+    Memory<double, MemorySpaceType>::delete_data(_values);
+  }
+
+  _dim_0 = size_0;
+  _values = Memory<double, MemorySpaceType>::allocate_data(_dim_0 * dim_1 *
+                                                           dim_2 * dim_3);
+}
+
+template <int dim_1, int dim_2, int dim_3, typename MemorySpaceType>
+void Array4D<-1, dim_1, dim_2, dim_3, MemorySpaceType>::set_zero()
+{
+
+  Memory<double, MemorySpaceType>::set_zero(_values,
+                                            _dim_0 * dim_1 * dim_2 * dim_3);
+}
+
+template <int dim_1, int dim_2, int dim_3, typename MemorySpaceType>
+ADAMANTINE_HOST_DEV unsigned int
+Array4D<-1, dim_1, dim_2, dim_3, MemorySpaceType>::extent(unsigned int i) const
+{
+  if (i == 0)
+    return _dim_0;
+  else if (i == 1)
+    return dim_1;
+  else if (i == 2)
+    return dim_2;
+  else if (i == 3)
+    return dim_3;
+  else
+    return 0;
+}
+
+template <int dim_1, int dim_2, int dim_3, typename MemorySpaceType>
+ADAMANTINE_HOST_DEV double &
+Array4D<-1, dim_1, dim_2, dim_3, MemorySpaceType>::operator()(unsigned int i,
+                                                              unsigned int j,
+                                                              unsigned int k,
+                                                              unsigned int l)
+{
+  return _values[i * (dim_1 * dim_2 * dim_3) + j * (dim_2 * dim_3) + k * dim_3 +
+                 l];
+}
+
+template <int dim_1, int dim_2, int dim_3, typename MemorySpaceType>
+ADAMANTINE_HOST_DEV double const &
+Array4D<-1, dim_1, dim_2, dim_3, MemorySpaceType>::operator()(
+    unsigned int i, unsigned int j, unsigned int k, unsigned int l) const
+{
+  return _values[i * (dim_1 * dim_2 * dim_3) + j * (dim_2 * dim_3) + k * dim_3 +
+                 l];
+}
+
+/**
+ * Four-dimensional array with the last dimension set at runtime and the other
+ * dimensions set at compile-time.
+ */
+template <int dim_0, int dim_1, int dim_2, typename MemorySpaceType>
+class Array4D<dim_0, dim_1, dim_2, -1, MemorySpaceType>
+{
+public:
+  static_assert(dim_0 > 0, "dim_0 should be greater than 0.");
+  static_assert(dim_1 > 0, "dim_1 should be greater than 0.");
+  static_assert(dim_2 > 0, "dim_2 should be greater than 0.");
+
+  /**
+   * Default constructor.
+   */
+  Array4D() = default;
+
+  /**
+   * Constructor. Set the last dimension to `size_3`.
+   */
+  Array4D(unsigned int size_3);
+
+  /**
+   * Copy constructor. The copy is non-owning, i.e., the lifetime of the
+   * underlying data is determined by the original object.
+   */
+  Array4D(Array4D<dim_0, dim_1, dim_2, -1, MemorySpaceType> const &other);
+
+  /**
+   * Destructor.
+   */
+  ~Array4D();
+
+  /**
+   * Reinitialize the data using `size_3` for the last dimension. The initial
+   * data is cleared.
+   */
+  void reinit(unsigned int size_3);
+
+  /**
+   * Set the data to zero.
+   */
+  void set_zero();
+
+  /**
+   * Dimension `i` of the array.
+   */
+  ADAMANTINE_HOST_DEV unsigned int extent(unsigned int i) const;
+
+  /**
+   * Access element `(i,j,k,l)` of the array.
+   */
+  ADAMANTINE_HOST_DEV double &operator()(unsigned int i, unsigned int j,
+                                         unsigned int k, unsigned int l);
+
+  /**
+   * Access element `(i,j,k,l)` of the array.
+   */
+  ADAMANTINE_HOST_DEV double const &operator()(unsigned int i, unsigned int j,
+                                               unsigned int k,
+                                               unsigned int l) const;
+
+private:
+  /**
+   * Owning flag true if owning and false otherwise.
+   */
+  bool _owning = true;
+  /**
+   * Dimension three of the array.
+   */
+  unsigned int _dim_3 = 0;
+  /**
+   * Pointer to data.
+   */
+  double *_values = nullptr;
+};
+
+template <int dim_0, int dim_1, int dim_2, typename MemorySpaceType>
+Array4D<dim_0, dim_1, dim_2, -1, MemorySpaceType>::Array4D(unsigned int size_3)
+    : _dim_3(size_3), _values(Memory<double, MemorySpaceType>::allocate_data(
+                          dim_0 * dim_1 * dim_2 * _dim_3))
+{
+}
+
+template <int dim_0, int dim_1, int dim_2, typename MemorySpaceType>
+Array4D<dim_0, dim_1, dim_2, -1, MemorySpaceType>::Array4D(
+    Array4D<dim_0, dim_1, dim_2, -1, MemorySpaceType> const &other)
+    : _owning(false), _dim_3(other._dim_3), _values(other._values)
+{
+}
+
+template <int dim_0, int dim_1, int dim_2, typename MemorySpaceType>
+Array4D<dim_0, dim_1, dim_2, -1, MemorySpaceType>::~Array4D()
+{
+  if (_owning && _values)
+  {
+    Memory<double, MemorySpaceType>::delete_data(_values);
+  }
+  _values = nullptr;
+}
+
+template <int dim_0, int dim_1, int dim_2, typename MemorySpaceType>
+void Array4D<dim_0, dim_1, dim_2, -1, MemorySpaceType>::reinit(
+    unsigned int size_3)
+{
+  // Free memory if necessary
+  if (_owning && _values)
+  {
+    Memory<double, MemorySpaceType>::delete_data(_values);
+  }
+
+  _dim_3 = size_3;
+  _values = Memory<double, MemorySpaceType>::allocate_data(dim_0 * dim_1 *
+                                                           dim_2 * _dim_3);
+}
+
+template <int dim_0, int dim_1, int dim_2, typename MemorySpaceType>
+void Array4D<dim_0, dim_1, dim_2, -1, MemorySpaceType>::set_zero()
+{
+
+  Memory<double, MemorySpaceType>::set_zero(_values,
+                                            dim_0 * dim_1 * dim_2 * _dim_3);
+}
+
+template <int dim_0, int dim_1, int dim_2, typename MemorySpaceType>
+ADAMANTINE_HOST_DEV unsigned int
+Array4D<dim_0, dim_1, dim_2, -1, MemorySpaceType>::extent(unsigned int i) const
+{
+  if (i == 0)
+    return dim_0;
+  else if (i == 1)
+    return dim_1;
+  else if (i == 2)
+    return dim_2;
+  else if (i == 3)
+    return _dim_3;
+  else
+    return 0;
+}
+template <int dim_0, int dim_1, int dim_2, typename MemorySpaceType>
+ADAMANTINE_HOST_DEV double &
+Array4D<dim_0, dim_1, dim_2, -1, MemorySpaceType>::operator()(unsigned int i,
+                                                              unsigned int j,
+                                                              unsigned int k,
+                                                              unsigned int l)
+{
+  return _values[i * (dim_1 * dim_2 * _dim_3) + j * (dim_2 * _dim_3) +
+                 k * _dim_3 + l];
+}
+
+template <int dim_0, int dim_1, int dim_2, typename MemorySpaceType>
+ADAMANTINE_HOST_DEV double const &
+Array4D<dim_0, dim_1, dim_2, -1, MemorySpaceType>::operator()(
+    unsigned int i, unsigned int j, unsigned int k, unsigned int l) const
+{
+  return _values[i * (dim_1 * dim_2 * _dim_3) + j * (dim_2 * _dim_3) +
+                 k * _dim_3 + l];
+}
+
+/**
+ * Four-dimensional array with the first and the last dimensions set at runtime
+ * and the other dimensions set at compile-time.
+ */
+template <int dim_1, int dim_2, typename MemorySpaceType>
+class Array4D<-1, dim_1, dim_2, -1, MemorySpaceType>
+{
+public:
+  static_assert(dim_1 > 0, "dim_1 should be greater than 0.");
+  static_assert(dim_2 > 0, "dim_2 should be greater than 0.");
+
+  /**
+   * Default constructor.
+   */
+  Array4D() = default;
+
+  /**
+   * Constructor. Set the first dimension to `size_0` and the last dimension to
+   * `size_3`.
+   */
+  Array4D(unsigned int size_0, unsigned int size_3);
+
+  /**
+   * Copy constructor. The copy is non-owning, i.e., the lifetime of the
+   * underlying data is determined by the original object.
+   */
+  Array4D(Array4D<-1, dim_1, dim_2, -1, MemorySpaceType> const &other);
+
+  /**
+   * Destructor.
+   */
+  ~Array4D();
+
+  /**
+   * Reinitialize the data using `size_0` for the first dimension. The initial
+   * data is cleared.
+   */
+  void reinit(unsigned int size_0, unsigned int size_3);
+
+  /**
+   * Set the data to zero.
+   */
+  void set_zero();
+
+  /**
+   * Dimension `i` of the array.
+   */
+  ADAMANTINE_HOST_DEV unsigned int extent(unsigned int i) const;
+
+  /**
+   * Access element `(i,j,k,l)` of the array.
+   */
+  ADAMANTINE_HOST_DEV double &operator()(unsigned int i, unsigned int j,
+                                         unsigned int k, unsigned int l);
+
+  /**
+   * Access element `(i,j,k,l)` of the array.
+   */
+  ADAMANTINE_HOST_DEV double const &operator()(unsigned int i, unsigned int j,
+                                               unsigned int k,
+                                               unsigned int l) const;
+
+private:
+  /**
+   * Owning flag true if owning and false otherwise.
+   */
+  bool _owning = true;
+  /**
+   * Dimension zero of the array.
+   */
+  unsigned int _dim_0 = 0;
+  /**
+   * Dimension three of the array.
+   */
+  unsigned int _dim_3 = 0;
+  /**
+   * Pointer to data.
+   */
+  double *_values = nullptr;
+};
+
+template <int dim_1, int dim_2, typename MemorySpaceType>
+Array4D<-1, dim_1, dim_2, -1, MemorySpaceType>::Array4D(unsigned int size_0,
+                                                        unsigned int size_3)
+    : _dim_0(size_0), _dim_3(size_3),
+      _values(Memory<double, MemorySpaceType>::allocate_data(_dim_0 * dim_1 *
+                                                             dim_2 * _dim_3))
+{
+}
+
+template <int dim_1, int dim_2, typename MemorySpaceType>
+Array4D<-1, dim_1, dim_2, -1, MemorySpaceType>::Array4D(
+    Array4D<-1, dim_1, dim_2, -1, MemorySpaceType> const &other)
+    : _owning(false), _dim_0(other._dim_0), _dim_3(other._dim_3),
+      _values(other._values)
+{
+}
+
+template <int dim_1, int dim_2, typename MemorySpaceType>
+Array4D<-1, dim_1, dim_2, -1, MemorySpaceType>::~Array4D()
+{
+  if (_owning && _values)
+  {
+    Memory<double, MemorySpaceType>::delete_data(_values);
+  }
+  _values = nullptr;
+}
+
+template <int dim_1, int dim_2, typename MemorySpaceType>
+void Array4D<-1, dim_1, dim_2, -1, MemorySpaceType>::reinit(unsigned int size_0,
+                                                            unsigned int size_3)
+{
+  // Free memory if necessary
+  if (_owning && _values)
+  {
+    Memory<double, MemorySpaceType>::delete_data(_values);
+  }
+
+  _dim_0 = size_0;
+  _dim_3 = size_3;
+  _values = Memory<double, MemorySpaceType>::allocate_data(_dim_0 * dim_1 *
+                                                           dim_2 * _dim_3);
+}
+
+template <int dim_1, int dim_2, typename MemorySpaceType>
+void Array4D<-1, dim_1, dim_2, -1, MemorySpaceType>::set_zero()
+{
+
+  Memory<double, MemorySpaceType>::set_zero(_values,
+                                            _dim_0 * dim_1 * dim_2 * _dim_3);
+}
+
+template <int dim_1, int dim_2, typename MemorySpaceType>
+ADAMANTINE_HOST_DEV unsigned int
+Array4D<-1, dim_1, dim_2, -1, MemorySpaceType>::extent(unsigned int i) const
+{
+  if (i == 0)
+    return _dim_0;
+  else if (i == 1)
+    return dim_1;
+  else if (i == 2)
+    return dim_2;
+  else if (i == 3)
+    return _dim_3;
+  else
+    return 0;
+}
+template <int dim_1, int dim_2, typename MemorySpaceType>
+ADAMANTINE_HOST_DEV double &
+Array4D<-1, dim_1, dim_2, -1, MemorySpaceType>::operator()(unsigned int i,
+                                                           unsigned int j,
+                                                           unsigned int k,
+                                                           unsigned int l)
+{
+  return _values[i * (dim_1 * dim_2 * _dim_3) + j * (dim_2 * _dim_3) +
+                 k * _dim_3 + l];
+}
+
+template <int dim_1, int dim_2, typename MemorySpaceType>
+ADAMANTINE_HOST_DEV double const &
+Array4D<-1, dim_1, dim_2, -1, MemorySpaceType>::operator()(unsigned int i,
+                                                           unsigned int j,
+                                                           unsigned int k,
+                                                           unsigned int l) const
+{
+  return _values[i * (dim_1 * dim_2 * _dim_3) + j * (dim_2 * _dim_3) +
+                 k * _dim_3 + l];
+}
+
+/**
+ * Five-dimensional array with all dimension set at compile-time.
+ */
+template <int dim_0, int dim_1, int dim_2, int dim_3, int dim_4,
+          typename MemorySpaceType>
+class Array5D
+{
+public:
+  static_assert(dim_0 > 0, "dim_0 should be greater than 0.");
+  static_assert(dim_1 > 0, "dim_1 should be greater than 0.");
+  static_assert(dim_2 > 0, "dim_2 should be greater than 0.");
+  static_assert(dim_3 > 0, "dim_3 should be greater than 0.");
+  static_assert(dim_4 > 0, "dim_4 should be greater than 0.");
+
+  /**
+   * Default constructor.
+   */
+  Array5D();
+
+  /**
+   * Copy constructor. The copy is non-owning, i.e., the lifetime of the
+   * underlying data is determined by the original object.
+   */
+  Array5D(
+      Array5D<dim_0, dim_1, dim_2, dim_3, dim_4, MemorySpaceType> const &other);
+
+  /**
+   * Destructor.
+   */
+  ~Array5D();
+
+  /**
+   * Set the data to zero.
+   */
+  void set_zero();
+
+  /**
+   * Dimension `i` of the array.
+   */
+  ADAMANTINE_HOST_DEV unsigned int extent(unsigned int i) const;
+
+  /**
+   * Access element `(i,j,k,l,m)` of the array.
+   */
+  ADAMANTINE_HOST_DEV double &operator()(unsigned int i, unsigned int j,
+                                         unsigned int k, unsigned int l,
+                                         unsigned int m);
+
+  /**
+   * Access element `(i,j,k,l,m)` of the array.
+   */
+  ADAMANTINE_HOST_DEV double const &operator()(unsigned int i, unsigned int j,
+                                               unsigned int k, unsigned int l,
+                                               unsigned int m) const;
+
+private:
+  /**
+   * Owning flag true if owning and false otherwise.
+   */
+  bool _owning = true;
+  /**
+   * Pointer to data.
+   */
+  double *_values = nullptr;
+};
+
+template <int dim_0, int dim_1, int dim_2, int dim_3, int dim_4,
+          typename MemorySpaceType>
+Array5D<dim_0, dim_1, dim_2, dim_3, dim_4, MemorySpaceType>::Array5D()
+    : _values(Memory<double, MemorySpaceType>::allocate_data(
+          dim_0 * dim_1 * dim_2 * dim_3 * dim_4))
+{
+}
+
+template <int dim_0, int dim_1, int dim_2, int dim_3, int dim_4,
+          typename MemorySpaceType>
+Array5D<dim_0, dim_1, dim_2, dim_3, dim_4, MemorySpaceType>::Array5D(
+    Array5D<dim_0, dim_1, dim_2, dim_3, dim_4, MemorySpaceType> const &other)
+    : _owning(false), _values(other._values)
+{
+}
+
+template <int dim_0, int dim_1, int dim_2, int dim_3, int dim_4,
+          typename MemorySpaceType>
+Array5D<dim_0, dim_1, dim_2, dim_3, dim_4, MemorySpaceType>::~Array5D()
+{
+  if (_owning && _values)
+  {
+    Memory<double, MemorySpaceType>::delete_data(_values);
+  }
+  _values = nullptr;
+}
+
+template <int dim_0, int dim_1, int dim_2, int dim_3, int dim_4,
+          typename MemorySpaceType>
+void Array5D<dim_0, dim_1, dim_2, dim_3, dim_4, MemorySpaceType>::set_zero()
+{
+
+  Memory<double, MemorySpaceType>::set_zero(_values, dim_0 * dim_1 * dim_2 *
+                                                         dim_3 * dim_4);
+}
+
+template <int dim_0, int dim_1, int dim_2, int dim_3, int dim_4,
+          typename MemorySpaceType>
+ADAMANTINE_HOST_DEV unsigned int
+Array5D<dim_0, dim_1, dim_2, dim_3, dim_4, MemorySpaceType>::extent(
+    unsigned int i) const
+{
+  if (i == 0)
+    return dim_0;
+  else if (i == 1)
+    return dim_1;
+  else if (i == 2)
+    return dim_2;
+  else if (i == 3)
+    return dim_3;
+  else if (i == 4)
+    return dim_4;
+  else
+    return 0;
+}
+
+template <int dim_0, int dim_1, int dim_2, int dim_3, int dim_4,
+          typename MemorySpaceType>
+ADAMANTINE_HOST_DEV double &
+Array5D<dim_0, dim_1, dim_2, dim_3, dim_4, MemorySpaceType>::operator()(
+    unsigned int i, unsigned int j, unsigned int k, unsigned int l,
+    unsigned int m)
+{
+  return _values[i * (dim_1 * dim_2 * dim_3 * dim_4) +
+                 j * (dim_2 * dim_3 * dim_4) + k * (dim_3 * dim_4) + l * dim_4 +
+                 m];
+}
+
+template <int dim_0, int dim_1, int dim_2, int dim_3, int dim_4,
+          typename MemorySpaceType>
+ADAMANTINE_HOST_DEV double const &
+Array5D<dim_0, dim_1, dim_2, dim_3, dim_4, MemorySpaceType>::operator()(
+    unsigned int i, unsigned int j, unsigned int k, unsigned int l,
+    unsigned int m) const
+{
+  return _values[i * (dim_1 * dim_2 * dim_3 * dim_4) +
+                 j * (dim_2 * dim_3 * dim_4) + k * (dim_3 * dim_4) + l * dim_4 +
+                 m];
+}
+
+/**
+ * Five-dimensional array with the first and the fourth dimensions set at
+ * runtime and the other dimensions set at compile-time.
+ */
+template <int dim_1, int dim_2, int dim_4, typename MemorySpaceType>
+class Array5D<-1, dim_1, dim_2, -1, dim_4, MemorySpaceType>
+{
+public:
+  static_assert(dim_1 > 0, "dim_1 should be greater than 0.");
+  static_assert(dim_2 > 0, "dim_2 should be greater than 0.");
+  static_assert(dim_4 > 0, "dim_4 should be greater than 0.");
+
+  /**
+   * Default constructor.
+   */
+  Array5D() = default;
+
+  /**
+   * Constructor. Set the first dimension to `size_0` and the fourth dimension
+   * to `size_3`.
+   */
+  Array5D(unsigned int size_0, unsigned int size_3);
+
+  /**
+   * Copy constructor. The copy is non-owning, i.e., the lifetime of the
+   * underlying data is determined by the original object.
+   */
+  Array5D(Array5D<-1, dim_1, dim_2, -1, dim_4, MemorySpaceType> const &other);
+
+  /**
+   * Destructor.
+   */
+  ~Array5D();
+
+  /**
+   * Reinitialize the data using `size_0` for the first dimension and `size_3`
+   * for the fourth dimensio. The initial data is cleared.
+   */
+  void reinit(unsigned int size_0, unsigned int size_3);
+
+  /**
+   * Set the data to zero.
+   */
+  void set_zero();
+
+  /**
+   * Dimension `i` of the array.
+   */
+  ADAMANTINE_HOST_DEV unsigned int extent(unsigned int i) const;
+
+  /**
+   * Access element `(i,j,k,l,m)` of the array.
+   */
+  ADAMANTINE_HOST_DEV double &operator()(unsigned int i, unsigned int j,
+                                         unsigned int k, unsigned int l,
+                                         unsigned int m);
+  /**
+   * Access element `(i,j,k,l,m)` of the array.
+   */
+  ADAMANTINE_HOST_DEV double const &operator()(unsigned int i, unsigned int j,
+                                               unsigned int k, unsigned int l,
+                                               unsigned int m) const;
+
+private:
+  /**
+   * Owning flag true if owning and false otherwise.
+   */
+  bool _owning = true;
+  /**
+   * Dimension zero of the array.
+   */
+  unsigned int _dim_0 = 0;
+  /**
+   * Dimension three of the array.
+   */
+  unsigned int _dim_3 = 0;
+  /**
+   * Pointer to data.
+   */
+  double *_values = nullptr;
+};
+
+template <int dim_1, int dim_2, int dim_4, typename MemorySpaceType>
+Array5D<-1, dim_1, dim_2, -1, dim_4, MemorySpaceType>::Array5D(
+    unsigned int size_0, unsigned int size_3)
+    : _dim_0(size_0), _dim_3(size_3),
+      _values(Memory<double, MemorySpaceType>::allocate_data(
+          _dim_0 * dim_1 * dim_2 * _dim_3 * dim_4))
+{
+}
+
+template <int dim_1, int dim_2, int dim_4, typename MemorySpaceType>
+Array5D<-1, dim_1, dim_2, -1, dim_4, MemorySpaceType>::Array5D(
+    Array5D<-1, dim_1, dim_2, -1, dim_4, MemorySpaceType> const &other)
+    : _owning(false), _dim_0(other._dim_0), _dim_3(other._dim_3),
+      _values(other._values)
+{
+}
+
+template <int dim_1, int dim_2, int dim_4, typename MemorySpaceType>
+void Array5D<-1, dim_1, dim_2, -1, dim_4, MemorySpaceType>::reinit(
+    unsigned int size_0, unsigned int size_3)
+{
+  // Free memory if necessary
+  if (_owning && _values)
+  {
+    Memory<double, MemorySpaceType>::delete_data(_values);
+  }
+
+  _dim_0 = size_0;
+  _dim_3 = size_3;
+  _values = Memory<double, MemorySpaceType>::allocate_data(
+      _dim_0 * dim_1 * dim_2 * _dim_3 * dim_4);
+}
+
+template <int dim_1, int dim_2, int dim_4, typename MemorySpaceType>
+Array5D<-1, dim_1, dim_2, -1, dim_4, MemorySpaceType>::~Array5D()
+{
+  if (_owning && _values)
+  {
+    Memory<double, MemorySpaceType>::delete_data(_values);
+  }
+  _values = nullptr;
+}
+
+template <int dim_1, int dim_2, int dim_4, typename MemorySpaceType>
+void Array5D<-1, dim_1, dim_2, -1, dim_4, MemorySpaceType>::set_zero()
+{
+
+  Memory<double, MemorySpaceType>::set_zero(_values, _dim_0 * dim_1 * dim_2 *
+                                                         _dim_3 * dim_4);
+}
+
+template <int dim_1, int dim_2, int dim_4, typename MemorySpaceType>
+ADAMANTINE_HOST_DEV unsigned int
+Array5D<-1, dim_1, dim_2, -1, dim_4, MemorySpaceType>::extent(
+    unsigned int i) const
+{
+  if (i == 0)
+    return _dim_0;
+  else if (i == 1)
+    return dim_1;
+  else if (i == 2)
+    return dim_2;
+  else if (i == 3)
+    return _dim_3;
+  else if (i == 4)
+    return dim_4;
+  else
+    return 0;
+}
+
+template <int dim_1, int dim_2, int dim_4, typename MemorySpaceType>
+ADAMANTINE_HOST_DEV double &
+Array5D<-1, dim_1, dim_2, -1, dim_4, MemorySpaceType>::operator()(
+    unsigned int i, unsigned int j, unsigned int k, unsigned int l,
+    unsigned int m)
+{
+  return _values[i * (dim_1 * dim_2 * _dim_3 * dim_4) +
+                 j * (dim_2 * _dim_3 * dim_4) + k * (_dim_3 * dim_4) +
+                 l * dim_4 + m];
+}
+
+template <int dim_1, int dim_2, int dim_4, typename MemorySpaceType>
+ADAMANTINE_HOST_DEV double const &
+Array5D<-1, dim_1, dim_2, -1, dim_4, MemorySpaceType>::operator()(
+    unsigned int i, unsigned int j, unsigned int k, unsigned int l,
+    unsigned int m) const
+{
+  return _values[i * (dim_1 * dim_2 * _dim_3 * dim_4) +
+                 j * (dim_2 * _dim_3 * dim_4) + k * (_dim_3 * dim_4) +
+                 l * dim_4 + m];
+}
+
+} // namespace adamantine
+
+#endif

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -7,6 +7,7 @@ set(Adamantine_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/HeatSource.hh
     ${CMAKE_CURRENT_SOURCE_DIR}/ImplicitOperator.hh
     ${CMAKE_CURRENT_SOURCE_DIR}/MaterialProperty.hh
+    ${CMAKE_CURRENT_SOURCE_DIR}/ArrayMD.hh
     ${CMAKE_CURRENT_SOURCE_DIR}/NewtonSolver.hh
     ${CMAKE_CURRENT_SOURCE_DIR}/Operator.hh
     ${CMAKE_CURRENT_SOURCE_DIR}/Physics.hh

--- a/source/ThermalPhysics.templates.hh
+++ b/source/ThermalPhysics.templates.hh
@@ -119,7 +119,7 @@ template <int dim, int fe_degree, typename MemorySpaceType,
 ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::ThermalPhysics(
     MPI_Comm const &communicator, boost::property_tree::ptree const &database,
     Geometry<dim> &geometry)
-    : _geometry(geometry), _boundary_type(BoundaryType::invalid),
+    : _boundary_type(BoundaryType::invalid), _geometry(geometry),
       _dof_handler(_geometry.get_triangulation())
 {
   // Create the FECollection

--- a/source/utils.hh
+++ b/source/utils.hh
@@ -8,13 +8,75 @@
 #ifndef UTILS_HH
 #define UTILS_HH
 
+#include <deal.II/base/cuda.h>
+#include <deal.II/base/exceptions.h>
+
 #include <cassert>
+#include <cstring>
 #include <exception>
 #include <stdexcept>
 #include <string>
 
 namespace adamantine
 {
+#ifdef __CUDACC__
+#define ADAMANTINE_HOST_DEV __host__ __device__
+#else
+#define ADAMANTINE_HOST_DEV
+#endif
+
+template <typename Number, typename MemorySpaceType>
+struct Memory
+{
+  static Number *allocate_data(std::size_t const size);
+
+  static void delete_data(Number *data_ptr) noexcept;
+
+  static void set_zero(Number *data_ptr, std::size_t const size);
+};
+
+template <typename Number>
+struct Memory<Number, dealii::MemorySpace::Host>
+{
+  static Number *allocate_data(std::size_t const size)
+  {
+    Number *data_ptr = new Number[size];
+    return data_ptr;
+  }
+
+  static void delete_data(Number *data_ptr) noexcept { delete[] data_ptr; }
+
+  static void set_zero(Number *data_ptr, std::size_t const size)
+  {
+    std::memset(data_ptr, 0, size * sizeof(Number));
+  }
+};
+
+#ifdef __CUDACC__
+template <typename Number>
+struct Memory<Number, dealii::MemorySpace::CUDA>
+{
+  static Number *allocate_data(std::size_t const size)
+  {
+    Number *data_ptr;
+    dealii::Utilities::CUDA::malloc(data_ptr, size);
+    return data_ptr;
+  }
+
+  static void delete_data(Number *data_ptr) noexcept
+  {
+    cudaError_t const error_code = cudaFree(data_ptr);
+    AssertNothrowCuda(error_code);
+  }
+
+  static void set_zero(Number *data_ptr, std::size_t const size)
+  {
+    cudaError_t const error_code =
+        cudaMemset(data_ptr, 0, size * sizeof(Number));
+    AssertCuda(error_code);
+  }
+};
+#endif
 
 inline void ASSERT(bool cond, std::string const &message)
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ list(APPEND
      test_heat_source
      test_implicit_operator
      test_material_property
+     test_arraymd
      test_newton_solver
      test_post_processor
      test_scan_path
@@ -32,6 +33,7 @@ set(CUDA_UNIT_TESTS "")
 list(APPEND
      CUDA_UNIT_TESTS
      test_integration_2d_device
+     test_arraymd_device
      test_thermal_operator_device
      test_thermal_physics_device
      )

--- a/tests/test_arraymd.cc
+++ b/tests/test_arraymd.cc
@@ -1,0 +1,107 @@
+/* Copyright (c) 2021, the adamantine authors.
+ *
+ * This file is subject to the Modified BSD License and may not be distributed
+ * without copyright and license information. Please refer to the file LICENSE
+ * for the text and further information on this license.
+ */
+
+#define BOOST_TEST_MODULE ArrayMD
+
+#include <ArrayMD.hh>
+
+#include "main.cc"
+
+BOOST_AUTO_TEST_CASE(array2d)
+{
+  int constexpr dim_0 = 2;
+  int constexpr dim_1 = 3;
+
+  adamantine::Array2D<dim_0, dim_1, dealii::MemorySpace::Host> array2d_template;
+  adamantine::Array2D<-1, dim_1, dealii::MemorySpace::Host>
+      array2d_partial_template(dim_0);
+
+  for (int i = 0; i < dim_0; ++i)
+    for (int j = 0; j < dim_1; ++j)
+    {
+      array2d_template(i, j) = i + j;
+      array2d_partial_template(i, j) = i + j;
+    }
+
+  for (int i = 0; i < dim_0; ++i)
+    for (int j = 0; j < dim_1; ++j)
+    {
+      BOOST_CHECK(array2d_template(i, j) == i + j);
+      BOOST_CHECK(array2d_partial_template(i, j) == i + j);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(array4d)
+{
+  int constexpr dim_0 = 2;
+  int constexpr dim_1 = 3;
+  int constexpr dim_2 = 4;
+  int constexpr dim_3 = 5;
+
+  adamantine::Array4D<dim_0, dim_1, dim_2, dim_3, dealii::MemorySpace::Host>
+      array4d_template;
+  adamantine::Array4D<dim_0, dim_1, dim_2, -1, dealii::MemorySpace::Host>
+      array4d_partial_template_1(dim_3);
+  adamantine::Array4D<-1, dim_1, dim_2, -1, dealii::MemorySpace::Host>
+      array4d_partial_template_2(dim_0, dim_3);
+
+  for (int i = 0; i < dim_0; ++i)
+    for (int j = 0; j < dim_1; ++j)
+      for (int k = 0; k < dim_2; ++k)
+        for (int l = 0; l < dim_3; ++l)
+        {
+          array4d_template(i, j, k, l) = i + j + k + l;
+          array4d_partial_template_1(i, j, k, l) = i + j + k + l;
+          array4d_partial_template_2(i, j, k, l) = i + j + k + l;
+        }
+
+  for (int i = 0; i < dim_0; ++i)
+    for (int j = 0; j < dim_1; ++j)
+      for (int k = 0; k < dim_2; ++k)
+        for (int l = 0; l < dim_3; ++l)
+        {
+          BOOST_CHECK(array4d_template(i, j, k, l) == i + j + k + l);
+          BOOST_CHECK(array4d_partial_template_1(i, j, k, l) == i + j + k + l);
+          BOOST_CHECK(array4d_partial_template_2(i, j, k, l) == i + j + k + l);
+        }
+}
+
+BOOST_AUTO_TEST_CASE(array5d)
+{
+  int constexpr dim_0 = 2;
+  int constexpr dim_1 = 3;
+  int constexpr dim_2 = 4;
+  int constexpr dim_3 = 5;
+  int constexpr dim_4 = 6;
+
+  adamantine::Array5D<dim_0, dim_1, dim_2, dim_3, dim_4,
+                      dealii::MemorySpace::Host>
+      array5d_template;
+  adamantine::Array5D<-1, dim_1, dim_2, -1, dim_4, dealii::MemorySpace::Host>
+      array5d_partial_template(dim_0, dim_3);
+
+  for (int i = 0; i < dim_0; ++i)
+    for (int j = 0; j < dim_1; ++j)
+      for (int k = 0; k < dim_2; ++k)
+        for (int l = 0; l < dim_3; ++l)
+          for (int m = 0; m < dim_4; ++m)
+          {
+            array5d_template(i, j, k, l, m) = i + j + k + l + m;
+            array5d_partial_template(i, j, k, l, m) = i + j + k + l + m;
+          }
+
+  for (int i = 0; i < dim_0; ++i)
+    for (int j = 0; j < dim_1; ++j)
+      for (int k = 0; k < dim_2; ++k)
+        for (int l = 0; l < dim_3; ++l)
+          for (int m = 0; m < dim_4; ++m)
+          {
+            BOOST_CHECK(array5d_template(i, j, k, l, m) == i + j + k + l + m);
+            BOOST_CHECK(array5d_partial_template(i, j, k, l, m) ==
+                        i + j + k + l + m);
+          }
+}

--- a/tests/test_arraymd_device.cu
+++ b/tests/test_arraymd_device.cu
@@ -1,0 +1,258 @@
+/* Copyright (c) 2021, the adamantine authors.
+ *
+ * This file is subject to the Modified BSD License and may not be distributed
+ * without copyright and license information. Please refer to the file LICENSE
+ * for the text and further information on this license.
+ */
+
+#include "utils.hh"
+#define BOOST_TEST_MODULE ArrayMDDevice
+
+#include <ArrayMD.hh>
+
+#include <deal.II/base/cuda_size.h>
+
+#include "main.cc"
+
+template <int dim_0, int dim_1>
+__global__ void
+fill_array2d(adamantine::Array2D<dim_0, dim_1, dealii::MemorySpace::CUDA>
+                 array2d_template,
+             adamantine::Array2D<-1, dim_1, dealii::MemorySpace::CUDA>
+                 array2d_partial_template)
+{
+  int id = threadIdx.x + blockDim.x * blockIdx.x;
+  if (id < dim_0 * dim_1)
+  {
+    int i = id / dim_1;
+    int j = id - i * dim_1;
+    array2d_template(i, j) = id;
+    array2d_partial_template(i, j) = id;
+  }
+}
+
+template <int dim_0, int dim_1>
+__global__ void
+check_array2d(adamantine::Array2D<dim_0, dim_1, dealii::MemorySpace::CUDA>
+                  array2d_template,
+              adamantine::Array2D<-1, dim_1, dealii::MemorySpace::CUDA>
+                  array2d_partial_template,
+              int *n_errors)
+{
+  int id = threadIdx.x + blockDim.x * blockIdx.x;
+  if (id < dim_0 * dim_1)
+  {
+    int i = id / dim_1;
+    int j = id - i * dim_1;
+    if (array2d_template(i, j) != id)
+      atomicAdd(&n_errors[0], 1);
+    if (array2d_partial_template(i, j) != id)
+      atomicAdd(&n_errors[1], 1);
+  }
+}
+
+template <int dim_0, int dim_1, int dim_2, int dim_3>
+__global__ void fill_array4d(
+    adamantine::Array4D<dim_0, dim_1, dim_2, dim_3, dealii::MemorySpace::CUDA>
+        array4d_template,
+    adamantine::Array4D<dim_0, dim_1, dim_2, -1, dealii::MemorySpace::CUDA>
+        array4d_partial_template_1,
+    adamantine::Array4D<-1, dim_1, dim_2, -1, dealii::MemorySpace::CUDA>
+        array4d_partial_template_2)
+{
+  int id = threadIdx.x + blockDim.x * blockIdx.x;
+  if (id < dim_0 * dim_1 * dim_2 * dim_3)
+  {
+    int i = id / (dim_1 * dim_2 * dim_3);
+    int j = (id - i * (dim_1 * dim_2 * dim_3)) / (dim_2 * dim_3);
+    int k = (id - i * (dim_1 * dim_2 * dim_3) - j * (dim_2 * dim_3)) / dim_3;
+    int l = id - i * (dim_1 * dim_2 * dim_3) - j * (dim_2 * dim_3) - k * dim_3;
+    array4d_template(i, j, k, l) = id;
+    array4d_partial_template_1(i, j, k, l) = id;
+    array4d_partial_template_2(i, j, k, l) = id;
+  }
+}
+
+template <int dim_0, int dim_1, int dim_2, int dim_3>
+__global__ void check_array4d(
+    adamantine::Array4D<dim_0, dim_1, dim_2, dim_3, dealii::MemorySpace::CUDA>
+        array4d_template,
+    adamantine::Array4D<dim_0, dim_1, dim_2, -1, dealii::MemorySpace::CUDA>
+        array4d_partial_template_1,
+    adamantine::Array4D<-1, dim_1, dim_2, -1, dealii::MemorySpace::CUDA>
+        array4d_partial_template_2,
+    int *n_errors)
+{
+  int id = threadIdx.x + blockDim.x * blockIdx.x;
+  if (id < dim_0 * dim_1 * dim_2 * dim_3)
+  {
+    int i = id / (dim_1 * dim_2 * dim_3);
+    int j = (id - i * (dim_1 * dim_2 * dim_3)) / (dim_2 * dim_3);
+    int k = (id - i * (dim_1 * dim_2 * dim_3) - j * (dim_2 * dim_3)) / dim_3;
+    int l = id - i * (dim_1 * dim_2 * dim_3) - j * (dim_2 * dim_3) - k * dim_3;
+    if (array4d_template(i, j, k, l) != id)
+      atomicAdd(&n_errors[0], 1);
+    if (array4d_partial_template_1(i, j, k, l) != id)
+      atomicAdd(&n_errors[1], 1);
+    if (array4d_partial_template_2(i, j, k, l) != id)
+      atomicAdd(&n_errors[2], 1);
+  }
+}
+
+template <int dim_0, int dim_1, int dim_2, int dim_3, int dim_4>
+__global__ void fill_array5d(
+    adamantine::Array5D<dim_0, dim_1, dim_2, dim_3, dim_4,
+                        dealii::MemorySpace::CUDA>
+        array5d_template,
+    adamantine::Array5D<-1, dim_1, dim_2, -1, dim_4, dealii::MemorySpace::CUDA>
+        array5d_partial_template)
+{
+  int id = threadIdx.x + blockDim.x * blockIdx.x;
+  if (id < dim_0 * dim_1 * dim_2 * dim_3 * dim_4)
+  {
+    int i = id / (dim_1 * dim_2 * dim_3 * dim_4);
+    int j =
+        (id - i * (dim_1 * dim_2 * dim_3 * dim_4)) / (dim_2 * dim_3 * dim_4);
+    int k = (id - i * (dim_1 * dim_2 * dim_3 * dim_4) -
+             j * (dim_2 * dim_3 * dim_4)) /
+            (dim_3 * dim_4);
+    int l = (id - i * (dim_1 * dim_2 * dim_3 * dim_4) -
+             j * (dim_2 * dim_3 * dim_4) - k * (dim_3 * dim_4)) /
+            dim_4;
+    int m = id - i * (dim_1 * dim_2 * dim_3 * dim_4) -
+            j * (dim_2 * dim_3 * dim_4) - k * (dim_3 * dim_4) - l * dim_4;
+    array5d_template(i, j, k, l, m) = id;
+    array5d_partial_template(i, j, k, l, m) = id;
+  }
+}
+
+template <int dim_0, int dim_1, int dim_2, int dim_3, int dim_4>
+__global__ void check_array5d(
+    adamantine::Array5D<dim_0, dim_1, dim_2, dim_3, dim_4,
+                        dealii::MemorySpace::CUDA>
+        array5d_template,
+    adamantine::Array5D<-1, dim_1, dim_2, -1, dim_4, dealii::MemorySpace::CUDA>
+        array5d_partial_template,
+    int *n_errors)
+{
+  int id = threadIdx.x + blockDim.x * blockIdx.x;
+  if (id < dim_0 * dim_1 * dim_2 * dim_3 * dim_4)
+  {
+    int i = id / (dim_1 * dim_2 * dim_3 * dim_4);
+    int j =
+        (id - i * (dim_1 * dim_2 * dim_3 * dim_4)) / (dim_2 * dim_3 * dim_4);
+    int k = (id - i * (dim_1 * dim_2 * dim_3 * dim_4) -
+             j * (dim_2 * dim_3 * dim_4)) /
+            (dim_3 * dim_4);
+    int l = (id - i * (dim_1 * dim_2 * dim_3 * dim_4) -
+             j * (dim_2 * dim_3 * dim_4) - k * (dim_3 * dim_4)) /
+            dim_4;
+    int m = id - i * (dim_1 * dim_2 * dim_3 * dim_4) -
+            j * (dim_2 * dim_3 * dim_4) - k * (dim_3 * dim_4) - l * dim_4;
+    if (array5d_template(i, j, k, l, m) != id)
+      atomicAdd(&n_errors[0], 1);
+    if (array5d_partial_template(i, j, k, l, m) != id)
+      atomicAdd(&n_errors[1], 1);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(array2d)
+{
+  int constexpr dim_0 = 2;
+  int constexpr dim_1 = 3;
+  int constexpr size = dim_0 * dim_1;
+
+  adamantine::Array2D<dim_0, dim_1, dealii::MemorySpace::CUDA> array2d_template;
+  adamantine::Array2D<-1, dim_1, dealii::MemorySpace::CUDA>
+      array2d_partial_template(dim_0);
+
+  const int n_blocks = 1 + size / dealii::CUDAWrappers::block_size;
+  fill_array2d<<<n_blocks, dealii::CUDAWrappers::block_size>>>(
+      array2d_template, array2d_partial_template);
+
+  int *n_errors_dev;
+  dealii::Utilities::CUDA::malloc(n_errors_dev, 2);
+  adamantine::Memory<int, dealii::MemorySpace::CUDA>::set_zero(n_errors_dev, 2);
+
+  check_array2d<<<n_blocks, dealii::CUDAWrappers::block_size>>>(
+      array2d_template, array2d_partial_template, n_errors_dev);
+
+  std::vector<int> n_errors_host(2);
+  dealii::Utilities::CUDA::copy_to_host(n_errors_dev, n_errors_host);
+
+  for (unsigned int i = 0; i < 2; ++i)
+    BOOST_CHECK(n_errors_host[i] == 0);
+
+  dealii::Utilities::CUDA::free(n_errors_dev);
+}
+
+BOOST_AUTO_TEST_CASE(array4d)
+{
+  int constexpr dim_0 = 2;
+  int constexpr dim_1 = 3;
+  int constexpr dim_2 = 4;
+  int constexpr dim_3 = 5;
+  int constexpr size = dim_0 * dim_1 * dim_2 * dim_3;
+
+  adamantine::Array4D<dim_0, dim_1, dim_2, dim_3, dealii::MemorySpace::CUDA>
+      array4d_template;
+  adamantine::Array4D<dim_0, dim_1, dim_2, -1, dealii::MemorySpace::CUDA>
+      array4d_partial_template_1(dim_3);
+  adamantine::Array4D<-1, dim_1, dim_2, -1, dealii::MemorySpace::CUDA>
+      array4d_partial_template_2(dim_0, dim_3);
+
+  const int n_blocks = 1 + size / dealii::CUDAWrappers::block_size;
+  fill_array4d<<<n_blocks, dealii::CUDAWrappers::block_size>>>(
+      array4d_template, array4d_partial_template_1, array4d_partial_template_2);
+
+  int *n_errors_dev;
+  dealii::Utilities::CUDA::malloc(n_errors_dev, 3);
+  adamantine::Memory<int, dealii::MemorySpace::CUDA>::set_zero(n_errors_dev, 3);
+
+  check_array4d<<<n_blocks, dealii::CUDAWrappers::block_size>>>(
+      array4d_template, array4d_partial_template_1, array4d_partial_template_2,
+      n_errors_dev);
+
+  std::vector<int> n_errors_host(3);
+  dealii::Utilities::CUDA::copy_to_host(n_errors_dev, n_errors_host);
+
+  for (unsigned int i = 0; i < 3; ++i)
+    BOOST_CHECK(n_errors_host[i] == 0);
+
+  dealii::Utilities::CUDA::free(n_errors_dev);
+}
+
+BOOST_AUTO_TEST_CASE(array5d)
+{
+  int constexpr dim_0 = 2;
+  int constexpr dim_1 = 3;
+  int constexpr dim_2 = 4;
+  int constexpr dim_3 = 5;
+  int constexpr dim_4 = 6;
+  int constexpr size = dim_0 * dim_1 * dim_2 * dim_3 * dim_4;
+
+  adamantine::Array5D<dim_0, dim_1, dim_2, dim_3, dim_4,
+                      dealii::MemorySpace::CUDA>
+      array5d_template;
+  adamantine::Array5D<-1, dim_1, dim_2, -1, dim_4, dealii::MemorySpace::CUDA>
+      array5d_partial_template(dim_0, dim_3);
+
+  const int n_blocks = 1 + size / dealii::CUDAWrappers::block_size;
+  fill_array5d<<<n_blocks, dealii::CUDAWrappers::block_size>>>(
+      array5d_template, array5d_partial_template);
+
+  int *n_errors_dev;
+  dealii::Utilities::CUDA::malloc(n_errors_dev, 2);
+  adamantine::Memory<int, dealii::MemorySpace::CUDA>::set_zero(n_errors_dev, 2);
+
+  check_array5d<<<n_blocks, dealii::CUDAWrappers::block_size>>>(
+      array5d_template, array5d_partial_template, n_errors_dev);
+
+  std::vector<int> n_errors_host(2);
+  dealii::Utilities::CUDA::copy_to_host(n_errors_dev, n_errors_host);
+
+  for (unsigned int i = 0; i < 2; ++i)
+    BOOST_CHECK(n_errors_host[i] == 0);
+
+  dealii::Utilities::CUDA::free(n_errors_dev);
+}

--- a/tests/test_thermal_operator_device.cu
+++ b/tests/test_thermal_operator_device.cu
@@ -5,7 +5,7 @@
  * for the text and further information on this license.
  */
 
-#define BOOST_TEST_MODULE ThermalOperator
+#define BOOST_TEST_MODULE ThermalOperatorDevice
 
 #include <Geometry.hh>
 #include <ThermalOperator.hh>


### PR DESCRIPTION
This PR adds new data structures: `Array2D`, `Array3D,` `Array4D`, and `Array5D` The memory space where the data is stored is determined by the last template parameters `MemorySpaceType`. The dimensions of the `Array` can be set at compile time using a template parameter or at run-time. In that last case, the template parameter should be set to `-1`. Note that I didn't implement all the combinations of compile/run-time parameters. I've implemented the one that I use in other parts of the code. 