### PR TITLE
Add support for adiak

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,10 +11,12 @@ IncludeCategories:
     Priority: 200
   - Regex: "boost*"
     Priority: 300
-  - Regex: "caliper*"
+  - Regex: "adiak*"
     Priority: 400
-  - Regex: "Kokkos*"
+  - Regex: "caliper*"
     Priority: 500
+  - Regex: "Kokkos*"
+    Priority: 600
   - Regex: "<[a-z_]+>"
     Priority: 1000
 ...

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ in a newly created `bin` subdirectory. You will find in this subdirectory the
 executable and an example of input files.
 
 The list of configuration options is:
-* ADAMNATINE\_ENABLE\_CALIPER=ON/OFF
+* ADAMANTINE\_ENABLE\_ADIAK=ON/OFF
+* ADAMANTINE\_ENABLE\_CALIPER=ON/OFF
 * ADAMANTINE\_ENABLE\_COVERAGE=ON/OFF
 * ADAMANTINE\_ENABLE\_CUDA=ON/OFF
 * ADAMANTINE\_ENABLE\_TESTS=ON/OFF

--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -21,5 +21,10 @@ endif()
 
 DEAL_II_SETUP_TARGET(adamantine)
 target_link_libraries(adamantine Adamantine)
+if (ADAMANTINE_ENABLE_ADIAK)
+  target_include_directories(adamantine PUBLIC ${adiak_INCLUDE_DIR})
+  target_link_libraries(adamantine adiak)
+endif()
+
 file(COPY input.info DESTINATION ${CMAKE_BINARY_DIR}/bin)
 file(COPY input_scan_path.txt DESTINATION ${CMAKE_BINARY_DIR}/bin)

--- a/application/adamantine.cc
+++ b/application/adamantine.cc
@@ -7,6 +7,10 @@
 
 #include "adamantine.hh"
 
+#ifdef ADAMANTINE_WITH_ADIAK
+#include <adiak.hpp>
+#endif
+
 #ifdef ADAMANTINE_WITH_CALIPER
 #include <caliper/cali-manager.h>
 #endif
@@ -24,6 +28,18 @@ int main(int argc, char *argv[])
   MPI_Comm communicator = MPI_COMM_WORLD;
 
   Kokkos::ScopeGuard guard(argc, argv);
+
+#ifdef ADAMANTINE_WITH_ADIAK
+  adiak_init(&communicator);
+  adiak::user();
+  adiak::launchdate();
+  adiak::executablepath();
+  adiak::libraries();
+  adiak::cmdline();
+  adiak::clustername();
+  adiak::jobsize();
+  adiak::value("MemorySpace", "Host");
+#endif
 
   std::vector<adamantine::Timer> timers;
   initialize_timers(communicator, timers);
@@ -143,6 +159,10 @@ int main(int argc, char *argv[])
   if (profiling == true)
     for (auto &timer : timers)
       timer.print();
+
+#ifdef ADAMANTINE_WITH_ADIAK
+  adiak::fini();
+#endif
 
   return 0;
 }

