### PR TITLE
Small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ The following options are available:
 #### Segment format
 After the self-explainatory tree-line header, the column descriptions are:
 * Column 1: mode 0 for line mode, mode 1 for spot mode
-* Columns 2 to 4: (x,y,z) coordinates in units of mm. For line mode, this
+* Columns 2 to 4: (x,y,z) coordinates in units of m. For line mode, this
 is the ending position of the the line.
 * Column 5: the coefficient for the nominal power. Usually this is either
 0 or 1, but sometimes intermediate values are used when turning a corner.
@@ -209,7 +209,7 @@ and instead choose some small positive number.
 For an event series the first segment is a point, then the rest are lines.
 The column descriptions are:
 * Column 1: segment endtime
-* Columns 2 to 4: (x,y,z) coordinates in units of mm. This is the ending
+* Columns 2 to 4: (x,y,z) coordinates in units of m. This is the ending
 position of the line.
 * Column 5: the coefficient for the nominal power. Usually this is either
 0 or 1, but sometimes intermediate values are used when turning a corner.

--- a/source/ScanPath.cc
+++ b/source/ScanPath.cc
@@ -123,7 +123,7 @@ void ScanPath::load_event_series_scan_path(std::string scan_path_file)
     ScanPathSegment segment;
 
     std::vector<std::string> split_line;
-    boost::split(split_line, line, boost::is_any_of(" "),
+    boost::split(split_line, line, boost::is_any_of(" ,,"),
                  boost::token_compress_on);
 
     // Set the segment end time

--- a/source/ScanPath.hh
+++ b/source/ScanPath.hh
@@ -43,7 +43,7 @@ struct ScanPathSegment
 {
   double end_time;            // Unit: seconds
   double power_modifier;      // Dimensionless
-  dealii::Point<3> end_point; // Unit: m (NOTE: converted from mm in the file)
+  dealii::Point<3> end_point; // Unit: m
 };
 
 /**

--- a/tests/data/demo_316_short_scan_path.txt
+++ b/tests/data/demo_316_short_scan_path.txt
@@ -1,5 +1,5 @@
 Number of path segments
-4
+3
 Mode    x       y     z   pmod    param
 1       2.1e-3   2.1e-3  0.75e-3   0       1e-6
 0       2.1e-3   4.1e-3  0.75e-3   1       1.0

--- a/tests/data/scan_path_layers.txt
+++ b/tests/data/scan_path_layers.txt
@@ -1,5 +1,5 @@
 Number of path segments
-2
+4
 Mode    x       y     z   pmod    param
 1       0.000   0.000  0   0       1e-6
 0       0.002   0.000  0   1       0.8


### PR DESCRIPTION
- Fix the READMS
- Fix scan path input files
- Read number of segments of the scan path (this easier to read if you use `Hide Widespace`). We know stop reading the file when the file ends or we reached the maximum number of segments to read, whichever comes first.
- Support `csv` format for event scan path