### PR TITLE
AMR fixes for ensemble calculations

### DIFF
--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -506,22 +506,19 @@ compute_cells_to_refine(
                triangulation.active_cell_iterators(),
                dealii::IteratorFilters::LocallyOwnedCell()))
       {
-        // Check the value at the center of the cell faces and cell center.
-        // Checking both is helpful when starting with a coarse mesh when the
-        // radius of the beam is smaller than the element size.
-        bool refine = false;
+        // Check the value at the center of the cell faces. For most cases this
+        // should be sufficient, but if the beam is small compared to the
+        // coarsest mesh we may need to add other points to check (e.g.
+        // quadrature points, vertices).
         for (unsigned int f = 0; f < cell->reference_cell().n_faces(); ++f)
         {
           if (beam->value(cell->face(f)->center(), current_time,
                           current_source_height) > refinement_beam_cutoff)
-            refine = true;
+          {
+            cells_to_refine.push_back(cell);
+            break;
+          }
         }
-        if (beam->value(cell->center(), current_time, current_source_height) >
-            refinement_beam_cutoff)
-          refine = true;
-
-        if (refine)
-          cells_to_refine.push_back(cell);
       }
     }
   }

--- a/source/ThermalOperator.cc
+++ b/source/ThermalOperator.cc
@@ -96,14 +96,17 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::
       }
     }
     cell->get_dof_indices(local_dof_indices);
+
     affine_constraints.distribute_local_to_global(cell_mass, local_dof_indices,
                                                   *_inverse_mass_matrix);
   }
   _inverse_mass_matrix->compress(dealii::VectorOperation::add);
 
   unsigned int const local_size = _inverse_mass_matrix->locally_owned_size();
+
   for (unsigned int k = 0; k < local_size; ++k)
   {
+
     _inverse_mass_matrix->local_element(k) =
         1. / _inverse_mass_matrix->local_element(k);
   }
@@ -142,6 +145,7 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::vmult_add(
 {
   // Execute the matrix-free matrix-vector multiplication
   _matrix_free.cell_loop(&ThermalOperator::cell_local_apply, this, dst, src);
+
   // We compute the boundary conditions by hand. We would like to use
   // dealii::MatrixFree::loop() but there are two problems: 1. the function does
   // not work with FE_Nothing 2. even if it did we could only use it for the

--- a/source/ThermalOperator.cc
+++ b/source/ThermalOperator.cc
@@ -96,17 +96,14 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::
       }
     }
     cell->get_dof_indices(local_dof_indices);
-
     affine_constraints.distribute_local_to_global(cell_mass, local_dof_indices,
                                                   *_inverse_mass_matrix);
   }
   _inverse_mass_matrix->compress(dealii::VectorOperation::add);
 
   unsigned int const local_size = _inverse_mass_matrix->locally_owned_size();
-
   for (unsigned int k = 0; k < local_size; ++k)
   {
-
     _inverse_mass_matrix->local_element(k) =
         1. / _inverse_mass_matrix->local_element(k);
   }

--- a/tests/data/bare_plate_L_da.info
+++ b/tests/data/bare_plate_L_da.info
@@ -35,9 +35,9 @@ geometry
   length 5.0e-3 ; [m]
   height 0.5e-3 ; [m] In 3D, the third parameters is width
   width  5.0e-3
-  length_divisions 8 ; Number of cell layers in the length direction
+  length_divisions 4 ; Number of cell layers in the length direction
   height_divisions 1 ; Number of cell layers in the height direction
-  width_divisions  8
+  width_divisions  4
 }
 
 boundary
@@ -50,10 +50,10 @@ refinement
   n_heat_refinements 0 ; Number of coarsening/refinement executed (uses Kelly's
                        ; error estimator)
   heat_cell_ratio    2.0 ;
-  n_beam_refinements 0 ; Number of time the cells on the paths of the beams are
+  n_beam_refinements 1 ; Number of time the cells on the paths of the beams are
                        ; refined
-  max_level          0 ; Maximum number of time a cell can be refined
-  time_steps_between_refinement 2000000000 ; number of time steps after which
+  max_level          1 ; Maximum number of time a cell can be refined
+  time_steps_between_refinement 250 ; number of time steps after which
                                                  ; the refinement process is performed
 }
 


### PR DESCRIPTION
This PR makes several changes to ensemble calculations, mostly relating to AMR:
- It resizes the blocks appropriately for the solution vector when the number of DOFs change
- It removes the copy of the constraints in `run_ensemble`, changing to direct access from `ThermalPhysics` to prevent the constraints from being out of sync
- It applies the constraints before data assimilation
- For AMR generally, it changes how the beam intensity is checked, adding checks at face centers
- For augmented state data assimilation, it prints out the augmented parameters before and after each data assimilation operation
- AMR is added to the data assimilation integration test