### PR TITLE
Only use parallel std library when using GLIBCXX

### DIFF
--- a/source/DataAssimilator.cc
+++ b/source/DataAssimilator.cc
@@ -10,7 +10,10 @@
 #include <deal.II/dofs/dof_tools.h>
 #include <deal.II/lac/linear_operator_tools.h>
 
+// libc++ does not support parallel std library
+#ifdef __GLIBCXX__
 #include <execution>
+#endif
 
 namespace adamantine
 {
@@ -114,9 +117,12 @@ DataAssimilator::apply_kalman_gain(
   // Apply the Kalman gain to the perturbed innovation for the ensemble members
   // in parallel
   std::transform(
-      std::execution::par, perturbed_innovation.begin(),
-      perturbed_innovation.end(), output.begin(),
-      [&](dealii::Vector<double> entry) {
+#ifdef __GLIBCXX__
+      std::execution::par,
+#endif
+      perturbed_innovation.begin(), perturbed_innovation.end(), output.begin(),
+      [&](dealii::Vector<double> entry)
+      {
         dealii::SolverGMRES<dealii::Vector<double>> HPH_plus_R_inv_solver(
             solver_control, additional_data);
 

--- a/source/ThermalPhysics.templates.hh
+++ b/source/ThermalPhysics.templates.hh
@@ -33,7 +33,10 @@
 #endif
 
 #include <algorithm>
+// libc++ does not support parallel std library
+#ifdef __GLIBCXX__
 #include <execution>
+#endif
 
 namespace adamantine
 {
@@ -655,13 +658,18 @@ void ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::
   // associated to the fine cell. The final value is decided by
   // AffineConstraints. Thus, we need to make sure that the newly activated
   // cells are at the same level than their neighbors.
-  std::for_each(std::execution::par_unseq, solution.begin(), solution.end(),
-                [&](double &val) {
-                  if (val == std::numeric_limits<double>::infinity())
-                  {
-                    val = new_material_temperature;
-                  }
-                });
+  std::for_each(
+#ifdef __GLIBCXX__
+      std::execution::par,
+#endif
+      solution.begin(), solution.end(),
+      [&](double &val)
+      {
+        if (val == std::numeric_limits<double>::infinity())
+        {
+          val = new_material_temperature;
+        }
+      });
 }
 
 template <int dim, int fe_degree, typename MemorySpaceType,

--- a/tests/test_ensemble_management.cc
+++ b/tests/test_ensemble_management.cc
@@ -9,7 +9,10 @@
 
 #include <deal.II/base/mpi.h>
 
+// libc++ does not support parallel std library
+#ifdef __GLIBCXX__
 #include <execution>
+#endif
 #include <numeric>
 
 #define BOOST_TEST_MODULE EnsembleManagement
@@ -35,9 +38,12 @@ BOOST_AUTO_TEST_CASE(fill_and_sync_random_vector)
   BOOST_CHECK(vec.size() == ensemble_size);
 
   // Check vector mean
-  double mean_check =
-      std::reduce(std::execution::par, vec.cbegin(), vec.cend()) /
-      ensemble_size;
+  double mean_check = std::reduce(
+#ifdef __GLIBCXX__
+                          std::execution::par,
+#endif
+                          vec.cbegin(), vec.cend()) /
+                      ensemble_size;
 
   BOOST_CHECK_CLOSE(mean, mean_check, tolerance);
 


### PR DESCRIPTION
`libc++` does not support parallel std library. This guards the use of parallel std library, so that we only use it with `libstdc++`. The other solution is to just not use the parallel std. I don't have a strong opinion either way. I think it is nice to use it by the macros make the code ugly and we probably don't gain much by using this.