### PR TITLE
Add missing BC inputs in the 316 demo input file

### DIFF
--- a/tests/data/demo_316_short.info
+++ b/tests/data/demo_316_short.info
@@ -49,7 +49,7 @@ materials
       thermal_conductivity_x 31.4 ; [W/m K]
       thermal_conductivity_y 31.4 ; [W/m K]
       thermal_conductivity_z 31.4 ; [W/m K]
-
+      convection_heat_transfer_coef 100 ; [W/(m^2*K)]
     }
 
     powder
@@ -59,21 +59,25 @@ materials
       thermal_conductivity_x 0.314 ; [W/m K]
       thermal_conductivity_y 0.314 ; [W/m K]
       thermal_conductivity_z 0.314 ; [W/m K]
+      convection_heat_transfer_coef 100 ; [W/(m^2*K)]
     }
 
     liquid
     {
       specific_heat 847; [J/kg K]
       density 7904; [kg/m^3]
-      thermal_conductivity_x 37.3 ; [W/m k] 
-      thermal_conductivity_y 37.3 ; [W/m k] 
-      thermal_conductivity_z 37.3 ; [W/m k] 
+      thermal_conductivity_x 37.3 ; [W/m k]
+      thermal_conductivity_y 37.3 ; [W/m k]
+      thermal_conductivity_z 37.3 ; [W/m k]
+      convection_heat_transfer_coef 100 ; [W/(m^2*K)]
       ; Not all three states need to define the same properties or to exist
     }
 
     solidus 1675; [K]
     liquidus 1708; [K]
     latent_heat 290000 ; [J/kg]
+    radiation_temperature_infty 300 ; [K]
+    convection_temperature_infty 300 ; [K]
   }
 }
 


### PR DESCRIPTION
The `demo_316_short.info` input file was missing the entries necessary for convective and radiative BCs and therefore the calculation went to all NANs.

Currently we don't have any notification if the user selects convective or radiative BCs but doesn't give the expected input parameters for those BC models. Part of this is how things are currently split up -- ThermalOperator handles the BCs but doesn't have access to the input material database and MaterialProperty handles the material properties but doesn't have access to the BC type. One option would be to have a check in ThermalPhysics to see if things are appropriately defined (ThermalPhysics currently gets the whole input database). Another option would be to have something in MaterialProperty that tracks what is defined and what isn't, and then ThermalOperator can check to see if the appropriate parameters are defined based on the BC choice. @Rombur, do you have a preference on how to handle this?