### PR TITLE
Merge multiple deposition paths

### DIFF
--- a/source/material_deposition.hh
+++ b/source/material_deposition.hh
@@ -54,10 +54,9 @@ template <int dim>
 std::tuple<std::vector<dealii::BoundingBox<dim>>, std::vector<double>,
            std::vector<double>, std::vector<double>>
 merge_deposition_paths(
-    std::vector<
-        std::tuple<std::vector<dealii::BoundingBox<dim>>, std::vector<double>,
-                   std::vector<double>, std::vector<double>>>
-        bounding_box_lists);
+    std::vector<std::tuple<std::vector<dealii::BoundingBox<dim>>,
+                           std::vector<double>, std::vector<double>,
+                           std::vector<double>>> const &bounding_box_lists);
 /**
  * Return a vector of cells to activate for each time deposition.
  */

--- a/tests/test_material_property.hh
+++ b/tests/test_material_property.hh
@@ -301,7 +301,7 @@ void material_property_table()
       temperature(dof_handler.locally_owned_dofs(), communicator);
   dealii::LA::ReadWriteVector<double> rw_vector(
       dof_handler.locally_owned_dofs());
-  for (unsigned int i = 0; i < rw_vector.n_elements(); ++i)
+  for (unsigned int i = 0; i < rw_vector.locally_owned_size(); ++i)
     rw_vector.local_element(i) = 15;
   temperature.import(rw_vector, dealii::VectorOperation::insert);
   mat_prop.update(dof_handler, temperature);


### PR DESCRIPTION
This merges multiple deposition paths into a single one. We had that for quite a while but it was actually quite simple to implement: we split the deposition into bounding boxes, sort the bounding boxes by the time of depositions, and finally reassemble the vector.