### PR TITLE
No full matrices in DataAssimilator for the random number fill for diagonal R

### DIFF
--- a/source/DataAssimilator.cc
+++ b/source/DataAssimilator.cc
@@ -61,11 +61,7 @@ void DataAssimilator::update_ensemble(
 
   // Check if R is diagonal, needed for filling the noise vector
   auto bandwidth = R.get_sparsity_pattern().bandwidth();
-  bool R_is_diagonal = false;
-  if (bandwidth == 0)
-  {
-    R_is_diagonal = true;
-  }
+  bool const R_is_diagonal = bandwidth == 0 ? true : false;
 
   // Get the perturbed innovation, ( y+u - Hx )
   if (rank == 0)

--- a/source/DataAssimilator.hh
+++ b/source/DataAssimilator.hh
@@ -102,10 +102,12 @@ private:
 
   /**
    * This fills a vector (vec) with noise from a multivariate normal
-   * distribution defined by a covariance matrix (R).
+   * distribution defined by a covariance matrix (R). Note: For non-diagonal R
+   * this method currently uses full matrices, which substantially limits the
+   * allowable problem size.
    */
   void fill_noise_vector(dealii::Vector<double> &vec,
-                         dealii::SparseMatrix<double> &R);
+                         dealii::SparseMatrix<double> &R, bool R_is_diagonal);
 
   /**
    * This calculates the sample covariance for an input ensemble of vectors


### PR DESCRIPTION
This removes one of the places where full matrices are used for data assimilation. The diagonal R case is the only case currently supported by the adamantine application, but we still have the non-diagonal case available as a more general fall-back.