### PR TITLE
Rename MaterialProperty::get to MaterialProperty::get_cell_value when using a cell

### DIFF
--- a/source/MaterialProperty.hh
+++ b/source/MaterialProperty.hh
@@ -47,16 +47,16 @@ public:
   /**
    * Return the value of the given StateProperty for a given cell.
    */
-  double
-  get(typename dealii::Triangulation<dim>::active_cell_iterator const &cell,
+  double get_cell_value(
+      typename dealii::Triangulation<dim>::active_cell_iterator const &cell,
       StateProperty prop) const;
 
   // TODO add a function to get tensor material properties
   /**
    * Return the value of the given Property for a given cell.
    */
-  double
-  get(typename dealii::Triangulation<dim>::active_cell_iterator const &cell,
+  double get_cell_value(
+      typename dealii::Triangulation<dim>::active_cell_iterator const &cell,
       Property prop) const;
 
   /**

--- a/source/MaterialProperty.templates.hh
+++ b/source/MaterialProperty.templates.hh
@@ -43,7 +43,7 @@ MaterialProperty<dim>::MaterialProperty(
 }
 
 template <int dim>
-double MaterialProperty<dim>::get(
+double MaterialProperty<dim>::get_cell_value(
     typename dealii::Triangulation<dim>::active_cell_iterator const &cell,
     StateProperty prop) const
 {
@@ -54,7 +54,7 @@ double MaterialProperty<dim>::get(
 }
 
 template <int dim>
-double MaterialProperty<dim>::get(
+double MaterialProperty<dim>::get_cell_value(
     typename dealii::Triangulation<dim>::active_cell_iterator const &cell,
     Property prop) const
 {

--- a/source/ThermalOperator.cc
+++ b/source/ThermalOperator.cc
@@ -189,16 +189,16 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::vmult_add(
           double rad_heat_transfer_coef = 0.;
           if (_boundary_type & BoundaryType::convective)
           {
-            conv_temperature_infty = _material_properties->get(
+            conv_temperature_infty = _material_properties->get_cell_value(
                 cell, Property::convection_temperature_infty);
-            conv_heat_transfer_coef = _material_properties->get(
+            conv_heat_transfer_coef = _material_properties->get_cell_value(
                 cell, StateProperty::convection_heat_transfer_coef);
           }
           if (_boundary_type & BoundaryType::radiative)
           {
-            rad_temperature_infty = _material_properties->get(
+            rad_temperature_infty = _material_properties->get_cell_value(
                 cell, Property::radiation_temperature_infty);
-            rad_heat_transfer_coef = _material_properties->get(
+            rad_heat_transfer_coef = _material_properties->get_cell_value(
                 cell, StateProperty::radiation_heat_transfer_coef);
           }
 

--- a/source/ThermalOperatorDevice.cu
+++ b/source/ThermalOperatorDevice.cu
@@ -294,11 +294,13 @@ void ThermalOperatorDevice<dim, fe_degree, MemorySpaceType>::
     {
       auto cell = graph[color][cell_id];
       double const cell_inv_rho_cp =
-          1. / (_material_properties->get(cell, StateProperty::density) *
-                _material_properties->get(cell, StateProperty::specific_heat));
+          1. /
+          (_material_properties->get_cell_value(cell, StateProperty::density) *
+           _material_properties->get_cell_value(cell,
+                                                StateProperty::specific_heat));
       _inv_rho_cp_cells[cell] = cell_inv_rho_cp;
-      double const cell_th_conductivity =
-          _material_properties->get(cell, StateProperty::thermal_conductivity);
+      double const cell_th_conductivity = _material_properties->get_cell_value(
+          cell, StateProperty::thermal_conductivity);
       for (unsigned int i = 0; i < n_q_points_per_cell; ++i)
       {
         unsigned int const pos =

--- a/source/ThermalPhysics.templates.hh
+++ b/source/ThermalPhysics.templates.hh
@@ -206,16 +206,16 @@ evaluate_thermal_physics_impl(
           double rad_heat_transfer_coef = 0.;
           if (boundary_type & BoundaryType::convective)
           {
-            conv_temperature_infty = material_properties->get(
+            conv_temperature_infty = material_properties->get_cell_value(
                 cell, Property::convection_temperature_infty);
-            conv_heat_transfer_coef = material_properties->get(
+            conv_heat_transfer_coef = material_properties->get_cell_value(
                 cell, StateProperty::convection_heat_transfer_coef);
           }
           if (boundary_type & BoundaryType::radiative)
           {
-            rad_temperature_infty = material_properties->get(
+            rad_temperature_infty = material_properties->get_cell_value(
                 cell, Property::radiation_temperature_infty);
-            rad_heat_transfer_coef = material_properties->get(
+            rad_heat_transfer_coef = material_properties->get_cell_value(
                 cell, StateProperty::radiation_heat_transfer_coef);
           }
 

--- a/tests/test_material_property.cc
+++ b/tests/test_material_property.cc
@@ -62,12 +62,13 @@ BOOST_AUTO_TEST_CASE(material_property)
   for (auto cell : triangulation.active_cell_iterators())
   {
     double const density =
-        mat_prop.get(cell, adamantine::StateProperty::density);
+        mat_prop.get_cell_value(cell, adamantine::StateProperty::density);
     BOOST_CHECK(density == 1.);
-    double const th_conduc =
-        mat_prop.get(cell, adamantine::StateProperty::thermal_conductivity);
+    double const th_conduc = mat_prop.get_cell_value(
+        cell, adamantine::StateProperty::thermal_conductivity);
     BOOST_CHECK(th_conduc == 10.);
-    double const liquidus = mat_prop.get(cell, adamantine::Property::liquidus);
+    double const liquidus =
+        mat_prop.get_cell_value(cell, adamantine::Property::liquidus);
     BOOST_CHECK(liquidus == 100.);
   }
 }
@@ -131,20 +132,22 @@ BOOST_AUTO_TEST_CASE(ratios)
     BOOST_CHECK(liquid_ratio == 0.);
 
     double const density =
-        mat_prop.get(cell, adamantine::StateProperty::density);
+        mat_prop.get_cell_value(cell, adamantine::StateProperty::density);
     BOOST_CHECK(density == 1.);
-    double const th_conduc =
-        mat_prop.get(cell, adamantine::StateProperty::thermal_conductivity);
+    double const th_conduc = mat_prop.get_cell_value(
+        cell, adamantine::StateProperty::thermal_conductivity);
     BOOST_CHECK(th_conduc == 1.);
-    double const liquidus = mat_prop.get(cell, adamantine::Property::liquidus);
+    double const liquidus =
+        mat_prop.get_cell_value(cell, adamantine::Property::liquidus);
     BOOST_CHECK(liquidus == 100.);
-    double const solidus = mat_prop.get(cell, adamantine::Property::solidus);
+    double const solidus =
+        mat_prop.get_cell_value(cell, adamantine::Property::solidus);
     BOOST_CHECK(solidus == 50.);
     double const latent_heat =
-        mat_prop.get(cell, adamantine::Property::latent_heat);
+        mat_prop.get_cell_value(cell, adamantine::Property::latent_heat);
     BOOST_CHECK(latent_heat == 1000.);
     double const specific_heat =
-        mat_prop.get(cell, adamantine::StateProperty::specific_heat);
+        mat_prop.get_cell_value(cell, adamantine::StateProperty::specific_heat);
     BOOST_CHECK(specific_heat == 1.);
   }
 
@@ -167,20 +170,22 @@ BOOST_AUTO_TEST_CASE(ratios)
     BOOST_CHECK(liquid_ratio == 1.);
 
     double const density =
-        mat_prop.get(cell, adamantine::StateProperty::density);
+        mat_prop.get_cell_value(cell, adamantine::StateProperty::density);
     BOOST_CHECK(density == 1.);
-    double const th_conduc =
-        mat_prop.get(cell, adamantine::StateProperty::thermal_conductivity);
+    double const th_conduc = mat_prop.get_cell_value(
+        cell, adamantine::StateProperty::thermal_conductivity);
     BOOST_CHECK(th_conduc == 20.);
-    double const liquidus = mat_prop.get(cell, adamantine::Property::liquidus);
+    double const liquidus =
+        mat_prop.get_cell_value(cell, adamantine::Property::liquidus);
     BOOST_CHECK(liquidus == 100.);
-    double const solidus = mat_prop.get(cell, adamantine::Property::solidus);
+    double const solidus =
+        mat_prop.get_cell_value(cell, adamantine::Property::solidus);
     BOOST_CHECK(solidus == 50.);
     double const latent_heat =
-        mat_prop.get(cell, adamantine::Property::latent_heat);
+        mat_prop.get_cell_value(cell, adamantine::Property::latent_heat);
     BOOST_CHECK(latent_heat == 1000.);
     double const specific_heat =
-        mat_prop.get(cell, adamantine::StateProperty::specific_heat);
+        mat_prop.get_cell_value(cell, adamantine::StateProperty::specific_heat);
     BOOST_CHECK(specific_heat == 20.);
   }
 
@@ -200,20 +205,22 @@ BOOST_AUTO_TEST_CASE(ratios)
     BOOST_CHECK(liquid_ratio == 0.);
 
     double const density =
-        mat_prop.get(cell, adamantine::StateProperty::density);
+        mat_prop.get_cell_value(cell, adamantine::StateProperty::density);
     BOOST_CHECK(density == 10.);
-    double const th_conduc =
-        mat_prop.get(cell, adamantine::StateProperty::thermal_conductivity);
+    double const th_conduc = mat_prop.get_cell_value(
+        cell, adamantine::StateProperty::thermal_conductivity);
     BOOST_CHECK(th_conduc == 10.);
-    double const liquidus = mat_prop.get(cell, adamantine::Property::liquidus);
+    double const liquidus =
+        mat_prop.get_cell_value(cell, adamantine::Property::liquidus);
     BOOST_CHECK(liquidus == 100.);
-    double const solidus = mat_prop.get(cell, adamantine::Property::solidus);
+    double const solidus =
+        mat_prop.get_cell_value(cell, adamantine::Property::solidus);
     BOOST_CHECK(solidus == 50.);
     double const latent_heat =
-        mat_prop.get(cell, adamantine::Property::latent_heat);
+        mat_prop.get_cell_value(cell, adamantine::Property::latent_heat);
     BOOST_CHECK(latent_heat == 1000.);
     double const specific_heat =
-        mat_prop.get(cell, adamantine::StateProperty::specific_heat);
+        mat_prop.get_cell_value(cell, adamantine::StateProperty::specific_heat);
     BOOST_CHECK(specific_heat == 10.);
   }
 }
@@ -278,26 +285,32 @@ BOOST_AUTO_TEST_CASE(material_property_table)
   {
     if (n < 10)
     {
-      BOOST_CHECK_CLOSE(mat_prop.get(cell, adamantine::StateProperty::density),
-                        1., tolerance);
       BOOST_CHECK_CLOSE(
-          mat_prop.get(cell, adamantine::StateProperty::thermal_conductivity),
+          mat_prop.get_cell_value(cell, adamantine::StateProperty::density), 1.,
+          tolerance);
+      BOOST_CHECK_CLOSE(
+          mat_prop.get_cell_value(
+              cell, adamantine::StateProperty::thermal_conductivity),
           100., tolerance);
     }
     else if (n < 15)
     {
-      BOOST_CHECK_CLOSE(mat_prop.get(cell, adamantine::StateProperty::density),
-                        1.75, tolerance);
       BOOST_CHECK_CLOSE(
-          mat_prop.get(cell, adamantine::StateProperty::thermal_conductivity),
+          mat_prop.get_cell_value(cell, adamantine::StateProperty::density),
+          1.75, tolerance);
+      BOOST_CHECK_CLOSE(
+          mat_prop.get_cell_value(
+              cell, adamantine::StateProperty::thermal_conductivity),
           150., tolerance);
     }
     else
     {
-      BOOST_CHECK_CLOSE(mat_prop.get(cell, adamantine::StateProperty::density),
-                        2., tolerance);
       BOOST_CHECK_CLOSE(
-          mat_prop.get(cell, adamantine::StateProperty::thermal_conductivity),
+          mat_prop.get_cell_value(cell, adamantine::StateProperty::density), 2.,
+          tolerance);
+      BOOST_CHECK_CLOSE(
+          mat_prop.get_cell_value(
+              cell, adamantine::StateProperty::thermal_conductivity),
           162.5, tolerance);
     }
     ++n;
@@ -362,26 +375,32 @@ BOOST_AUTO_TEST_CASE(material_property_polynomials)
   {
     if (n < 10)
     {
-      BOOST_CHECK_CLOSE(mat_prop.get(cell, adamantine::StateProperty::density),
-                        15., tolerance);
       BOOST_CHECK_CLOSE(
-          mat_prop.get(cell, adamantine::StateProperty::thermal_conductivity),
+          mat_prop.get_cell_value(cell, adamantine::StateProperty::density),
+          15., tolerance);
+      BOOST_CHECK_CLOSE(
+          mat_prop.get_cell_value(
+              cell, adamantine::StateProperty::thermal_conductivity),
           465., tolerance);
     }
     else if (n < 15)
     {
-      BOOST_CHECK_CLOSE(mat_prop.get(cell, adamantine::StateProperty::density),
-                        706., tolerance);
       BOOST_CHECK_CLOSE(
-          mat_prop.get(cell, adamantine::StateProperty::thermal_conductivity),
+          mat_prop.get_cell_value(cell, adamantine::StateProperty::density),
+          706., tolerance);
+      BOOST_CHECK_CLOSE(
+          mat_prop.get_cell_value(
+              cell, adamantine::StateProperty::thermal_conductivity),
           681001., tolerance);
     }
     else
     {
-      BOOST_CHECK_CLOSE(mat_prop.get(cell, adamantine::StateProperty::density),
-                        720., tolerance);
       BOOST_CHECK_CLOSE(
-          mat_prop.get(cell, adamantine::StateProperty::thermal_conductivity),
+          mat_prop.get_cell_value(cell, adamantine::StateProperty::density),
+          720., tolerance);
+      BOOST_CHECK_CLOSE(
+          mat_prop.get_cell_value(
+              cell, adamantine::StateProperty::thermal_conductivity),
           45280., tolerance);
     }
     ++n;


### PR DESCRIPTION
 Fixes #110 