--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -44,6 +44,9 @@ void output_pvtu(
         &solution,
     std::vector<adamantine::Timer> &timers)
 {
+#ifdef ADAMANTINE_WITH_CALIPER
+  CALI_CXX_MARK_FUNCTION;
+#endif
   timers[adamantine::output].start();
   affine_constraints.distribute(solution);
   post_processor.output_pvtu(cycle, n_time_step, time, solution);
@@ -63,6 +66,9 @@ void output_pvtu(
         &solution,
     std::vector<adamantine::Timer> &timers)
 {
+#ifdef ADAMANTINE_WITH_CALIPER
+  CALI_CXX_MARK_FUNCTION;
+#endif
   timers[adamantine::output].start();
   dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host>
       solution_host(solution.get_partitioner());
@@ -456,6 +462,9 @@ void refine_mesh(
     unsigned int const time_steps_refinement,
     boost::property_tree::ptree const &refinement_database)
 {
+#ifdef ADAMANTINE_WITH_CALIPER
+  CALI_CXX_MARK_FUNCTION;
+#endif
   dealii::DoFHandler<dim> &dof_handler = thermal_physics->get_dof_handler();
   // Use the Kelly error estimator to refine the mesh. This is done so that the
   // part of the domain that were heated stay refined.

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -19,6 +19,9 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
       lcov \
       zlib1g-dev \
       libopenblas-dev \
+      libdw-dev \
+      libpfm4-dev \
+      libunwind-dev \
       && \
       apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -35,10 +38,9 @@ RUN mkdir -p ${PREFIX} && \
     mkdir build
 
 # Install CMake
-RUN export CMAKE_VERSION=3.18.3 && \
-    export CMAKE_VERSION_SHORT=3.18 && \
-    export CMAKE_SHA256=eb23bac95873cc0bc3946eed5d1aea6876ac03f7c0dcc6ad3a05462354b08228 && \
-    export CMAKE_URL=https://cmake.org/files/v${CMAKE_VERSION_SHORT}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz && \
+RUN export CMAKE_VERSION=3.21.0 && \
+    export CMAKE_SHA256=d54ef6909f519740bc85cec07ff54574cd1e061f9f17357d9ace69f61c6291ce && \
+    export CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz && \
     export CMAKE_ARCHIVE=${ARCHIVE_DIR}/cmake.tar.gz && \
     export CMAKE_BUILD_DIR=${BUILD_DIR}/cmake && \
     wget --quiet ${CMAKE_URL} --output-document=${CMAKE_ARCHIVE} && \
@@ -51,9 +53,9 @@ RUN export CMAKE_VERSION=3.18.3 && \
 ENV PATH=${INSTALL_DIR}/cmake/bin:$PATH
 
 # Install OpenMPI
-RUN export OPENMPI_VERSION=4.0.5 && \
-    export OPENMPI_VERSION_SHORT=4.0 && \
-    export OPENMPI_SHA256=c58f3863b61d944231077f344fe6b4b8fbb83f3d1bc93ab74640bf3e5acac009 && \
+RUN export OPENMPI_VERSION=4.1.1 && \
+    export OPENMPI_VERSION_SHORT=4.1 && \
+    export OPENMPI_SHA256=e24f7a778bd11a71ad0c14587a7f5b00e68a71aa5623e2157bafee3d44c07cda && \
     export OPENMPI_URL=https://www.open-mpi.org/software/ompi/v${OPENMPI_VERSION_SHORT}/downloads/openmpi-${OPENMPI_VERSION}.tar.bz2 && \
     export OPENMPI_ARCHIVE=${ARCHIVE_DIR}/openmpi-${OPENMPI_VERSION}.tar.bz2 && \
     export OPENMPI_SOURCE_DIR=${SOURCE_DIR}/openmpi && \
@@ -77,10 +79,10 @@ ENV OMPI_MCA_btl_base_warn_component_unused='0'
 ENV PATH=${INSTALL_DIR}/openmpi/bin:$PATH
 
 # Install Boost
-RUN export BOOST_VERSION=1.73.0 && \
-    export BOOST_VERSION_U=1_73_0 && \
-    export BOOST_URL=https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_U}.tar.bz2 && \
-    export BOOST_SHA256=4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402 && \
+RUN export BOOST_VERSION=1.76.0 && \
+    export BOOST_VERSION_U=1_76_0 && \
+    export BOOST_URL=https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_U}.tar.bz2 && \
+    export BOOST_SHA256=f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41 && \
     export BOOST_ARCHIVE=${ARCHIVE_DIR}/boost_${BOOST_VERSION_U}.tar.bz2 && \
     export BOOST_SOURCE_DIR=${SOURCE_DIR}/boost && \
     export BOOST_BUILD_DIR=${BUILD_DIR}/boost && \
@@ -107,7 +109,7 @@ RUN export BOOST_VERSION=1.73.0 && \
 ENV BOOST_ROOT=${INSTALL_DIR}/boost
 
 # Install p4est
-RUN export P4EST_VERSION=2.2 && \
+RUN export P4EST_VERSION=2.3.2 && \
     export P4EST_URL=http://p4est.github.io/release/p4est-${P4EST_VERSION}.tar.gz && \
     export P4EST_ARCHIVE=${ARCHIVE_DIR}/p4est-${P4EST_VERSION}.tar.gz && \
     export P4EST_SOURCE_DIR=${SOURCE_DIR}/p4est && \
@@ -116,7 +118,7 @@ RUN export P4EST_VERSION=2.2 && \
     wget --quiet ${P4EST_URL} --output-document=${P4EST_ARCHIVE} && \
     mkdir -p ${P4EST_SOURCE_DIR} && \
     cd ${P4EST_SOURCE_DIR} && \
-    wget --quiet https://www.dealii.org/9.0.0/external-libs/p4est-setup.sh && \
+    wget --quiet https://raw.githubusercontent.com/dealii/dealii/master/doc/external-libs/p4est-setup.sh && \
     bash ./p4est-setup.sh ${P4EST_ARCHIVE} ${P4EST_INSTALL_DIR} && \
     rm -rf ${P4EST_ARCHIVE} && \
     rm -rf ${P4EST_BUILD_DIR} && \
@@ -233,8 +235,58 @@ ENV P4EST_DIR=${INSTALL_DIR}/p4est
 #    rm -rf ${TRILINOS_SOURCE_DIR}
 #ENV TRILINOS_DIR=${INSTALL_DIR}/trilinos
 
+# Install Adiak
+RUN export ADIAK_VERSION=0.2.1 && \
+    export ADIAK_URL=https://github.com/LLNL/Adiak/releases/download/v${ADIAK_VERSION}/adiak-${ADIAK_VERSION}.tar.gz && \
+    export ADIAK_ARCHIVE=${ARCHIVE_DIR}/adiak-${ADIAK_VERSION}.tar.gz && \
+    export ADIAK_SOURCE_DIR=${SOURCE_DIR}/adiak && \
+    export ADIAK_BUILD_DIR=${BUILD_DIR}/adiak && \
+    export ADIAK_INSTALL_DIR=${INSTALL_DIR}/adiak && \
+    wget --quiet ${ADIAK_URL} --output-document=${ADIAK_ARCHIVE} && \
+    mkdir -p ${ADIAK_SOURCE_DIR} && \
+    tar -xf ${ADIAK_ARCHIVE} -C ${ADIAK_SOURCE_DIR} --strip-components=1 && \
+    mkdir -p ${ADIAK_BUILD_DIR} && \
+    cd ${ADIAK_BUILD_DIR} && \
+    cmake -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_INSTALL_PREFIX=${ADIAK_INSTALL_DIR} \
+        ${ADIAK_SOURCE_DIR} && \
+    make -j${N_PROCS} install && \
+    rm -rf ${ADIAK_ARCHIVE} && \
+    rm -rf ${ADIAK_BUILD_DIR} && \
+    rm -rf ${ADIAK_SOURCE_DIR}
+ENV ADIAK_DIR=${INSTALL_DIR}/adiak
+
+# Install Caliper
+RUN export CALIPER_HASH=69c5456afed8d02668e3eebbf056714bb1c6d422 && \
+    export CALIPER_URL=https://github.com/LLNL/caliper/archive/${CALIPER_HASH}.tar.gz && \
+    export CALIPER_ARCHIVE=${CALIPER_DIR}/caliper-${CALIPER_VERSION}.tar.gz && \
+    export CALIPER_SOURCE_DIR=${SOURCE_DIR}/caliper && \
+    export CALIPER_BUILD_DIR=${BUILD_DIR}/caliper && \
+    export CALIPER_INSTALL_DIR=${INSTALL_DIR}/caliper && \
+    wget --quiet ${CALIPER_URL} --output-document=${CALIPER_ARCHIVE} && \
+    mkdir -p ${CALIPER_SOURCE_DIR} && \
+    tar -xf ${CALIPER_ARCHIVE} -C ${CALIPER_SOURCE_DIR} --strip-components=1 && \
+    mkdir -p ${CALIPER_BUILD_DIR} && \
+    cd ${CALIPER_BUILD_DIR} && \
+    cmake -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=ON \
+        -DWITH_ADIAK=ON \
+        -DWITH_LIBDW=ON \
+        -DWITH_LIBPFM=ON \
+        -DWITH_LIBUNWIND=ON \
+        -DWITH_MPI=ON \
+        -DWITH_SAMPLER=ON \
+        -DCMAKE_INSTALL_PREFIX=${CALIPER_INSTALL_DIR} \
+        ${CALIPER_SOURCE_DIR} && \
+    make -j${N_PROCS} install && \
+    rm -rf ${CALIPER_ARCHIVE} && \
+    rm -rf ${CALIPER_BUILD_DIR} && \
+    rm -rf ${CALIPER_SOURCE_DIR}
+ENV CALIPER_DIR=${INSTALL_DIR}/caliper
+
 # Install Kokkos
-RUN export KOKKOS_VERSION=3.3.01 && \
+RUN export KOKKOS_VERSION=3.4.01 && \
     export KOKKOS_URL=https://github.com/kokkos/kokkos/archive/${KOKKOS_VERSION}.tar.gz && \
     export KOKKOS_ARCHIVE=${ARCHIVE_DIR}/kokkos-${KOKKOS_VERSION}.tar.gz && \
     export KOKKOS_SOURCE_DIR=${SOURCE_DIR}/kokkos && \
@@ -279,8 +331,8 @@ RUN export ARBORX_HASH=731d3cb9c942158089cbd8c6e3ce64098bb46fb7 && \
 ENV ARBORX_DIR=${INSTALL_DIR}/arborx
 
 # Install deal.II 
-RUN export DEAL_II_HASH=9b598a48765e61f0419c42497aad1eeb03c1e4bb && \
-    export DEAL_II_URL=https://github.com/Rombur/dealii/archive/${DEAL_II_HASH}.tar.gz && \
+RUN export DEAL_II_HASH=7f0732c52157f6c373020b7b38e26d2e467be5d0 && \
+    export DEAL_II_URL=https://github.com/dealii/dealii/archive/${DEAL_II_HASH}.tar.gz && \
     export DEAL_II_ARCHIVE=${ARCHIVE_DIR}/dealii.tar.gz && \
     export DEAL_II_SOURCE_DIR=${SOURCE_DIR}/dealii && \
     export DEAL_II_BUILD_DIR=${BUILD_DIR}/dealii && \
@@ -304,6 +356,7 @@ RUN export DEAL_II_HASH=9b598a48765e61f0419c42497aad1eeb03c1e4bb && \
         -DARBORX_DIR=${ARBORX_DIR} \
         -DDEAL_II_WITH_TRILINOS=OFF \
         -DDEAL_II_TRILINOS_WITH_SEACAS=OFF \
+        -DDEAL_II_COMPONENT_EXAMPLES=OFF \
         -DCMAKE_INSTALL_PREFIX=${DEAL_II_INSTALL_DIR} \
         ${DEAL_II_SOURCE_DIR}  && \
     make -j${N_PROCS} install && \

--- a/cmake/SetupTPLs.cmake
+++ b/cmake/SetupTPLs.cmake
@@ -14,6 +14,13 @@ set(Boost_COMPONENTS
 )
 find_package(Boost 1.70.0 REQUIRED COMPONENTS ${Boost_COMPONENTS})
 
+#### Adiak ###################################################################
+if (ADAMANTINE_ENABLE_ADIAK)
+  find_package(adiak REQUIRED PATHS ${ADIAK_DIR})
+  add_compile_definitions(ADAMANTINE_WITH_ADIAK)
+  message(STATUS "Found Adiak: ${PACKAGE_PREFIX_DIR}")
+endif()
+
 #### Caliper #################################################################
 if (ADAMANTINE_ENABLE_CALIPER)
   find_package(caliper REQUIRED PATHS ${CALIPER_DIR})

--- a/source/ThermalPhysics.templates.hh
+++ b/source/ThermalPhysics.templates.hh
@@ -28,6 +28,10 @@
 #include <deal.II/lac/precondition.h>
 #include <deal.II/lac/solver_gmres.h>
 
+#ifdef ADAMANTINE_WITH_CALIPER
+#include <caliper/cali.h>
+#endif
+
 #include <algorithm>
 #include <execution>
 
@@ -575,6 +579,9 @@ void ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::
         double initial_temperature,
         dealii::LA::distributed::Vector<double, MemorySpaceType> &solution)
 {
+#ifdef ADAMANTINE_WITH_CALIPER
+  CALI_CXX_MARK_FUNCTION;
+#endif
   std::vector<dealii::Vector<double>> data_to_transfer;
   unsigned int const dofs_per_cell = _dof_handler.get_fe().n_dofs_per_cell();
   dealii::Vector<double> cell_solution(dofs_per_cell);
@@ -751,6 +758,9 @@ ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::
         dealii::LA::distributed::Vector<double, MemorySpaceType> const &y,
         std::vector<Timer> &timers) const
 {
+#ifdef ADAMANTINE_WITH_CALIPER
+  CALI_CXX_MARK_FUNCTION;
+#endif
   if constexpr (std::is_same<MemorySpaceType, dealii::MemorySpace::Host>::value)
   {
     _thermal_operator->evaluate_material_properties(y);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,8 @@ if (ADAMANTINE_ENABLE_CUDA)
   endforeach()
 endif()
 
+adamantine_COPY_INPUT_FILE(demo_316_short.info tests/data)
+adamantine_COPY_INPUT_FILE(demo_316_short_scan_path.txt tests/data)
 adamantine_COPY_INPUT_FILE(experimental_data_0_0.csv tests/data)
 adamantine_COPY_INPUT_FILE(extruded_cube.msh tests/data)
 adamantine_COPY_INPUT_FILE(integration_2d.info tests/data)

--- a/tests/data/demo_316_short.info
+++ b/tests/data/demo_316_short.info
@@ -17,6 +17,11 @@ geometry
   material_height 0.75e-3
 }
 
+boundary
+{
+  type convective,radiative
+}
+
 refinement
 {
   n_heat_refinements 0 ; Number of coarsening/refinement executed (uses Kelly's
@@ -108,7 +113,8 @@ discretization
 
 profiling
 {
-  timer true
+  timer false
+  caliper "spot(profile.mpi),loop-report,runtime-report"
 }
 
-memory_space host ; If compiled with CUDA support, run on the device
+memory_space host ; Always run on the host


### PR DESCRIPTION
This adds support for [adiak](https://github.com/LLNL/Adiak). Adiak is necessary for Caliper to write data can be read by [spot](https://github.com/LLNL/spotfe/). My plan is to monitor the performance on the host using `demo_316_short`. Once I have a better understanding of spot, I may add more test cases.