### PR TITLE
Disable multithreading in Docker image and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ mpirun -n 2 ./adamantine --input-file=input.info
 Note that the name of the input file is totally arbitrary, `my_input_file` is as
 valid as `input.info`.
 
+There is a [known bug](https://github.com/adamantine-sim/adamantine/issues/130)
+when using multithreading. To deactivate multithreading use
+```bash
+export DEAL_II_NUM_THREADS=1
+```
+If you use our Docker image, the variable is already set.
+
 ### Input file
 The following options are available:
 * boundary:

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -364,3 +364,6 @@ RUN export DEAL_II_HASH=d3aed38b935ff22bd0d33a5aa47ba014ebce3812 && \
     rm -rf ${DEAL_II_BUILD_DIR} && \
     rm -rf ${DEAL_II_SOURCE_DIR}
 ENV DEAL_II_DIR=${INSTALL_DIR}/dealii
+
+# There is a bug when using multithreading. Disabling it for now.
+ENV DEAL_II_NUM_THREADS=1

--- a/source/ensemble_management.cc
+++ b/source/ensemble_management.cc
@@ -18,8 +18,7 @@ std::vector<double> fill_and_sync_random_vector(unsigned int length,
 
   if (rank == 0)
   {
-    std::random_device dev;
-    std::mt19937 pseudorandom_number_generator(dev());
+    std::mt19937 pseudorandom_number_generator;
     std::normal_distribution<> normal_dist_generator(0.0, 1.0);
 
     for (unsigned int member = 0; member < length; ++member)


### PR DESCRIPTION
I was trying to add a new test case but I hit the multithreading bug https://github.com/adamantine-sim/adamantine/issues/130 This PR updates the Docker image and the README