### PR TITLE
Replace BOOST_CHECK with BOOST_TEST

### DIFF
--- a/tests/test_data_assimilator.cc
+++ b/tests/test_data_assimilator.cc
@@ -15,6 +15,8 @@
 
 #include "main.cc"
 
+namespace tt = boost::test_tools;
+
 namespace adamantine
 {
 class DataAssimilatorTester
@@ -28,18 +30,20 @@ public:
     DataAssimilator da0(database);
 
     double tol = 1.0e-12;
-    BOOST_CHECK_SMALL(da0._solver_control.tolerance() - 1.0e-10, tol);
-    BOOST_CHECK(da0._solver_control.max_steps() == 100);
-    BOOST_CHECK(da0._additional_data.max_n_tmp_vectors == 30);
+    BOOST_TEST(da0._solver_control.tolerance() - 1.0e-10 == 0.,
+               tt::tolerance(tol));
+    BOOST_TEST(da0._solver_control.max_steps() == 100u);
+    BOOST_TEST(da0._additional_data.max_n_tmp_vectors == 30u);
 
     // Now explicitly setting them
     database.put("solver.convergence_tolerance", 1.0e-6);
     database.put("solver.max_iterations", 25);
     database.put("solver.max_number_of_temp_vectors", 4);
     DataAssimilator da1(database);
-    BOOST_CHECK_SMALL(da1._solver_control.tolerance() - 1.0e-6, tol);
-    BOOST_CHECK(da1._solver_control.max_steps() == 25);
-    BOOST_CHECK(da1._additional_data.max_n_tmp_vectors == 4);
+    BOOST_TEST(da1._solver_control.tolerance() - 1.0e-6 == 0.,
+               tt::tolerance(tol));
+    BOOST_TEST(da1._solver_control.max_steps() == 25u);
+    BOOST_TEST(da1._additional_data.max_n_tmp_vectors == 4u);
   };
 
   void test_calc_kalman_gain()
@@ -150,18 +154,18 @@ public:
     double tol = 1.0e-4;
 
     // Reference solution calculated using Python
-    BOOST_CHECK_CLOSE(forecast_shift[0][0], 0.21352564, tol);
-    BOOST_CHECK_CLOSE(forecast_shift[0][1], -0.14600986, tol);
-    BOOST_CHECK_CLOSE(forecast_shift[0][2], -0.02616469, tol);
-    BOOST_CHECK_CLOSE(forecast_shift[0][3], 0.45321598, tol);
-    BOOST_CHECK_CLOSE(forecast_shift[1][0], -0.27786325, tol);
-    BOOST_CHECK_CLOSE(forecast_shift[1][1], -0.32946285, tol);
-    BOOST_CHECK_CLOSE(forecast_shift[1][2], -0.31226298, tol);
-    BOOST_CHECK_CLOSE(forecast_shift[1][3], -0.24346351, tol);
-    BOOST_CHECK_CLOSE(forecast_shift[2][0], 0.12767094, tol);
-    BOOST_CHECK_CLOSE(forecast_shift[2][1], -0.20319395, tol);
-    BOOST_CHECK_CLOSE(forecast_shift[2][2], -0.09290565, tol);
-    BOOST_CHECK_CLOSE(forecast_shift[2][3], 0.34824753, tol);
+    BOOST_TEST(forecast_shift[0][0] == 0.21352564, tt::tolerance(tol));
+    BOOST_TEST(forecast_shift[0][1] == -0.14600986, tt::tolerance(tol));
+    BOOST_TEST(forecast_shift[0][2] == -0.02616469, tt::tolerance(tol));
+    BOOST_TEST(forecast_shift[0][3] == 0.45321598, tt::tolerance(tol));
+    BOOST_TEST(forecast_shift[1][0] == -0.27786325, tt::tolerance(tol));
+    BOOST_TEST(forecast_shift[1][1] == -0.32946285, tt::tolerance(tol));
+    BOOST_TEST(forecast_shift[1][2] == -0.31226298, tt::tolerance(tol));
+    BOOST_TEST(forecast_shift[1][3] == -0.24346351, tt::tolerance(tol));
+    BOOST_TEST(forecast_shift[2][0] == 0.12767094, tt::tolerance(tol));
+    BOOST_TEST(forecast_shift[2][1] == -0.20319395, tt::tolerance(tol));
+    BOOST_TEST(forecast_shift[2][2] == -0.09290565, tt::tolerance(tol));
+    BOOST_TEST(forecast_shift[2][3] == 0.34824753, tt::tolerance(tol));
   };
 
   void test_update_dof_mapping()
@@ -202,12 +206,12 @@ public:
     da._expt_size = expt_size;
     da.update_dof_mapping<2>(dof_handler, indices_and_offsets);
 
-    BOOST_CHECK(da._expt_to_dof_mapping.first[0] == 0);
-    BOOST_CHECK(da._expt_to_dof_mapping.first[1] == 1);
-    BOOST_CHECK(da._expt_to_dof_mapping.first[2] == 2);
-    BOOST_CHECK(da._expt_to_dof_mapping.second[0] == 0);
-    BOOST_CHECK(da._expt_to_dof_mapping.second[1] == 1);
-    BOOST_CHECK(da._expt_to_dof_mapping.second[2] == 3);
+    BOOST_TEST(da._expt_to_dof_mapping.first[0] == 0);
+    BOOST_TEST(da._expt_to_dof_mapping.first[1] == 1);
+    BOOST_TEST(da._expt_to_dof_mapping.first[2] == 2);
+    BOOST_TEST(da._expt_to_dof_mapping.second[0] == 0);
+    BOOST_TEST(da._expt_to_dof_mapping.second[1] == 1);
+    BOOST_TEST(da._expt_to_dof_mapping.second[2] == 3);
   };
 
   void test_calc_H()
@@ -258,13 +262,13 @@ public:
       for (unsigned int j = 0; j < sim_size; ++j)
       {
         if (i == 0 && j == 0)
-          BOOST_CHECK_CLOSE(H(i, j), 1.0, tol);
+          BOOST_TEST(H(i, j) == 1.0, tt::tolerance(tol));
         else if (i == 1 && j == 1)
-          BOOST_CHECK_CLOSE(H(i, j), 1.0, tol);
+          BOOST_TEST(H(i, j) == 1.0, tt::tolerance(tol));
         else if (i == 2 && j == 3)
-          BOOST_CHECK_CLOSE(H(i, j), 1.0, tol);
+          BOOST_TEST(H(i, j) == 1.0, tt::tolerance(tol));
         else
-          BOOST_CHECK_CLOSE(H.el(i, j), 0.0, tol);
+          BOOST_TEST(H.el(i, j) == 0.0, tt::tolerance(tol));
       }
     }
   };
@@ -319,9 +323,9 @@ public:
     dealii::Vector<double> Hx = da.calc_Hx(sim_vec);
 
     double tol = 1e-10;
-    BOOST_CHECK_CLOSE(Hx(0), 2.0, tol);
-    BOOST_CHECK_CLOSE(Hx(1), 4.0, tol);
-    BOOST_CHECK_CLOSE(Hx(2), 7.0, tol);
+    BOOST_TEST(Hx(0) == 2.0, tt::tolerance(tol));
+    BOOST_TEST(Hx(1) == 4.0, tt::tolerance(tol));
+    BOOST_TEST(Hx(2) == 7.0, tt::tolerance(tol));
   };
 
   void test_update_covariance_sparsity_pattern()
@@ -348,26 +352,26 @@ public:
     da._localization_cutoff_distance = 100.0;
     da._localization_cutoff_function = LocalizationCutoff::step_function;
     da.update_covariance_sparsity_pattern<2>(dof_handler, 0);
-    BOOST_CHECK(da._covariance_sparsity_pattern.n_nonzero_elements() == 81);
+    BOOST_TEST(da._covariance_sparsity_pattern.n_nonzero_elements() == 81u);
 
     // Sparse diagonal matrix
     da._localization_cutoff_distance = 1.0e-6;
     da._localization_cutoff_function = LocalizationCutoff::step_function;
     da.update_covariance_sparsity_pattern<2>(dof_handler, 0);
-    BOOST_CHECK(da._covariance_sparsity_pattern.n_nonzero_elements() == 9);
+    BOOST_TEST(da._covariance_sparsity_pattern.n_nonzero_elements() == 9u);
 
     // More general sparse matrix, cuts off interactions between the corners
     // of the domain
     da._localization_cutoff_distance = 1.2;
     da._localization_cutoff_function = LocalizationCutoff::step_function;
     da.update_covariance_sparsity_pattern<2>(dof_handler, 0);
-    BOOST_CHECK(da._covariance_sparsity_pattern.n_nonzero_elements() == 77);
+    BOOST_TEST(da._covariance_sparsity_pattern.n_nonzero_elements() == 77u);
 
     // Sparse diagonal matrix with two augmentation parameters
     da._localization_cutoff_distance = 1.0e-6;
     da._localization_cutoff_function = LocalizationCutoff::step_function;
     da.update_covariance_sparsity_pattern<2>(dof_handler, 2);
-    BOOST_CHECK(da._covariance_sparsity_pattern.n_nonzero_elements() == 49);
+    BOOST_TEST(da._covariance_sparsity_pattern.n_nonzero_elements() == 49u);
   }
 
   void test_calc_sample_covariance_sparse()
@@ -419,7 +423,7 @@ public:
     {
       for (unsigned int j = 0; j < 4; ++j)
       {
-        BOOST_CHECK_SMALL(std::abs(cov(i, j)), tol);
+        BOOST_TEST(cov(i, j) == 0., tt::tolerance(tol));
       }
     }
 
@@ -438,71 +442,83 @@ public:
     dealii::SparseMatrix<double> cov1 =
         da.calc_sample_covariance_sparse(vec_ensemble1);
 
-    BOOST_CHECK_CLOSE(cov1(0, 0), 0.005, tol);
-    BOOST_CHECK_CLOSE(cov1(0, 1), 0.015, tol);
-    BOOST_CHECK_CLOSE(cov1(0, 2), 0.01, tol);
-    BOOST_CHECK_CLOSE(cov1(0, 3), 0.02, tol);
-    BOOST_CHECK_CLOSE(cov1(1, 0), 0.015, tol);
-    BOOST_CHECK_CLOSE(cov1(1, 1), 0.045, tol);
-    BOOST_CHECK_CLOSE(cov1(1, 2), 0.03, tol);
-    BOOST_CHECK_CLOSE(cov1(1, 3), 0.06, tol);
-    BOOST_CHECK_CLOSE(cov1(2, 0), 0.01, tol);
-    BOOST_CHECK_CLOSE(cov1(2, 1), 0.03, tol);
-    BOOST_CHECK_CLOSE(cov1(2, 2), 0.02, tol);
-    BOOST_CHECK_CLOSE(cov1(2, 3), 0.04, tol);
-    BOOST_CHECK_CLOSE(cov1(3, 0), 0.02, tol);
-    BOOST_CHECK_CLOSE(cov1(3, 1), 0.06, tol);
-    BOOST_CHECK_CLOSE(cov1(3, 2), 0.04, tol);
-    BOOST_CHECK_CLOSE(cov1(3, 3), 0.08, tol);
+    BOOST_TEST(cov1(0, 0) == 0.005, tt::tolerance(tol));
+    BOOST_TEST(cov1(0, 1) == 0.015, tt::tolerance(tol));
+    BOOST_TEST(cov1(0, 2) == 0.01, tt::tolerance(tol));
+    BOOST_TEST(cov1(0, 3) == 0.02, tt::tolerance(tol));
+    BOOST_TEST(cov1(1, 0) == 0.015, tt::tolerance(tol));
+    BOOST_TEST(cov1(1, 1) == 0.045, tt::tolerance(tol));
+    BOOST_TEST(cov1(1, 2) == 0.03, tt::tolerance(tol));
+    BOOST_TEST(cov1(1, 3) == 0.06, tt::tolerance(tol));
+    BOOST_TEST(cov1(2, 0) == 0.01, tt::tolerance(tol));
+    BOOST_TEST(cov1(2, 1) == 0.03, tt::tolerance(tol));
+    BOOST_TEST(cov1(2, 2) == 0.02, tt::tolerance(tol));
+    BOOST_TEST(cov1(2, 3) == 0.04, tt::tolerance(tol));
+    BOOST_TEST(cov1(3, 0) == 0.02, tt::tolerance(tol));
+    BOOST_TEST(cov1(3, 1) == 0.06, tt::tolerance(tol));
+    BOOST_TEST(cov1(3, 2) == 0.04, tt::tolerance(tol));
+    BOOST_TEST(cov1(3, 3) == 0.08, tt::tolerance(tol));
 
     // Non-trivial case with step-function sparsity
     da._localization_cutoff_distance = 1.0e-6;
     da.update_covariance_sparsity_pattern<2>(dof_handler, 0);
-    BOOST_CHECK(da._covariance_sparsity_pattern.n_nonzero_elements() == 4);
+    BOOST_TEST(da._covariance_sparsity_pattern.n_nonzero_elements() == 4);
     dealii::SparseMatrix<double> cov2 =
         da.calc_sample_covariance_sparse(vec_ensemble1);
 
-    BOOST_CHECK_CLOSE(cov2.el(0, 0), 0.005, tol);
-    BOOST_CHECK_CLOSE(cov2.el(0, 1), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov2.el(0, 2), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov2.el(0, 3), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov2.el(1, 0), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov2.el(1, 1), 0.045, tol);
-    BOOST_CHECK_CLOSE(cov2.el(1, 2), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov2.el(1, 3), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov2.el(2, 0), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov2.el(2, 1), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov2.el(2, 2), 0.02, tol);
-    BOOST_CHECK_CLOSE(cov2.el(2, 3), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov2.el(3, 0), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov2.el(3, 1), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov2.el(3, 2), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov2.el(3, 3), 0.08, tol);
+    BOOST_TEST(cov2.el(0, 0) == 0.005, tt::tolerance(tol));
+    BOOST_TEST(cov2.el(0, 1) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov2.el(0, 2) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov2.el(0, 3) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov2.el(1, 0) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov2.el(1, 1) == 0.045, tt::tolerance(tol));
+    BOOST_TEST(cov2.el(1, 2) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov2.el(1, 3) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov2.el(2, 0) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov2.el(2, 1) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov2.el(2, 2) == 0.02, tt::tolerance(tol));
+    BOOST_TEST(cov2.el(2, 3) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov2.el(3, 0) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov2.el(3, 1) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov2.el(3, 2) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov2.el(3, 3) == 0.08, tt::tolerance(tol));
 
     // Non-trivial case with Gaspari-Cohn sparsity
     da._localization_cutoff_distance = 3.0;
     da._localization_cutoff_function = LocalizationCutoff::gaspari_cohn;
     da.update_covariance_sparsity_pattern<2>(dof_handler, 0);
-    BOOST_CHECK(da._covariance_sparsity_pattern.n_nonzero_elements() == 16);
+    BOOST_TEST(da._covariance_sparsity_pattern.n_nonzero_elements() == 16);
     dealii::SparseMatrix<double> cov3 =
         da.calc_sample_covariance_sparse(vec_ensemble1);
 
-    BOOST_CHECK_CLOSE(cov3.el(0, 0), 0.005, tol);
-    BOOST_CHECK(cov3.el(0, 1) > 0.0 && cov3.el(0, 1) < 0.015);
-    BOOST_CHECK(cov3.el(0, 2) > 0.0 && cov3.el(0, 2) < 0.01);
-    BOOST_CHECK(cov3.el(0, 3) > 0.0 && cov3.el(0, 3) < 0.02);
-    BOOST_CHECK(cov3.el(1, 0) > 0.0 && cov3.el(1, 0) < 0.015);
-    BOOST_CHECK_CLOSE(cov3.el(1, 1), 0.045, tol);
-    BOOST_CHECK(cov3.el(1, 2) > 0.0 && cov3.el(1, 2) < 0.03);
-    BOOST_CHECK(cov3.el(1, 3) > 0.0 && cov3.el(1, 3) < 0.06);
-    BOOST_CHECK(cov3.el(2, 0) > 0.0 && cov3.el(2, 0) < 0.01);
-    BOOST_CHECK(cov3.el(2, 1) > 0.0 && cov3.el(2, 1) < 0.03);
-    BOOST_CHECK_CLOSE(cov3.el(2, 2), 0.02, tol);
-    BOOST_CHECK(cov3.el(2, 3) > 0.0 && cov3.el(2, 3) < 0.04);
-    BOOST_CHECK(cov3.el(3, 0) > 0.0 && cov3.el(3, 0) < 0.02);
-    BOOST_CHECK(cov3.el(3, 1) > 0.0 && cov3.el(3, 1) < 0.06);
-    BOOST_CHECK(cov3.el(3, 2) > 0.0 && cov3.el(3, 2) < 0.04);
-    BOOST_CHECK_CLOSE(cov3.el(3, 3), 0.08, tol);
+    BOOST_TEST(cov3.el(0, 0) == 0.005, tt::tolerance(tol));
+    BOOST_TEST(cov3.el(0, 1) > 0.0);
+    BOOST_TEST(cov3.el(0, 1) < 0.015);
+    BOOST_TEST(cov3.el(0, 2) > 0.0);
+    BOOST_TEST(cov3.el(0, 2) < 0.01);
+    BOOST_TEST(cov3.el(0, 3) > 0.0);
+    BOOST_TEST(cov3.el(0, 3) < 0.02);
+    BOOST_TEST(cov3.el(1, 0) > 0.0);
+    BOOST_TEST(cov3.el(1, 0) < 0.015);
+    BOOST_TEST(cov3.el(1, 1) == 0.045, tt::tolerance(tol));
+    BOOST_TEST(cov3.el(1, 2) > 0.0);
+    BOOST_TEST(cov3.el(1, 2) < 0.03);
+    BOOST_TEST(cov3.el(1, 3) > 0.0);
+    BOOST_TEST(cov3.el(1, 3) < 0.06);
+    BOOST_TEST(cov3.el(2, 0) > 0.0);
+    BOOST_TEST(cov3.el(2, 0) < 0.01);
+    BOOST_TEST(cov3.el(2, 1) > 0.0);
+    BOOST_TEST(cov3.el(2, 1) < 0.03);
+    BOOST_TEST(cov3.el(2, 2) == 0.02, tt::tolerance(tol));
+    BOOST_TEST(cov3.el(2, 3) > 0.0);
+    BOOST_TEST(cov3.el(2, 3) < 0.04);
+    BOOST_TEST(cov3.el(3, 0) > 0.0);
+    BOOST_TEST(cov3.el(3, 0) < 0.02);
+    BOOST_TEST(cov3.el(3, 1) > 0.0);
+    BOOST_TEST(cov3.el(3, 1) < 0.06);
+    BOOST_TEST(cov3.el(3, 2) > 0.0);
+    BOOST_TEST(cov3.el(3, 2) < 0.04);
+    BOOST_TEST(cov3.el(3, 3) == 0.08, tt::tolerance(tol));
 
     // Non-trivial case with step-function sparsity and two augmented parameters
     dealii::LA::distributed::Vector<double> sim_vec2(dof_handler.n_dofs() + 2);
@@ -527,40 +543,40 @@ public:
 
     da._localization_cutoff_distance = 1.0e-6;
     da.update_covariance_sparsity_pattern<2>(dof_handler, 2);
-    BOOST_CHECK(da._covariance_sparsity_pattern.n_nonzero_elements() == 24);
+    BOOST_TEST(da._covariance_sparsity_pattern.n_nonzero_elements() == 24u);
     dealii::SparseMatrix<double> cov4 =
         da.calc_sample_covariance_sparse(vec_ensemble2);
 
-    BOOST_CHECK_CLOSE(cov4.el(0, 0), 0.005, tol);
-    BOOST_CHECK_CLOSE(cov4.el(0, 1), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov4.el(0, 2), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov4.el(0, 3), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov4.el(1, 0), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov4.el(1, 1), 0.045, tol);
-    BOOST_CHECK_CLOSE(cov4.el(1, 2), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov4.el(1, 3), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov4.el(2, 0), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov4.el(2, 1), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov4.el(2, 2), 0.02, tol);
-    BOOST_CHECK_CLOSE(cov4.el(2, 3), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov4.el(3, 0), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov4.el(3, 1), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov4.el(3, 2), 0.0, tol);
-    BOOST_CHECK_CLOSE(cov4.el(3, 3), 0.08, tol);
+    BOOST_TEST(cov4.el(0, 0) == 0.005, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(0, 1) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(0, 2) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(0, 3) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(1, 0) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(1, 1) == 0.045, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(1, 2) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(1, 3) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(2, 0) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(2, 1) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(2, 2) == 0.02, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(2, 3) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(3, 0) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(3, 1) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(3, 2) == 0.0, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(3, 3) == 0.08, tt::tolerance(tol));
 
-    BOOST_CHECK_CLOSE(cov4.el(4, 0), 0.005, tol);
-    BOOST_CHECK_CLOSE(cov4.el(4, 1), 0.015, tol);
-    BOOST_CHECK_CLOSE(cov4.el(4, 2), 0.01, tol);
-    BOOST_CHECK_CLOSE(cov4.el(4, 3), 0.02, tol);
-    BOOST_CHECK_CLOSE(cov4.el(4, 4), 0.005, tol);
-    BOOST_CHECK_CLOSE(cov4.el(4, 5), -0.005, tol);
+    BOOST_TEST(cov4.el(4, 0) == 0.005, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(4, 1) == 0.015, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(4, 2) == 0.01, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(4, 3) == 0.02, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(4, 4) == 0.005, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(4, 5) == -0.005, tt::tolerance(tol));
 
-    BOOST_CHECK_CLOSE(cov4.el(5, 0), -0.005, tol);
-    BOOST_CHECK_CLOSE(cov4.el(5, 1), -0.015, tol);
-    BOOST_CHECK_CLOSE(cov4.el(5, 2), -0.01, tol);
-    BOOST_CHECK_CLOSE(cov4.el(5, 3), -0.02, tol);
-    BOOST_CHECK_CLOSE(cov4.el(5, 4), -0.005, tol);
-    BOOST_CHECK_CLOSE(cov4.el(5, 5), 0.005, tol);
+    BOOST_TEST(cov4.el(5, 0) == -0.005, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(5, 1) == -0.015, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(5, 2) == -0.01, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(5, 3) == -0.02, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(5, 4) == -0.005, tt::tolerance(tol));
+    BOOST_TEST(cov4.el(5, 5) == 0.005, tt::tolerance(tol));
   };
 
   void test_fill_noise_vector(bool R_is_diagonal)
@@ -594,9 +610,9 @@ public:
 
       double tol =
           20.; // Loose 20% tolerance because this is a statistical check
-      BOOST_CHECK_CLOSE(R(0, 0), Rtest(0, 0), tol);
-      BOOST_CHECK_CLOSE(R(1, 1), Rtest(1, 1), tol);
-      BOOST_CHECK_CLOSE(R(2, 2), Rtest(2, 2), tol);
+      BOOST_TEST(R(0, 0) == Rtest(0, 0), tt::tolerance(tol));
+      BOOST_TEST(R(1, 1) == Rtest(1, 1), tt::tolerance(tol));
+      BOOST_TEST(R(2, 2) == Rtest(2, 2), tt::tolerance(tol));
     }
     else
     {
@@ -631,11 +647,11 @@ public:
 
       double tol =
           20.; // Loose 20% tolerance because this is a statistical check
-      BOOST_CHECK_CLOSE(R(0, 0), Rtest(0, 0), tol);
-      BOOST_CHECK_CLOSE(R(1, 0), Rtest(1, 0), tol);
-      BOOST_CHECK_CLOSE(R(1, 1), Rtest(1, 1), tol);
-      BOOST_CHECK_CLOSE(R(0, 1), Rtest(0, 1), tol);
-      BOOST_CHECK_CLOSE(R(2, 2), Rtest(2, 2), tol);
+      BOOST_TEST(R(0, 0) == Rtest(0, 0), tt::tolerance(tol));
+      BOOST_TEST(R(1, 0) == Rtest(1, 0), tt::tolerance(tol));
+      BOOST_TEST(R(1, 1) == Rtest(1, 1), tt::tolerance(tol));
+      BOOST_TEST(R(0, 1) == Rtest(0, 1), tt::tolerance(tol));
+      BOOST_TEST(R(2, 2) == Rtest(2, 2), tt::tolerance(tol));
     }
   }; // namespace adamantine
 
@@ -750,10 +766,10 @@ public:
     // Large entries in R could make these fail spuriously
     for (int member = 0; member < 3; ++member)
     {
-      BOOST_CHECK(std::abs(expt_vec[0] - sim_at_expt_pt_1_after[member]) <=
-                  std::abs(expt_vec[0] - sim_at_expt_pt_1_before[member]));
-      BOOST_CHECK(std::abs(expt_vec[1] - sim_at_expt_pt_2_after[member]) <=
-                  std::abs(expt_vec[1] - sim_at_expt_pt_2_before[member]));
+      BOOST_TEST(std::abs(expt_vec[0] - sim_at_expt_pt_1_after[member]) <=
+                 std::abs(expt_vec[0] - sim_at_expt_pt_1_before[member]));
+      BOOST_TEST(std::abs(expt_vec[1] - sim_at_expt_pt_2_after[member]) <=
+                 std::abs(expt_vec[1] - sim_at_expt_pt_2_before[member]));
     }
   };
 
@@ -880,10 +896,10 @@ public:
     // Large entries in R could make these fail spuriously
     for (int member = 0; member < 3; ++member)
     {
-      BOOST_CHECK(std::abs(expt_vec[0] - sim_at_expt_pt_1_after[member]) <=
-                  std::abs(expt_vec[0] - sim_at_expt_pt_1_before[member]));
-      BOOST_CHECK(std::abs(expt_vec[1] - sim_at_expt_pt_2_after[member]) <=
-                  std::abs(expt_vec[1] - sim_at_expt_pt_2_before[member]));
+      BOOST_TEST(std::abs(expt_vec[0] - sim_at_expt_pt_1_after[member]) <=
+                 std::abs(expt_vec[0] - sim_at_expt_pt_1_before[member]));
+      BOOST_TEST(std::abs(expt_vec[1] - sim_at_expt_pt_2_after[member]) <=
+                 std::abs(expt_vec[1] - sim_at_expt_pt_2_before[member]));
     }
   };
 

--- a/tests/test_ensemble_management.cc
+++ b/tests/test_ensemble_management.cc
@@ -16,10 +16,11 @@
 
 #include "main.cc"
 
-BOOST_AUTO_TEST_CASE(fill_and_sync_random_vector)
+namespace utf = boost::unit_test;
+
+// Fairly loose tolerance because this is a statistical check
+BOOST_AUTO_TEST_CASE(fill_and_sync_random_vector, *utf::tolerance(10.))
 {
-  // Fairly loose tolerance because this is a statistical check
-  double tolerance = 10.0;
 
   // Create the random vector
   double mean = -1.2;
@@ -29,13 +30,13 @@ BOOST_AUTO_TEST_CASE(fill_and_sync_random_vector)
       adamantine::fill_and_sync_random_vector(ensemble_size, mean, stddev);
 
   // Check vector size
-  BOOST_CHECK(vec.size() == ensemble_size);
+  BOOST_TEST(vec.size() == ensemble_size);
 
   // Check vector mean
   double mean_check =
       std::accumulate(vec.cbegin(), vec.cend(), 0.) / ensemble_size;
 
-  BOOST_CHECK_CLOSE(mean, mean_check, tolerance);
+  BOOST_TEST(mean == mean_check);
 
   // Check vector variance
   boost::accumulators::accumulator_set<
@@ -45,6 +46,5 @@ BOOST_AUTO_TEST_CASE(fill_and_sync_random_vector)
   {
     acc(vec[member]);
   }
-  BOOST_CHECK_CLOSE(stddev * stddev, boost::accumulators::variance(acc),
-                    tolerance);
+  BOOST_TEST(stddev * stddev == boost::accumulators::variance(acc));
 }

--- a/tests/test_experimental_data.cc
+++ b/tests/test_experimental_data.cc
@@ -16,6 +16,8 @@
 
 #include "main.cc"
 
+namespace utf = boost::unit_test;
+
 BOOST_AUTO_TEST_CASE(read_experimental_data_point_cloud_from_file)
 {
   MPI_Comm communicator = MPI_COMM_WORLD;
@@ -42,13 +44,13 @@ BOOST_AUTO_TEST_CASE(read_experimental_data_point_cloud_from_file)
   points_ref.emplace_back(1., 0.5, 1.);
   points_ref.emplace_back(1., 1., 1.);
 
-  BOOST_CHECK(points_values.size() == 1);
-  BOOST_CHECK(points_values[0].points.size() == 9);
-  BOOST_CHECK(points_values[0].points.size() == points_values[0].values.size());
+  BOOST_TEST(points_values.size() == 1);
+  BOOST_TEST(points_values[0].points.size() == 9);
+  BOOST_TEST(points_values[0].points.size() == points_values[0].values.size());
   for (unsigned int i = 0; i < points_values[0].points.size(); ++i)
   {
-    BOOST_CHECK(points_values[0].values[i] == values_ref[i]);
-    BOOST_CHECK(points_values[0].points[i] == points_ref[i]);
+    BOOST_TEST(points_values[0].values[i] == values_ref[i]);
+    BOOST_TEST(points_values[0].points[i] == points_ref[i]);
   }
 }
 
@@ -102,8 +104,8 @@ BOOST_AUTO_TEST_CASE(set_vector_with_experimental_data_point_cloud)
 
   for (unsigned int i = 0; i < temperature.locally_owned_size(); ++i)
   {
-    BOOST_CHECK(temperature.local_element(i) ==
-                temperature_ref[locally_owned_dofs.nth_index_in_set(i)]);
+    BOOST_TEST(temperature.local_element(i) ==
+               temperature_ref[locally_owned_dofs.nth_index_in_set(i)]);
   }
 }
 
@@ -151,12 +153,12 @@ BOOST_AUTO_TEST_CASE(read_experimental_data_ray_tracing_from_file)
   if (dealii::Utilities::MPI::this_mpi_process(communicator) == 0)
     for (unsigned int i = 0; i < values_ref.size(); ++i)
     {
-      BOOST_CHECK(points_values.values[i] == values_ref[i]);
-      BOOST_CHECK(points_values.points[i] == points_ref[i]);
+      BOOST_TEST(points_values.values[i] == values_ref[i]);
+      BOOST_TEST(points_values.points[i] == points_ref[i]);
     }
 }
 
-BOOST_AUTO_TEST_CASE(timestamp)
+BOOST_AUTO_TEST_CASE(timestamp, *utf::tolerance(1e-12))
 {
   boost::property_tree::ptree database;
   database.put("log_filename", "experiment_log_test.txt");
@@ -169,17 +171,15 @@ BOOST_AUTO_TEST_CASE(timestamp)
   std::vector<std::vector<double>> time_stamps =
       adamantine::read_frame_timestamps(database);
 
-  double tol = 1.0e-12;
+  BOOST_TEST(time_stamps.size() == 2);
+  BOOST_TEST(time_stamps[0].size() == 3);
+  BOOST_TEST(time_stamps[1].size() == 3);
 
-  BOOST_CHECK(time_stamps.size() == 2);
-  BOOST_CHECK(time_stamps[0].size() == 3);
-  BOOST_CHECK(time_stamps[1].size() == 3);
+  BOOST_TEST(time_stamps[0][0] == 0.1);
+  BOOST_TEST(time_stamps[0][1] == 0.1135);
+  BOOST_TEST(time_stamps[0][2] == 0.1345);
 
-  BOOST_CHECK_CLOSE(time_stamps[0][0], 0.1, tol);
-  BOOST_CHECK_CLOSE(time_stamps[0][1], 0.1135, tol);
-  BOOST_CHECK_CLOSE(time_stamps[0][2], 0.1345, tol);
-
-  BOOST_CHECK_CLOSE(time_stamps[1][0], 0.1, tol);
-  BOOST_CHECK_CLOSE(time_stamps[1][1], 0.1136, tol);
-  BOOST_CHECK_CLOSE(time_stamps[1][2], 0.1348, tol);
+  BOOST_TEST(time_stamps[1][0] == 0.1);
+  BOOST_TEST(time_stamps[1][1] == 0.1136);
+  BOOST_TEST(time_stamps[1][2] == 0.1348);
 }

--- a/tests/test_geometry.cc
+++ b/tests/test_geometry.cc
@@ -34,19 +34,20 @@ void check_material_id(
         if ((cell->face(i)->at_boundary()) &&
             (cell->face(i)->boundary_id() == top_boundary))
         {
-          BOOST_CHECK(cell->user_index() ==
-                      static_cast<int>(adamantine::MaterialState::powder));
+          BOOST_TEST(
+              cell->user_index() ==
+              static_cast<unsigned int>(adamantine::MaterialState::powder));
           powder = true;
           break;
         }
       }
       if (powder == false)
-        BOOST_CHECK(cell->user_index() ==
-                    static_cast<int>(adamantine::MaterialState::solid));
+        BOOST_TEST(cell->user_index() ==
+                   static_cast<unsigned int>(adamantine::MaterialState::solid));
     }
     else
-      BOOST_CHECK(cell->user_index() ==
-                  static_cast<int>(adamantine::MaterialState::solid));
+      BOOST_TEST(cell->user_index() ==
+                 static_cast<unsigned int>(adamantine::MaterialState::solid));
   }
 }
 
@@ -67,7 +68,7 @@ BOOST_AUTO_TEST_CASE(geometry_2D)
   dealii::parallel::distributed::Triangulation<2> const &tria =
       geometry.get_triangulation();
 
-  BOOST_CHECK(tria.n_active_cells() == 20);
+  BOOST_TEST(tria.n_active_cells() == 20);
 
   dealii::types::boundary_id const top_boundary = 3;
   check_material_id(tria, top_boundary);
@@ -92,7 +93,7 @@ BOOST_AUTO_TEST_CASE(geometry_3D)
   dealii::parallel::distributed::Triangulation<3> const &tria =
       geometry.get_triangulation();
 
-  BOOST_CHECK(tria.n_active_cells() == 40);
+  BOOST_TEST(tria.n_active_cells() == 40);
 
   dealii::types::boundary_id const top_boundary = 5;
   check_material_id(tria, top_boundary);
@@ -113,7 +114,7 @@ BOOST_AUTO_TEST_CASE(gmsh)
   dealii::parallel::distributed::Triangulation<3> const &tria =
       geometry.get_triangulation();
 
-  BOOST_CHECK(tria.n_active_cells() == 320);
+  BOOST_TEST(tria.n_active_cells() == 320);
 
   dealii::types::boundary_id const top_boundary = 1;
   check_material_id(tria, top_boundary);

--- a/tests/test_heat_source.cc
+++ b/tests/test_heat_source.cc
@@ -14,13 +14,13 @@
 
 #include "main.cc"
 
+namespace utf = boost::unit_test;
+
 namespace adamantine
 {
 
-BOOST_AUTO_TEST_CASE(heat_source_value_2d)
+BOOST_AUTO_TEST_CASE(heat_source_value_2d, *utf::tolerance(1e-12))
 {
-  double const tolerance = 1e-12;
-
   boost::property_tree::ptree database;
 
   database.put("depth", 0.1);
@@ -38,18 +38,18 @@ BOOST_AUTO_TEST_CASE(heat_source_value_2d)
   std::cout << "Checking point 1..." << std::endl;
   dealii::Point<2> point1(0.0, 0.15);
   g_value = goldak_heat_source.value(point1, 1.0e-7, 0.2);
-  BOOST_CHECK_CLOSE(g_value, 0.0, tolerance);
+  BOOST_TEST(g_value == 0.0);
 
   eb_value = eb_heat_source.value(point1, 1.0e-7, 0.2);
-  BOOST_CHECK_CLOSE(eb_value, 0.0, tolerance);
+  BOOST_TEST(eb_value == 0.0);
 
   std::cout << "Checking point 2..." << std::endl;
   dealii::Point<2> point2(10.0, 0.0);
   g_value = goldak_heat_source.value(point2, 5.0e-7, 0.2);
-  BOOST_CHECK_CLOSE(g_value, 0.0, tolerance);
+  BOOST_TEST(g_value == 0.0);
 
   eb_value = eb_heat_source.value(point2, 5.0e-7, 0.2);
-  BOOST_CHECK_CLOSE(eb_value, 0.0, tolerance);
+  BOOST_TEST(eb_value == 0.0);
 
   // Check the beam center 0.001 s into the second segment
   std::cout << "Checking point 3..." << std::endl;
@@ -58,12 +58,12 @@ BOOST_AUTO_TEST_CASE(heat_source_value_2d)
   double pi_over_3_to_1p5 = std::pow(dealii::numbers::PI / 3.0, 1.5);
   double expected_value =
       2.0 * 0.1 * 10.0 / (0.5 * 0.5 * 0.1 * pi_over_3_to_1p5);
-  BOOST_CHECK_CLOSE(g_value, expected_value, tolerance);
+  BOOST_TEST(g_value == expected_value);
 
   eb_value = eb_heat_source.value(point3, 0.001001, 0.2);
   expected_value = -0.1 * 10. * 1.0 * std::log(0.1) /
                    (dealii::numbers::PI * 0.5 * 0.5 * 0.1) * 1. * 1.;
-  BOOST_CHECK_CLOSE(eb_value, expected_value, tolerance);
+  BOOST_TEST(eb_value == expected_value);
 
   // Check slightly off beam center 0.001 s into the second segment
   std::cout << "Checking point 4..." << std::endl;
@@ -72,29 +72,27 @@ BOOST_AUTO_TEST_CASE(heat_source_value_2d)
   expected_value = 2.0 * 0.1 * 10.0 / (0.5 * 0.5 * 0.1 * pi_over_3_to_1p5);
   expected_value *=
       std::exp(-3.0 * 1.0e-4 * 1.0e-4 / 0.25 - 3.0 * 0.01 * 0.01 / 0.1 / 0.1);
-  BOOST_CHECK_CLOSE(g_value, expected_value, tolerance);
+  BOOST_TEST(g_value == expected_value);
 
   eb_value = eb_heat_source.value(point4, 0.001001, 0.2);
   expected_value = -0.1 * 10. * 1.0 * std::log(0.1) /
                    (dealii::numbers::PI * 0.5 * 0.5 * 0.1) *
                    std::exp(std::log(0.1) * 1.0e-4 * 1.0e-4 / 0.25) *
                    (-3.0 * 0.01 * 0.01 / 0.1 / 0.1 + 2.0 * 0.01 / 0.1 + 1.0);
-  BOOST_CHECK_CLOSE(eb_value, expected_value, tolerance);
+  BOOST_TEST(eb_value == expected_value);
 
   // Checking beyond the defined time, where the expected value is zero
   std::cout << "Checking point 5..." << std::endl;
   g_value = goldak_heat_source.value(point4, 100.0, 0.2);
   expected_value = 0.0;
-  BOOST_CHECK_CLOSE(g_value, expected_value, tolerance);
+  BOOST_TEST(g_value == expected_value);
 
   eb_value = eb_heat_source.value(point4, 100.0, 0.2);
-  BOOST_CHECK_CLOSE(eb_value, expected_value, tolerance);
+  BOOST_TEST(eb_value == expected_value);
 }
 
-BOOST_AUTO_TEST_CASE(heat_source_value_3d)
+BOOST_AUTO_TEST_CASE(heat_source_value_3d, *utf::tolerance(1e-12))
 {
-  double const tolerance = 1e-12;
-
   boost::property_tree::ptree database;
 
   database.put("depth", 0.1);
@@ -113,18 +111,18 @@ BOOST_AUTO_TEST_CASE(heat_source_value_3d)
   std::cout << "Checking point 1..." << std::endl;
   dealii::Point<3> point1(0.0, 0.0, 0.15);
   g_value = goldak_heat_source.value(point1, 1.0e-7, 0.2);
-  BOOST_CHECK_CLOSE(g_value, 0.0, tolerance);
+  BOOST_TEST(g_value == 0.0);
 
   eb_value = eb_heat_source.value(point1, 1.0e-7, 0.2);
-  BOOST_CHECK_CLOSE(eb_value, 0.0, tolerance);
+  BOOST_TEST(eb_value == 0.0);
 
   std::cout << "Checking point 2..." << std::endl;
   dealii::Point<3> point2(10.0, 0.0, 0.0);
   g_value = goldak_heat_source.value(point2, 5.0e-7, 0.2);
-  BOOST_CHECK_CLOSE(g_value, 0.0, tolerance);
+  BOOST_TEST(g_value == 0.0);
 
   eb_value = eb_heat_source.value(point2, 5.0e-7, 0.2);
-  BOOST_CHECK_CLOSE(eb_value, 0.0, tolerance);
+  BOOST_TEST(eb_value == 0.0);
 
   // Check the beam center 0.001 s into the second segment
   std::cout << "Checking point 3..." << std::endl;
@@ -132,12 +130,12 @@ BOOST_AUTO_TEST_CASE(heat_source_value_3d)
   g_value = goldak_heat_source.value(point3, 0.001001, 0.2);
   double pi_over_3_to_1p5 = std::pow(dealii::numbers::PI / 3.0, 1.5);
   double expected_value = 2.0 * 0.1 * 10.0 / 0.5 / 0.5 / 0.1 / pi_over_3_to_1p5;
-  BOOST_CHECK_CLOSE(g_value, expected_value, tolerance);
+  BOOST_TEST(g_value == expected_value);
 
   eb_value = eb_heat_source.value(point3, 0.001001, 0.2);
   expected_value = -0.1 * 10. * 1.0 * std::log(0.1) /
                    (dealii::numbers::PI * 0.5 * 0.5 * 0.1) * 1. * 1.;
-  BOOST_CHECK_CLOSE(eb_value, expected_value, tolerance);
+  BOOST_TEST(eb_value == expected_value);
 
   // Check slightly off beam center 0.001 s into the second segment
   std::cout << "Checking point 4..." << std::endl;
@@ -146,20 +144,18 @@ BOOST_AUTO_TEST_CASE(heat_source_value_3d)
   expected_value = 2.0 * 0.1 * 10.0 / (0.5 * 0.5 * 0.1 * pi_over_3_to_1p5);
   expected_value *=
       std::exp(-3.0 * 1.0e-4 * 1.0e-4 / 0.25 - 3.0 * 0.01 * 0.01 / 0.1 / 0.1);
-  BOOST_CHECK_CLOSE(g_value, expected_value, tolerance);
+  BOOST_TEST(g_value == expected_value);
 
   eb_value = eb_heat_source.value(point4, 0.001001, 0.2);
   expected_value = -0.1 * 10. * 1.0 * std::log(0.1) /
                    (dealii::numbers::PI * 0.5 * 0.5 * 0.1) *
                    std::exp(std::log(0.1) * 1.0e-4 * 1.0e-4 / 0.25) *
                    (-3.0 * 0.01 * 0.01 / 0.1 / 0.1 + 2.0 * 0.01 / 0.1 + 1.0);
-  BOOST_CHECK_CLOSE(eb_value, expected_value, tolerance);
+  BOOST_TEST(eb_value == expected_value);
 }
 
-BOOST_AUTO_TEST_CASE(heat_source_height)
+BOOST_AUTO_TEST_CASE(heat_source_height, *utf::tolerance(1e-12))
 {
-  double const tolerance = 1e-12;
-
   boost::property_tree::ptree database;
 
   database.put("depth", 0.1);
@@ -176,24 +172,24 @@ BOOST_AUTO_TEST_CASE(heat_source_height)
 
   // Check the height for the first segment
   g_height = goldak_heat_source.get_current_height(1.0e-7);
-  BOOST_CHECK_SMALL(std::abs(g_height - 0.0), tolerance);
+  BOOST_TEST(g_height == 0.);
 
   eb_height = eb_heat_source.get_current_height(1.0e-7);
-  BOOST_CHECK_SMALL(std::abs(eb_height - 0.0), tolerance);
+  BOOST_TEST(eb_height == 0.);
 
   // Check the height for the second segment
   g_height = goldak_heat_source.get_current_height(0.001001);
-  BOOST_CHECK_SMALL(std::abs(g_height - 0.0), tolerance);
+  BOOST_TEST(g_height == 0.);
 
   eb_height = eb_heat_source.get_current_height(0.001001);
-  BOOST_CHECK_SMALL(std::abs(eb_height - 0.0), tolerance);
+  BOOST_TEST(eb_height == 0.);
 
   // Check the height for the third segment
   g_height = goldak_heat_source.get_current_height(0.003);
-  BOOST_CHECK_CLOSE(g_height, 0.001, tolerance);
+  BOOST_TEST(g_height == 0.001);
 
   eb_height = eb_heat_source.get_current_height(0.003);
-  BOOST_CHECK_CLOSE(eb_height, 0.001, tolerance);
+  BOOST_TEST(eb_height == 0.001);
 }
 
 } // namespace adamantine

--- a/tests/test_implicit_operator.cc
+++ b/tests/test_implicit_operator.cc
@@ -24,6 +24,8 @@
 
 #include "main.cc"
 
+namespace tt = boost::test_tools;
+
 BOOST_AUTO_TEST_CASE(implicit_operator)
 {
   MPI_Comm communicator = MPI_COMM_WORLD;
@@ -103,8 +105,8 @@ BOOST_AUTO_TEST_CASE(implicit_operator)
   // Initialize the ImplicitOperator
   adamantine::ImplicitOperator<dealii::MemorySpace::Host> implicit_operator(
       thermal_operator, false);
-  BOOST_CHECK(implicit_operator.m() == 99);
-  BOOST_CHECK(implicit_operator.n() == 99);
+  BOOST_TEST(implicit_operator.m() == 99);
+  BOOST_TEST(implicit_operator.n() == 99);
   BOOST_CHECK_THROW(implicit_operator.Tvmult(dummy, dummy),
                     adamantine::NotImplementedExc);
   BOOST_CHECK_THROW(implicit_operator.vmult_add(dummy, dummy),
@@ -144,5 +146,5 @@ BOOST_AUTO_TEST_CASE(implicit_operator)
   implicit_operator_jfnk.vmult(dst_jfnk, source);
 
   double const tolerance = 1e-7;
-  BOOST_CHECK_CLOSE(dst.l2_norm(), dst_jfnk.l2_norm(), tolerance);
+  BOOST_TEST(dst.l2_norm() == dst_jfnk.l2_norm(), tt::tolerance(tolerance));
 }

--- a/tests/test_integration_2d.cc
+++ b/tests/test_integration_2d.cc
@@ -13,7 +13,9 @@
 
 #include "main.cc"
 
-BOOST_AUTO_TEST_CASE(integration_2D)
+namespace utf = boost::unit_test;
+
+BOOST_AUTO_TEST_CASE(integration_2D, *utf::tolerance(0.1))
 {
   MPI_Comm communicator = MPI_COMM_WORLD;
 
@@ -31,16 +33,17 @@ BOOST_AUTO_TEST_CASE(integration_2D)
       run<2, dealii::MemorySpace::Host>(communicator, database, timers);
 
   std::ifstream gold_file("integration_2d_gold.txt");
-  double const tolerance = 0.1;
   for (unsigned int i = 0; i < result.locally_owned_size(); ++i)
   {
     double gold_value = -1.;
     gold_file >> gold_value;
-    BOOST_CHECK_CLOSE(result.local_element(i), gold_value, tolerance);
+    BOOST_TEST(result.local_element(i) == gold_value);
   }
-}
+} // namespace
+  // boost::unit_testBOOST_AUTO_TEST_CASE(integration_2D,*utf::tolerance(0.1))
+  // boost::unit_testBOOST_AUTO_TEST_CASE(integration_2D,*utf::tolerance(0.1))
 
-BOOST_AUTO_TEST_CASE(integration_2D_ensemble)
+BOOST_AUTO_TEST_CASE(integration_2D_ensemble, *utf::tolerance(0.1))
 {
   MPI_Comm communicator = MPI_COMM_WORLD;
 
@@ -57,7 +60,6 @@ BOOST_AUTO_TEST_CASE(integration_2D_ensemble)
   auto result = run_ensemble<2, dealii::MemorySpace::Host>(communicator,
                                                            database, timers);
 
-  double const tolerance = 0.1;
   for (unsigned int member = 0; member < 3; ++member)
   {
     std::ifstream gold_file("integration_2d_gold.txt");
@@ -66,8 +68,7 @@ BOOST_AUTO_TEST_CASE(integration_2D_ensemble)
     {
       double gold_value = -1.;
       gold_file >> gold_value;
-      BOOST_CHECK_CLOSE(result[member].block(0).local_element(i), gold_value,
-                        tolerance);
+      BOOST_TEST(result[member].block(0).local_element(i) == gold_value);
     }
   }
 }

--- a/tests/test_integration_2d_device.cu
+++ b/tests/test_integration_2d_device.cu
@@ -13,7 +13,9 @@
 
 #include "main.cc"
 
-BOOST_AUTO_TEST_CASE(intregation_2D_device)
+namespace utf = boost::unit_test;
+
+BOOST_AUTO_TEST_CASE(intregation_2D_device, *utf::tolerance(0.1))
 {
   MPI_Comm communicator = MPI_COMM_WORLD;
 
@@ -31,11 +33,10 @@ BOOST_AUTO_TEST_CASE(intregation_2D_device)
       run<2, dealii::MemorySpace::CUDA>(communicator, database, timers);
 
   std::ifstream gold_file("integration_2d_gold.txt");
-  double const tolerance = 0.1;
   for (unsigned int i = 0; i < result.locally_owned_size(); ++i)
   {
     double gold_value = -1.;
     gold_file >> gold_value;
-    BOOST_CHECK_CLOSE(result.local_element(i), gold_value, tolerance);
+    BOOST_TEST(result.local_element(i) == gold_value);
   }
 }

--- a/tests/test_integration_3d.cc
+++ b/tests/test_integration_3d.cc
@@ -13,7 +13,9 @@
 
 #include "main.cc"
 
-BOOST_AUTO_TEST_CASE(integration_3D)
+namespace utf = boost::unit_test;
+
+BOOST_AUTO_TEST_CASE(integration_3D, *utf::tolerance(0.1))
 {
   MPI_Comm communicator = MPI_COMM_WORLD;
 
@@ -31,11 +33,10 @@ BOOST_AUTO_TEST_CASE(integration_3D)
       run<3, dealii::MemorySpace::Host>(communicator, database, timers);
 
   std::ifstream gold_file("integration_3d_gold.txt");
-  double const tolerance = 0.1;
   for (unsigned int i = 0; i < result.locally_owned_size(); ++i)
   {
     double gold_value = -1.;
     gold_file >> gold_value;
-    BOOST_CHECK_CLOSE(result.local_element(i), gold_value, tolerance);
+    BOOST_TEST(result.local_element(i) == gold_value);
   }
 }

--- a/tests/test_integration_3d_amr.cc
+++ b/tests/test_integration_3d_amr.cc
@@ -13,7 +13,9 @@
 
 #include "main.cc"
 
-BOOST_AUTO_TEST_CASE(integration_3D_amr)
+namespace utf = boost::unit_test;
+
+BOOST_AUTO_TEST_CASE(integration_3D_amr, *utf::tolerance(0.1))
 {
   MPI_Comm communicator = MPI_COMM_WORLD;
 
@@ -49,8 +51,6 @@ BOOST_AUTO_TEST_CASE(integration_3D_amr)
   double expected_max = 329.5;
   double expected_min = 296.1;
 
-  double const tolerance = 0.1;
-
-  BOOST_CHECK_CLOSE(expected_max, global_max, tolerance);
-  BOOST_CHECK_CLOSE(expected_min, global_min, tolerance);
+  BOOST_TEST(expected_max == global_max);
+  BOOST_TEST(expected_min == global_min);
 }

--- a/tests/test_integration_da.cc
+++ b/tests/test_integration_da.cc
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(integration_data_assimilation)
                                                            database, timers);
 
   // Three ensemble members expected
-  BOOST_CHECK(result.size() == 3);
+  BOOST_TEST(result.size() == 3);
 
   // Get the average minimum value for each ensemble member, which is very close
   // to the initial temperature
@@ -52,6 +52,6 @@ BOOST_AUTO_TEST_CASE(integration_data_assimilation)
   double average_minimum_value = sum / result.size();
 
   // Based on the experimental data, the expected temperature is ~200.0
-  BOOST_CHECK((average_minimum_value >= 200.0) &&
-              (average_minimum_value < 300.0));
+  BOOST_TEST(average_minimum_value >= 200.0);
+  BOOST_TEST(average_minimum_value < 300.0);
 }

--- a/tests/test_integration_da_augmented.cc
+++ b/tests/test_integration_da_augmented.cc
@@ -13,7 +13,10 @@
 
 #include "main.cc"
 
-BOOST_AUTO_TEST_CASE(integration_3D_data_assimilation_augmented)
+namespace utf = boost::unit_test;
+
+BOOST_AUTO_TEST_CASE(integration_3D_data_assimilation_augmented,
+                     *utf::tolerance(5.))
 {
 
   MPI_Comm communicator = MPI_COMM_WORLD;
@@ -33,7 +36,7 @@ BOOST_AUTO_TEST_CASE(integration_3D_data_assimilation_augmented)
                                                            database, timers);
 
   // Three ensemble members expected
-  BOOST_CHECK(result.size() == 3);
+  BOOST_TEST(result.size() == 3);
 
   // Get the average absorption value for each ensemble member
   double sum = 0.0;
@@ -45,11 +48,10 @@ BOOST_AUTO_TEST_CASE(integration_3D_data_assimilation_augmented)
 
   // Based on the reference solution, the expected absorption efficiency is 0.3
   double gold_solution = 0.3;
-  double tolerance = 5.0;
-  BOOST_CHECK_CLOSE(average_value, gold_solution, tolerance);
+  BOOST_TEST(average_value == gold_solution);
 }
 
-BOOST_AUTO_TEST_CASE(integration_3D)
+BOOST_AUTO_TEST_CASE(integration_3D, *utf::tolerance(0.1))
 {
   MPI_Comm communicator = MPI_COMM_WORLD;
 
@@ -67,11 +69,10 @@ BOOST_AUTO_TEST_CASE(integration_3D)
       run<3, dealii::MemorySpace::Host>(communicator, database, timers);
 
   std::ifstream gold_file("integration_3d_gold.txt");
-  double const tolerance = 0.1;
   for (unsigned int i = 0; i < result.locally_owned_size(); ++i)
   {
     double gold_value = -1.;
     gold_file >> gold_value;
-    BOOST_CHECK_CLOSE(result.local_element(i), gold_value, tolerance);
+    BOOST_TEST(result.local_element(i) == gold_value);
   }
 }

--- a/tests/test_material_deposition.cc
+++ b/tests/test_material_deposition.cc
@@ -18,7 +18,9 @@
 
 #include "main.cc"
 
-BOOST_AUTO_TEST_CASE(read_material_deposition_file_2d)
+namespace utf = boost::unit_test;
+
+BOOST_AUTO_TEST_CASE(read_material_deposition_file_2d, *utf::tolerance(1e-13))
 {
   // Geometry database
   boost::property_tree::ptree geometry_database;
@@ -44,24 +46,23 @@ BOOST_AUTO_TEST_CASE(read_material_deposition_file_2d)
   auto [bounding_boxes, time, deposition_cos, deposition_sin] =
       adamantine::read_material_deposition<2>(geometry_database);
 
-  BOOST_CHECK(time == time_ref);
-  BOOST_CHECK(deposition_cos == cos_ref);
-  BOOST_CHECK(deposition_sin == sin_ref);
-  BOOST_CHECK(bounding_boxes.size() == bounding_boxes_ref.size());
-  double const tolerance = 1e-13;
+  BOOST_TEST(time == time_ref);
+  BOOST_TEST(deposition_cos == cos_ref);
+  BOOST_TEST(deposition_sin == sin_ref);
+  BOOST_TEST(bounding_boxes.size() == bounding_boxes_ref.size());
   for (unsigned int i = 0; i < bounding_boxes_ref.size(); ++i)
   {
     auto points = bounding_boxes[i].get_boundary_points();
     auto points_ref = bounding_boxes_ref[i].get_boundary_points();
     for (int d = 0; d < 2; ++d)
     {
-      BOOST_CHECK_CLOSE(points.first[d], points_ref.first[d], tolerance);
-      BOOST_CHECK_CLOSE(points.second[d], points_ref.second[d], tolerance);
+      BOOST_TEST(points.first[d] == points_ref.first[d]);
+      BOOST_TEST(points.second[d] == points_ref.second[d]);
     }
   }
 }
 
-BOOST_AUTO_TEST_CASE(read_material_deposition_file_3d)
+BOOST_AUTO_TEST_CASE(read_material_deposition_file_3d, *utf::tolerance(1e-13))
 {
   // Geometry database
   boost::property_tree::ptree geometry_database;
@@ -87,19 +88,18 @@ BOOST_AUTO_TEST_CASE(read_material_deposition_file_3d)
   auto [bounding_boxes, time, deposition_cos, deposition_sin] =
       adamantine::read_material_deposition<3>(geometry_database);
 
-  BOOST_CHECK(time == time_ref);
-  BOOST_CHECK(deposition_cos == cos_ref);
-  BOOST_CHECK(deposition_sin == sin_ref);
-  BOOST_CHECK(bounding_boxes.size() == bounding_boxes_ref.size());
-  double const tolerance = 1e-13;
+  BOOST_TEST(time == time_ref);
+  BOOST_TEST(deposition_cos == cos_ref);
+  BOOST_TEST(deposition_sin == sin_ref);
+  BOOST_TEST(bounding_boxes.size() == bounding_boxes_ref.size());
   for (unsigned int i = 0; i < bounding_boxes_ref.size(); ++i)
   {
     auto points = bounding_boxes[i].get_boundary_points();
     auto points_ref = bounding_boxes_ref[i].get_boundary_points();
     for (int d = 0; d < 2; ++d)
     {
-      BOOST_CHECK_CLOSE(points.first[d], points_ref.first[d], tolerance);
-      BOOST_CHECK_CLOSE(points.second[d], points_ref.second[d], tolerance);
+      BOOST_TEST(points.first[d] == points_ref.first[d]);
+      BOOST_TEST(points.second[d] == points_ref.second[d]);
     }
   }
 }
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(get_elements_to_activate_2d)
     auto elements_to_activate =
         adamantine::get_elements_to_activate(dof_handler, bounding_boxes);
 
-    BOOST_CHECK(elements_to_activate.size() == bounding_boxes.size());
+    BOOST_TEST(elements_to_activate.size() == bounding_boxes.size());
 
     std::vector<std::vector<dealii::CellId>> cell_id_ref(3);
     cell_id_ref[0].push_back(dealii::CellId("0_0:"));
@@ -155,10 +155,10 @@ BOOST_AUTO_TEST_CASE(get_elements_to_activate_2d)
 
     for (unsigned int i = 0; i < cell_id_ref.size(); ++i)
     {
-      BOOST_CHECK(elements_to_activate[i].size() == cell_id_ref[i].size());
+      BOOST_TEST(elements_to_activate[i].size() == cell_id_ref[i].size());
       for (unsigned int j = 0; j < cell_id_ref[i].size(); ++j)
       {
-        BOOST_CHECK(elements_to_activate[i][j]->id() == cell_id_ref[i][j]);
+        BOOST_TEST(elements_to_activate[i][j]->id() == cell_id_ref[i][j]);
       }
     }
   }
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(get_elements_to_activate_3d)
     auto elements_to_activate =
         adamantine::get_elements_to_activate(dof_handler, bounding_boxes);
 
-    BOOST_CHECK(elements_to_activate.size() == bounding_boxes.size());
+    BOOST_TEST(elements_to_activate.size() == bounding_boxes.size());
 
     std::vector<std::vector<dealii::CellId>> cell_id_ref(3);
     cell_id_ref[0].push_back(dealii::CellId("0_0:"));
@@ -221,10 +221,10 @@ BOOST_AUTO_TEST_CASE(get_elements_to_activate_3d)
 
     for (unsigned int i = 0; i < cell_id_ref.size(); ++i)
     {
-      BOOST_CHECK(elements_to_activate[i].size() == cell_id_ref[i].size());
+      BOOST_TEST(elements_to_activate[i].size() == cell_id_ref[i].size());
       for (unsigned int j = 0; j < cell_id_ref[i].size(); ++j)
       {
-        BOOST_CHECK(elements_to_activate[i][j]->id() == cell_id_ref[i][j]);
+        BOOST_TEST(elements_to_activate[i][j]->id() == cell_id_ref[i][j]);
       }
     }
   }
@@ -333,12 +333,12 @@ BOOST_AUTO_TEST_CASE(material_deposition)
       (void)cell;
       ++n_cells;
     }
-    BOOST_CHECK(dealii::Utilities::MPI::sum(n_cells, communicator) ==
-                n_cells_ref[i]);
+    BOOST_TEST(dealii::Utilities::MPI::sum(n_cells, communicator) ==
+               n_cells_ref[i]);
   }
 }
 
-BOOST_AUTO_TEST_CASE(deposition_from_scan_path_2d)
+BOOST_AUTO_TEST_CASE(deposition_from_scan_path_2d, *utf::tolerance(1e-13))
 {
   adamantine::ScanPath scan_path("scan_path.txt", "segment");
 
@@ -351,50 +351,42 @@ BOOST_AUTO_TEST_CASE(deposition_from_scan_path_2d)
   auto [bounding_boxes, deposition_times, deposition_cos, deposition_sin] =
       adamantine::deposition_along_scan_path<2>(database, scan_path);
 
-  double const tolerance = 1e-13;
-
   // Check the first and last boxes
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().first(0),
-                    -0.00025, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().first(1), 0.0,
-                    tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().second(0),
-                    0.00025, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().second(1), 0.1,
-                    tolerance);
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().first(0) == -0.00025);
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().first(1) == 0.0);
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().second(0) == 0.00025);
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().second(1) == 0.1);
 
-  BOOST_CHECK_CLOSE(bounding_boxes.at(4).get_boundary_points().first(0),
-                    0.002 - 0.00025, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(4).get_boundary_points().first(1), 0.0,
-                    tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(4).get_boundary_points().second(0),
-                    0.002 + 0.00025, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(4).get_boundary_points().second(1), 0.1,
-                    tolerance);
+  BOOST_TEST(bounding_boxes.at(4).get_boundary_points().first(0) ==
+             (0.002 - 0.00025));
+  BOOST_TEST(bounding_boxes.at(4).get_boundary_points().first(1) == 0.0);
+  BOOST_TEST(bounding_boxes.at(4).get_boundary_points().second(0) ==
+             (0.002 + 0.00025));
+  BOOST_TEST(bounding_boxes.at(4).get_boundary_points().second(1) == 0.1);
 
   // Check the times
-  BOOST_CHECK_CLOSE(deposition_times.at(0), 1.0e-6, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(1), 6.26e-4, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(2), 1.251e-3, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(3), 1.876e-3, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(4), 2.501e-3, tolerance);
+  BOOST_TEST(deposition_times.at(0) == 1.0e-6);
+  BOOST_TEST(deposition_times.at(1) == 6.26e-4);
+  BOOST_TEST(deposition_times.at(2) == 1.251e-3);
+  BOOST_TEST(deposition_times.at(3) == 1.876e-3);
+  BOOST_TEST(deposition_times.at(4) == 2.501e-3);
 
   // Check the deposition cosines
-  BOOST_CHECK_CLOSE(deposition_cos.at(0), 1., tolerance);
-  BOOST_CHECK_CLOSE(deposition_cos.at(1), 1., tolerance);
-  BOOST_CHECK_CLOSE(deposition_cos.at(2), 1., tolerance);
-  BOOST_CHECK_CLOSE(deposition_cos.at(3), 1., tolerance);
-  BOOST_CHECK_CLOSE(deposition_cos.at(4), 1., tolerance);
+  BOOST_TEST(deposition_cos.at(0) == 1.);
+  BOOST_TEST(deposition_cos.at(1) == 1.);
+  BOOST_TEST(deposition_cos.at(2) == 1.);
+  BOOST_TEST(deposition_cos.at(3) == 1.);
+  BOOST_TEST(deposition_cos.at(4) == 1.);
 
   // Check the deposition sines
-  BOOST_CHECK_CLOSE(deposition_sin.at(0), 0., tolerance);
-  BOOST_CHECK_CLOSE(deposition_sin.at(1), 0., tolerance);
-  BOOST_CHECK_CLOSE(deposition_sin.at(2), 0., tolerance);
-  BOOST_CHECK_CLOSE(deposition_sin.at(3), 0., tolerance);
-  BOOST_CHECK_CLOSE(deposition_sin.at(4), 0., tolerance);
+  BOOST_TEST(deposition_sin.at(0) == 0.);
+  BOOST_TEST(deposition_sin.at(1) == 0.);
+  BOOST_TEST(deposition_sin.at(2) == 0.);
+  BOOST_TEST(deposition_sin.at(3) == 0.);
+  BOOST_TEST(deposition_sin.at(4) == 0.);
 }
 
-BOOST_AUTO_TEST_CASE(deposition_from_scan_path_3d)
+BOOST_AUTO_TEST_CASE(deposition_from_scan_path_3d, *utf::tolerance(1e-13))
 {
   adamantine::ScanPath scan_path("scan_path.txt", "segment");
 
@@ -407,58 +399,46 @@ BOOST_AUTO_TEST_CASE(deposition_from_scan_path_3d)
   auto [bounding_boxes, deposition_times, deposition_cos, deposition_sin] =
       adamantine::deposition_along_scan_path<3>(database, scan_path);
 
-  double const tolerance = 1e-13;
-
   // Check the first and last boxes
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().first(0),
-                    -0.00025, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().first(1), -0.05,
-                    tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().first(2), 0.0,
-                    tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().second(0),
-                    0.00025, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().second(1), 0.05,
-                    tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().second(2), 0.1,
-                    tolerance);
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().first(0) == -0.00025);
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().first(1) == -0.05);
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().first(2) == 0.0);
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().second(0) == 0.00025);
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().second(1) == 0.05);
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().second(2) == 0.1);
 
-  BOOST_CHECK_CLOSE(bounding_boxes.at(4).get_boundary_points().first(0),
-                    0.002 - 0.00025, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(4).get_boundary_points().first(1), -0.05,
-                    tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(4).get_boundary_points().first(2), 0.0,
-                    tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(4).get_boundary_points().second(0),
-                    0.002 + 0.00025, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(4).get_boundary_points().second(1), 0.05,
-                    tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(4).get_boundary_points().second(2), 0.1,
-                    tolerance);
+  BOOST_TEST(bounding_boxes.at(4).get_boundary_points().first(0) ==
+             (0.002 - 0.00025));
+  BOOST_TEST(bounding_boxes.at(4).get_boundary_points().first(1) == -0.05);
+  BOOST_TEST(bounding_boxes.at(4).get_boundary_points().first(2) == 0.0);
+  BOOST_TEST(bounding_boxes.at(4).get_boundary_points().second(0) ==
+             (0.002 + 0.00025));
+  BOOST_TEST(bounding_boxes.at(4).get_boundary_points().second(1) == 0.05);
+  BOOST_TEST(bounding_boxes.at(4).get_boundary_points().second(2) == 0.1);
 
   // Check the times
-  BOOST_CHECK_CLOSE(deposition_times.at(0), 1.0e-6, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(1), 6.26e-4, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(2), 1.251e-3, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(3), 1.876e-3, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(4), 2.501e-3, tolerance);
+  BOOST_TEST(deposition_times.at(0) == 1.0e-6);
+  BOOST_TEST(deposition_times.at(1) == 6.26e-4);
+  BOOST_TEST(deposition_times.at(2) == 1.251e-3);
+  BOOST_TEST(deposition_times.at(3) == 1.876e-3);
+  BOOST_TEST(deposition_times.at(4) == 2.501e-3);
 
   // Check the deposition cosines
-  BOOST_CHECK_CLOSE(deposition_cos.at(0), 1., tolerance);
-  BOOST_CHECK_CLOSE(deposition_cos.at(1), 1., tolerance);
-  BOOST_CHECK_CLOSE(deposition_cos.at(2), 1., tolerance);
-  BOOST_CHECK_CLOSE(deposition_cos.at(3), 1., tolerance);
-  BOOST_CHECK_CLOSE(deposition_cos.at(4), 1., tolerance);
+  BOOST_TEST(deposition_cos.at(0) == 1.);
+  BOOST_TEST(deposition_cos.at(1) == 1.);
+  BOOST_TEST(deposition_cos.at(2) == 1.);
+  BOOST_TEST(deposition_cos.at(3) == 1.);
+  BOOST_TEST(deposition_cos.at(4) == 1.);
 
   // Check the deposition sines
-  BOOST_CHECK_CLOSE(deposition_sin.at(0), 0., tolerance);
-  BOOST_CHECK_CLOSE(deposition_sin.at(1), 0., tolerance);
-  BOOST_CHECK_CLOSE(deposition_sin.at(2), 0., tolerance);
-  BOOST_CHECK_CLOSE(deposition_sin.at(3), 0., tolerance);
-  BOOST_CHECK_CLOSE(deposition_sin.at(4), 0., tolerance);
+  BOOST_TEST(deposition_sin.at(0) == 0.);
+  BOOST_TEST(deposition_sin.at(1) == 0.);
+  BOOST_TEST(deposition_sin.at(2) == 0.);
+  BOOST_TEST(deposition_sin.at(3) == 0.);
+  BOOST_TEST(deposition_sin.at(4) == 0.);
 }
 
-BOOST_AUTO_TEST_CASE(deposition_from_L_scan_path_3d)
+BOOST_AUTO_TEST_CASE(deposition_from_L_scan_path_3d, *utf::tolerance(1e-13))
 {
   adamantine::ScanPath scan_path("scan_path_L.txt", "segment");
 
@@ -471,99 +451,80 @@ BOOST_AUTO_TEST_CASE(deposition_from_L_scan_path_3d)
   auto [bounding_boxes, deposition_times, deposition_cos, deposition_sin] =
       adamantine::deposition_along_scan_path<3>(database, scan_path);
 
-  double const tolerance = 1e-13;
-
   // Check the first and last boxes for each segment
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().first(0),
-                    -0.00025, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().first(1), -0.05,
-                    tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().first(2), 0.0,
-                    tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().second(0),
-                    0.00025, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().second(1), 0.05,
-                    tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().second(2), 0.1,
-                    tolerance);
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().first(0) == -0.00025);
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().first(1) == -0.05);
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().first(2) == 0.0);
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().second(0) == 0.00025);
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().second(1) == 0.05);
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().second(2) == 0.1);
 
-  BOOST_CHECK_CLOSE(bounding_boxes.at(4).get_boundary_points().first(0),
-                    0.002 - 0.00025, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(4).get_boundary_points().first(1), -0.05,
-                    tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(4).get_boundary_points().first(2), 0.0,
-                    tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(4).get_boundary_points().second(0),
-                    0.002 + 0.00025, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(4).get_boundary_points().second(1), 0.05,
-                    tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(4).get_boundary_points().second(2), 0.1,
-                    tolerance);
+  BOOST_TEST(bounding_boxes.at(4).get_boundary_points().first(0) ==
+             (0.002 - 0.00025));
+  BOOST_TEST(bounding_boxes.at(4).get_boundary_points().first(1) == -0.05);
+  BOOST_TEST(bounding_boxes.at(4).get_boundary_points().first(2) == 0.0);
+  BOOST_TEST(bounding_boxes.at(4).get_boundary_points().second(0) ==
+             (0.002 + 0.00025));
+  BOOST_TEST(bounding_boxes.at(4).get_boundary_points().second(1) == 0.05);
+  BOOST_TEST(bounding_boxes.at(4).get_boundary_points().second(2) == 0.1);
 
-  BOOST_CHECK_CLOSE(bounding_boxes.at(5).get_boundary_points().first(0),
-                    0.002 - 0.05, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(5).get_boundary_points().first(1),
-                    -0.00025, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(5).get_boundary_points().first(2), 0.0,
-                    tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(5).get_boundary_points().second(0),
-                    0.002 + 0.05, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(5).get_boundary_points().second(1),
-                    0.00025, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(5).get_boundary_points().second(2), 0.1,
-                    tolerance);
+  BOOST_TEST(bounding_boxes.at(5).get_boundary_points().first(0) ==
+             (0.002 - 0.05));
+  BOOST_TEST(bounding_boxes.at(5).get_boundary_points().first(1) == -0.00025);
+  BOOST_TEST(bounding_boxes.at(5).get_boundary_points().first(2) == 0.0);
+  BOOST_TEST(bounding_boxes.at(5).get_boundary_points().second(0) ==
+             (0.002 + 0.05));
+  BOOST_TEST(bounding_boxes.at(5).get_boundary_points().second(1) == 0.00025);
+  BOOST_TEST(bounding_boxes.at(5).get_boundary_points().second(2) == 0.1);
 
-  BOOST_CHECK_CLOSE(bounding_boxes.at(9).get_boundary_points().first(0),
-                    0.002 - 0.05, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(9).get_boundary_points().first(1),
-                    0.00175, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(9).get_boundary_points().first(2), 0.0,
-                    tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(9).get_boundary_points().second(0),
-                    0.002 + 0.05, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(9).get_boundary_points().second(1),
-                    0.00205, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(9).get_boundary_points().second(2), 0.1,
-                    tolerance);
+  BOOST_TEST(bounding_boxes.at(9).get_boundary_points().first(0) ==
+             (0.002 - 0.05));
+  BOOST_TEST(bounding_boxes.at(9).get_boundary_points().first(1) == 0.00175);
+  BOOST_TEST(bounding_boxes.at(9).get_boundary_points().first(2) == 0.0);
+  BOOST_TEST(bounding_boxes.at(9).get_boundary_points().second(0) ==
+             0.002 + 0.05);
+  BOOST_TEST(bounding_boxes.at(9).get_boundary_points().second(1) == 0.00205);
+  BOOST_TEST(bounding_boxes.at(9).get_boundary_points().second(2) == 0.1);
 
   // Check the times
-  BOOST_CHECK_CLOSE(deposition_times.at(0), 1.0e-6, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(1), 6.26e-4, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(2), 1.251e-3, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(3), 1.876e-3, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(4), 2.501e-3, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(5), 2.501e-3, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(6), 3.126e-3, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(7), 3.751e-3, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(8), 4.376e-3, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(9), 4.876e-3, tolerance);
+  BOOST_TEST(deposition_times.at(0) == 1.0e-6);
+  BOOST_TEST(deposition_times.at(1) == 6.26e-4);
+  BOOST_TEST(deposition_times.at(2) == 1.251e-3);
+  BOOST_TEST(deposition_times.at(3) == 1.876e-3);
+  BOOST_TEST(deposition_times.at(4) == 2.501e-3);
+  BOOST_TEST(deposition_times.at(5) == 2.501e-3);
+  BOOST_TEST(deposition_times.at(6) == 3.126e-3);
+  BOOST_TEST(deposition_times.at(7) == 3.751e-3);
+  BOOST_TEST(deposition_times.at(8) == 4.376e-3);
+  BOOST_TEST(deposition_times.at(9) == 4.876e-3);
 
   // Check the deposition cosines
-  BOOST_CHECK_CLOSE(deposition_cos.at(0), 1., tolerance);
-  BOOST_CHECK_CLOSE(deposition_cos.at(1), 1., tolerance);
-  BOOST_CHECK_CLOSE(deposition_cos.at(2), 1., tolerance);
-  BOOST_CHECK_CLOSE(deposition_cos.at(3), 1., tolerance);
-  BOOST_CHECK_CLOSE(deposition_cos.at(4), 1., tolerance);
-  BOOST_CHECK_CLOSE(deposition_cos.at(5), 0., tolerance);
-  BOOST_CHECK_CLOSE(deposition_cos.at(6), 0., tolerance);
-  BOOST_CHECK_CLOSE(deposition_cos.at(7), 0., tolerance);
-  BOOST_CHECK_CLOSE(deposition_cos.at(8), 0., tolerance);
-  BOOST_CHECK_CLOSE(deposition_cos.at(9), 0., tolerance);
+  BOOST_TEST(deposition_cos.at(0) == 1.);
+  BOOST_TEST(deposition_cos.at(1) == 1.);
+  BOOST_TEST(deposition_cos.at(2) == 1.);
+  BOOST_TEST(deposition_cos.at(3) == 1.);
+  BOOST_TEST(deposition_cos.at(4) == 1.);
+  BOOST_TEST(deposition_cos.at(5) == 0.);
+  BOOST_TEST(deposition_cos.at(6) == 0.);
+  BOOST_TEST(deposition_cos.at(7) == 0.);
+  BOOST_TEST(deposition_cos.at(8) == 0.);
+  BOOST_TEST(deposition_cos.at(9) == 0.);
 
   // Check the deposition sines
-  BOOST_CHECK_CLOSE(deposition_sin.at(0), 0., tolerance);
-  BOOST_CHECK_CLOSE(deposition_sin.at(1), 0., tolerance);
-  BOOST_CHECK_CLOSE(deposition_sin.at(2), 0., tolerance);
-  BOOST_CHECK_CLOSE(deposition_sin.at(3), 0., tolerance);
-  BOOST_CHECK_CLOSE(deposition_sin.at(4), 0., tolerance);
-  BOOST_CHECK_CLOSE(deposition_sin.at(5), 1., tolerance);
-  BOOST_CHECK_CLOSE(deposition_sin.at(6), 1., tolerance);
-  BOOST_CHECK_CLOSE(deposition_sin.at(7), 1., tolerance);
-  BOOST_CHECK_CLOSE(deposition_sin.at(8), 1., tolerance);
-  BOOST_CHECK_CLOSE(deposition_sin.at(8), 1., tolerance);
+  BOOST_TEST(deposition_sin.at(0) == 0.);
+  BOOST_TEST(deposition_sin.at(1) == 0.);
+  BOOST_TEST(deposition_sin.at(2) == 0.);
+  BOOST_TEST(deposition_sin.at(3) == 0.);
+  BOOST_TEST(deposition_sin.at(4) == 0.);
+  BOOST_TEST(deposition_sin.at(5) == 1.);
+  BOOST_TEST(deposition_sin.at(6) == 1.);
+  BOOST_TEST(deposition_sin.at(7) == 1.);
+  BOOST_TEST(deposition_sin.at(8) == 1.);
+  BOOST_TEST(deposition_sin.at(8) == 1.);
 }
 
-BOOST_AUTO_TEST_CASE(deposition_from_diagonal_scan_path_3d)
+BOOST_AUTO_TEST_CASE(deposition_from_diagonal_scan_path_3d,
+                     *utf::tolerance(1e-10))
 {
   adamantine::ScanPath scan_path("scan_path_diagonal.txt", "segment");
 
@@ -576,51 +537,45 @@ BOOST_AUTO_TEST_CASE(deposition_from_diagonal_scan_path_3d)
   auto [bounding_boxes, deposition_times, deposition_cos, deposition_sin] =
       adamantine::deposition_along_scan_path<3>(database, scan_path);
 
-  double const tolerance = 1e-10;
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().first(0) ==
+             -0.00022360679775);
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().first(1) ==
+             -0.050111803398874992);
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().first(2) == 0);
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().second(0) ==
+             0.00022360679775);
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().second(1) ==
+             0.050111803398874992);
+  BOOST_TEST(bounding_boxes.at(0).get_boundary_points().second(2) == 0.1);
 
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().first(0),
-                    -0.00022360679775, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().first(1),
-                    -0.050111803398874992, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().first(2), 0,
-                    tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().second(0),
-                    0.00022360679775, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().second(1),
-                    0.050111803398874992, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(0).get_boundary_points().second(2), 0.1,
-                    tolerance);
-
-  BOOST_CHECK_CLOSE(bounding_boxes.at(5).get_boundary_points().first(0),
-                    0.00201246117975, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(5).get_boundary_points().first(1),
-                    -0.0489937694101251, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(5).get_boundary_points().first(2), 0.,
-                    tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(5).get_boundary_points().second(0),
-                    0.00222360679775, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(5).get_boundary_points().second(1),
-                    0.051111803398874993, tolerance);
-  BOOST_CHECK_CLOSE(bounding_boxes.at(5).get_boundary_points().second(2), 0.1,
-                    tolerance);
+  BOOST_TEST(bounding_boxes.at(5).get_boundary_points().first(0) ==
+             0.00201246117975);
+  BOOST_TEST(bounding_boxes.at(5).get_boundary_points().first(1) ==
+             -0.0489937694101251);
+  BOOST_TEST(bounding_boxes.at(5).get_boundary_points().first(2) == 0.);
+  BOOST_TEST(bounding_boxes.at(5).get_boundary_points().second(0) ==
+             0.00222360679775);
+  BOOST_TEST(bounding_boxes.at(5).get_boundary_points().second(1) ==
+             0.051111803398874993);
+  BOOST_TEST(bounding_boxes.at(5).get_boundary_points().second(2) == 0.1);
 
   // Check the times
-  BOOST_CHECK_CLOSE(deposition_times.at(0), 1.0e-6, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(1), 6.26e-4, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(2), 1.251e-3, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(3), 1.876e-3, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(4), 2.501e-3, tolerance);
-  BOOST_CHECK_CLOSE(deposition_times.at(5), 0.002961042485937369, tolerance);
+  BOOST_TEST(deposition_times.at(0) == 1.0e-6);
+  BOOST_TEST(deposition_times.at(1) == 6.26e-4);
+  BOOST_TEST(deposition_times.at(2) == 1.251e-3);
+  BOOST_TEST(deposition_times.at(3) == 1.876e-3);
+  BOOST_TEST(deposition_times.at(4) == 2.501e-3);
+  BOOST_TEST(deposition_times.at(5) == 0.002961042485937369);
 
   // Check the deposition cosines and sines
   for (unsigned int i = 0; i < 6; ++i)
   {
-    BOOST_CHECK_CLOSE(deposition_cos.at(0), 2. / std::sqrt(5.), tolerance);
-    BOOST_CHECK_CLOSE(deposition_sin.at(0), 1. / std::sqrt(5.), tolerance);
+    BOOST_TEST(deposition_cos.at(0) == 2. / std::sqrt(5.));
+    BOOST_TEST(deposition_sin.at(0) == 1. / std::sqrt(5.));
   }
 }
 
-BOOST_AUTO_TEST_CASE(merge_multiple_deposition_paths)
+BOOST_AUTO_TEST_CASE(merge_multiple_deposition_paths, *utf::tolerance(1e-10))
 {
   dealii::BoundingBox<2> box_0(
       std::make_pair(dealii::Point<2>(0., 0.), dealii::Point<2>(1., 1.)));
@@ -658,22 +613,21 @@ BOOST_AUTO_TEST_CASE(merge_multiple_deposition_paths)
   auto [bounding_boxes, time, cos, sin] =
       adamantine::merge_deposition_paths(multiple_paths);
 
-  double const tolerance = 1e-10;
   for (unsigned int i = 0; i < 4; ++i)
   {
-    BOOST_CHECK_CLOSE(bounding_boxes[i].get_boundary_points().first(0),
-                      bb_ref[i].get_boundary_points().first(0), tolerance);
-    BOOST_CHECK_CLOSE(bounding_boxes[i].get_boundary_points().first(1),
-                      bb_ref[i].get_boundary_points().first(1), tolerance);
-    BOOST_CHECK_CLOSE(bounding_boxes[i].get_boundary_points().second(0),
-                      bb_ref[i].get_boundary_points().second(0), tolerance);
-    BOOST_CHECK_CLOSE(bounding_boxes[i].get_boundary_points().second(1),
-                      bb_ref[i].get_boundary_points().second(1), tolerance);
+    BOOST_TEST(bounding_boxes[i].get_boundary_points().first(0) ==
+               bb_ref[i].get_boundary_points().first(0));
+    BOOST_TEST(bounding_boxes[i].get_boundary_points().first(1) ==
+               bb_ref[i].get_boundary_points().first(1));
+    BOOST_TEST(bounding_boxes[i].get_boundary_points().second(0) ==
+               bb_ref[i].get_boundary_points().second(0));
+    BOOST_TEST(bounding_boxes[i].get_boundary_points().second(1) ==
+               bb_ref[i].get_boundary_points().second(1));
 
-    BOOST_CHECK_CLOSE(time[i], time_ref[i], tolerance);
+    BOOST_TEST(time[i] == time_ref[i]);
 
-    BOOST_CHECK_CLOSE(cos[i], cos_ref[i], tolerance);
+    BOOST_TEST(cos[i] == cos_ref[i]);
 
-    BOOST_CHECK_CLOSE(sin[i], sin_ref[i], tolerance);
+    BOOST_TEST(sin[i] == sin_ref[i]);
   }
 }

--- a/tests/test_material_property.hh
+++ b/tests/test_material_property.hh
@@ -15,6 +15,8 @@
 
 #include <boost/property_tree/ptree.hpp>
 
+namespace tt = boost::test_tools;
+
 template <typename MemorySpaceType>
 void material_property()
 {
@@ -62,16 +64,16 @@ void material_property()
   {
     double const density =
         mat_prop.get_cell_value(cell, adamantine::StateProperty::density);
-    BOOST_CHECK(density == 1.);
+    BOOST_TEST(density == 1.);
     double const th_conduc_x = mat_prop.get_cell_value(
         cell, adamantine::StateProperty::thermal_conductivity_x);
-    BOOST_CHECK(th_conduc_x == 10.);
+    BOOST_TEST(th_conduc_x == 10.);
     double const th_conduc_z = mat_prop.get_cell_value(
         cell, adamantine::StateProperty::thermal_conductivity_z);
-    BOOST_CHECK(th_conduc_z == 10.);
+    BOOST_TEST(th_conduc_z == 10.);
     double const liquidus =
         mat_prop.get_cell_value(cell, adamantine::Property::liquidus);
-    BOOST_CHECK(liquidus == 100.);
+    BOOST_TEST(liquidus == 100.);
   }
 }
 
@@ -129,35 +131,35 @@ void ratios()
   {
     double powder_ratio =
         mat_prop.get_state_ratio(cell, adamantine::MaterialState::powder);
-    BOOST_CHECK(powder_ratio == 1.);
+    BOOST_TEST(powder_ratio == 1.);
     double solid_ratio =
         mat_prop.get_state_ratio(cell, adamantine::MaterialState::solid);
-    BOOST_CHECK(solid_ratio == 0.);
+    BOOST_TEST(solid_ratio == 0.);
     double liquid_ratio =
         mat_prop.get_state_ratio(cell, adamantine::MaterialState::liquid);
-    BOOST_CHECK(liquid_ratio == 0.);
+    BOOST_TEST(liquid_ratio == 0.);
 
     double const density =
         mat_prop.get_cell_value(cell, adamantine::StateProperty::density);
-    BOOST_CHECK(density == 1.);
+    BOOST_TEST(density == 1.);
     double const th_conduc_x = mat_prop.get_cell_value(
         cell, adamantine::StateProperty::thermal_conductivity_x);
-    BOOST_CHECK(th_conduc_x == 1.);
+    BOOST_TEST(th_conduc_x == 1.);
     double const th_conduc_z = mat_prop.get_cell_value(
         cell, adamantine::StateProperty::thermal_conductivity_z);
-    BOOST_CHECK(th_conduc_z == 1.);
+    BOOST_TEST(th_conduc_z == 1.);
     double const liquidus =
         mat_prop.get_cell_value(cell, adamantine::Property::liquidus);
-    BOOST_CHECK(liquidus == 100.);
+    BOOST_TEST(liquidus == 100.);
     double const solidus =
         mat_prop.get_cell_value(cell, adamantine::Property::solidus);
-    BOOST_CHECK(solidus == 50.);
+    BOOST_TEST(solidus == 50.);
     double const latent_heat =
         mat_prop.get_cell_value(cell, adamantine::Property::latent_heat);
-    BOOST_CHECK(latent_heat == 1000.);
+    BOOST_TEST(latent_heat == 1000.);
     double const specific_heat =
         mat_prop.get_cell_value(cell, adamantine::StateProperty::specific_heat);
-    BOOST_CHECK(specific_heat == 1.);
+    BOOST_TEST(specific_heat == 1.);
   }
 
   // Check the material properties of the liquid
@@ -173,35 +175,35 @@ void ratios()
   {
     double powder_ratio =
         mat_prop.get_state_ratio(cell, adamantine::MaterialState::powder);
-    BOOST_CHECK(powder_ratio == 0.);
+    BOOST_TEST(powder_ratio == 0.);
     double solid_ratio =
         mat_prop.get_state_ratio(cell, adamantine::MaterialState::solid);
-    BOOST_CHECK(solid_ratio == 0.);
+    BOOST_TEST(solid_ratio == 0.);
     double liquid_ratio =
         mat_prop.get_state_ratio(cell, adamantine::MaterialState::liquid);
-    BOOST_CHECK(liquid_ratio == 1.);
+    BOOST_TEST(liquid_ratio == 1.);
 
     double const density =
         mat_prop.get_cell_value(cell, adamantine::StateProperty::density);
-    BOOST_CHECK(density == 1.);
+    BOOST_TEST(density == 1.);
     double const th_conduc_x = mat_prop.get_cell_value(
         cell, adamantine::StateProperty::thermal_conductivity_x);
-    BOOST_CHECK(th_conduc_x == 20.);
+    BOOST_TEST(th_conduc_x == 20.);
     double const th_conduc_z = mat_prop.get_cell_value(
         cell, adamantine::StateProperty::thermal_conductivity_z);
-    BOOST_CHECK(th_conduc_z == 20.);
+    BOOST_TEST(th_conduc_z == 20.);
     double const liquidus =
         mat_prop.get_cell_value(cell, adamantine::Property::liquidus);
-    BOOST_CHECK(liquidus == 100.);
+    BOOST_TEST(liquidus == 100.);
     double const solidus =
         mat_prop.get_cell_value(cell, adamantine::Property::solidus);
-    BOOST_CHECK(solidus == 50.);
+    BOOST_TEST(solidus == 50.);
     double const latent_heat =
         mat_prop.get_cell_value(cell, adamantine::Property::latent_heat);
-    BOOST_CHECK(latent_heat == 1000.);
+    BOOST_TEST(latent_heat == 1000.);
     double const specific_heat =
         mat_prop.get_cell_value(cell, adamantine::StateProperty::specific_heat);
-    BOOST_CHECK(specific_heat == 20.);
+    BOOST_TEST(specific_heat == 20.);
   }
 
   // Check the material properties of the solid
@@ -211,35 +213,35 @@ void ratios()
   {
     double powder_ratio =
         mat_prop.get_state_ratio(cell, adamantine::MaterialState::powder);
-    BOOST_CHECK(powder_ratio == 0.);
+    BOOST_TEST(powder_ratio == 0.);
     double solid_ratio =
         mat_prop.get_state_ratio(cell, adamantine::MaterialState::solid);
-    BOOST_CHECK(solid_ratio == 1.);
+    BOOST_TEST(solid_ratio == 1.);
     double liquid_ratio =
         mat_prop.get_state_ratio(cell, adamantine::MaterialState::liquid);
-    BOOST_CHECK(liquid_ratio == 0.);
+    BOOST_TEST(liquid_ratio == 0.);
 
     double const density =
         mat_prop.get_cell_value(cell, adamantine::StateProperty::density);
-    BOOST_CHECK(density == 10.);
+    BOOST_TEST(density == 10.);
     double const th_conduc_x = mat_prop.get_cell_value(
         cell, adamantine::StateProperty::thermal_conductivity_x);
-    BOOST_CHECK(th_conduc_x == 10.);
+    BOOST_TEST(th_conduc_x == 10.);
     double const th_conduc_z = mat_prop.get_cell_value(
         cell, adamantine::StateProperty::thermal_conductivity_z);
-    BOOST_CHECK(th_conduc_z == 10.);
+    BOOST_TEST(th_conduc_z == 10.);
     double const liquidus =
         mat_prop.get_cell_value(cell, adamantine::Property::liquidus);
-    BOOST_CHECK(liquidus == 100.);
+    BOOST_TEST(liquidus == 100.);
     double const solidus =
         mat_prop.get_cell_value(cell, adamantine::Property::solidus);
-    BOOST_CHECK(solidus == 50.);
+    BOOST_TEST(solidus == 50.);
     double const latent_heat =
         mat_prop.get_cell_value(cell, adamantine::Property::latent_heat);
-    BOOST_CHECK(latent_heat == 1000.);
+    BOOST_TEST(latent_heat == 1000.);
     double const specific_heat =
         mat_prop.get_cell_value(cell, adamantine::StateProperty::specific_heat);
-    BOOST_CHECK(specific_heat == 10.);
+    BOOST_TEST(specific_heat == 10.);
   }
 }
 
@@ -312,45 +314,45 @@ void material_property_table()
   {
     if (n < 10)
     {
-      BOOST_CHECK_CLOSE(
-          mat_prop.get_cell_value(cell, adamantine::StateProperty::density), 1.,
-          tolerance);
-      BOOST_CHECK_CLOSE(
-          mat_prop.get_cell_value(
-              cell, adamantine::StateProperty::thermal_conductivity_x),
-          100., tolerance);
-      BOOST_CHECK_CLOSE(
-          mat_prop.get_cell_value(
-              cell, adamantine::StateProperty::thermal_conductivity_z),
-          100., tolerance);
+      BOOST_TEST(mat_prop.get_cell_value(
+                     cell, adamantine::StateProperty::density) == 1.,
+                 tt::tolerance(tolerance));
+      BOOST_TEST(mat_prop.get_cell_value(
+                     cell, adamantine::StateProperty::thermal_conductivity_x) ==
+                     100.,
+                 tt::tolerance(tolerance));
+      BOOST_TEST(mat_prop.get_cell_value(
+                     cell, adamantine::StateProperty::thermal_conductivity_z) ==
+                     100.,
+                 tt::tolerance(tolerance));
     }
     else if (n < 15)
     {
-      BOOST_CHECK_CLOSE(
-          mat_prop.get_cell_value(cell, adamantine::StateProperty::density),
-          1.75, tolerance);
-      BOOST_CHECK_CLOSE(
-          mat_prop.get_cell_value(
-              cell, adamantine::StateProperty::thermal_conductivity_x),
-          150., tolerance);
-      BOOST_CHECK_CLOSE(
-          mat_prop.get_cell_value(
-              cell, adamantine::StateProperty::thermal_conductivity_z),
-          150., tolerance);
+      BOOST_TEST(mat_prop.get_cell_value(
+                     cell, adamantine::StateProperty::density) == 1.75,
+                 tt::tolerance(tolerance));
+      BOOST_TEST(mat_prop.get_cell_value(
+                     cell, adamantine::StateProperty::thermal_conductivity_x) ==
+                     150.,
+                 tt::tolerance(tolerance));
+      BOOST_TEST(mat_prop.get_cell_value(
+                     cell, adamantine::StateProperty::thermal_conductivity_z) ==
+                     150.,
+                 tt::tolerance(tolerance));
     }
     else
     {
-      BOOST_CHECK_CLOSE(
-          mat_prop.get_cell_value(cell, adamantine::StateProperty::density), 2.,
-          tolerance);
-      BOOST_CHECK_CLOSE(
-          mat_prop.get_cell_value(
-              cell, adamantine::StateProperty::thermal_conductivity_x),
-          162.5, tolerance);
-      BOOST_CHECK_CLOSE(
-          mat_prop.get_cell_value(
-              cell, adamantine::StateProperty::thermal_conductivity_z),
-          162.5, tolerance);
+      BOOST_TEST(mat_prop.get_cell_value(
+                     cell, adamantine::StateProperty::density) == 2.,
+                 tt::tolerance(tolerance));
+      BOOST_TEST(mat_prop.get_cell_value(
+                     cell, adamantine::StateProperty::thermal_conductivity_x) ==
+                     162.5,
+                 tt::tolerance(tolerance));
+      BOOST_TEST(mat_prop.get_cell_value(
+                     cell, adamantine::StateProperty::thermal_conductivity_z) ==
+                     162.5,
+                 tt::tolerance(tolerance));
     }
     ++n;
   }
@@ -423,45 +425,45 @@ void material_property_polynomials()
   {
     if (n < 10)
     {
-      BOOST_CHECK_CLOSE(
-          mat_prop.get_cell_value(cell, adamantine::StateProperty::density),
-          15., tolerance);
-      BOOST_CHECK_CLOSE(
-          mat_prop.get_cell_value(
-              cell, adamantine::StateProperty::thermal_conductivity_x),
-          465., tolerance);
-      BOOST_CHECK_CLOSE(
-          mat_prop.get_cell_value(
-              cell, adamantine::StateProperty::thermal_conductivity_z),
-          465., tolerance);
+      BOOST_TEST(mat_prop.get_cell_value(
+                     cell, adamantine::StateProperty::density) == 15.,
+                 tt::tolerance(tolerance));
+      BOOST_TEST(mat_prop.get_cell_value(
+                     cell, adamantine::StateProperty::thermal_conductivity_x) ==
+                     465.,
+                 tt::tolerance(tolerance));
+      BOOST_TEST(mat_prop.get_cell_value(
+                     cell, adamantine::StateProperty::thermal_conductivity_z) ==
+                     465.,
+                 tt::tolerance(tolerance));
     }
     else if (n < 15)
     {
-      BOOST_CHECK_CLOSE(
-          mat_prop.get_cell_value(cell, adamantine::StateProperty::density),
-          706., tolerance);
-      BOOST_CHECK_CLOSE(
-          mat_prop.get_cell_value(
-              cell, adamantine::StateProperty::thermal_conductivity_x),
-          681001., tolerance);
-      BOOST_CHECK_CLOSE(
-          mat_prop.get_cell_value(
-              cell, adamantine::StateProperty::thermal_conductivity_z),
-          681001., tolerance);
+      BOOST_TEST(mat_prop.get_cell_value(
+                     cell, adamantine::StateProperty::density) == 706.,
+                 tt::tolerance(tolerance));
+      BOOST_TEST(mat_prop.get_cell_value(
+                     cell, adamantine::StateProperty::thermal_conductivity_x) ==
+                     681001.,
+                 tt::tolerance(tolerance));
+      BOOST_TEST(mat_prop.get_cell_value(
+                     cell, adamantine::StateProperty::thermal_conductivity_z) ==
+                     681001.,
+                 tt::tolerance(tolerance));
     }
     else
     {
-      BOOST_CHECK_CLOSE(
-          mat_prop.get_cell_value(cell, adamantine::StateProperty::density),
-          720., tolerance);
-      BOOST_CHECK_CLOSE(
-          mat_prop.get_cell_value(
-              cell, adamantine::StateProperty::thermal_conductivity_x),
-          45280., tolerance);
-      BOOST_CHECK_CLOSE(
-          mat_prop.get_cell_value(
-              cell, adamantine::StateProperty::thermal_conductivity_z),
-          45280., tolerance);
+      BOOST_TEST(mat_prop.get_cell_value(
+                     cell, adamantine::StateProperty::density) == 720.,
+                 tt::tolerance(tolerance));
+      BOOST_TEST(mat_prop.get_cell_value(
+                     cell, adamantine::StateProperty::thermal_conductivity_x) ==
+                     45280.,
+                 tt::tolerance(tolerance));
+      BOOST_TEST(mat_prop.get_cell_value(
+                     cell, adamantine::StateProperty::thermal_conductivity_z) ==
+                     45280.,
+                 tt::tolerance(tolerance));
     }
     ++n;
   }

--- a/tests/test_mechanical_operator.cc
+++ b/tests/test_mechanical_operator.cc
@@ -25,6 +25,8 @@
 
 #include "main.cc"
 
+namespace utf = boost::unit_test;
+
 template <int dim>
 void right_hand_side(const std::vector<dealii::Point<dim>> &points,
                      std::vector<dealii::Tensor<1, dim>> &values)
@@ -48,7 +50,7 @@ void right_hand_side(const std::vector<dealii::Point<dim>> &points,
   }
 }
 
-BOOST_AUTO_TEST_CASE(elastostatic)
+BOOST_AUTO_TEST_CASE(elastostatic, *utf::tolerance(1e-12))
 {
   MPI_Comm communicator = MPI_COMM_WORLD;
   int constexpr dim = 3;
@@ -195,7 +197,6 @@ BOOST_AUTO_TEST_CASE(elastostatic)
     }
   }
   // Compare the results
-  double const tolerance = 1e-12;
   unsigned int const n_dofs = system_matrix.m();
   dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> src(
       n_dofs);
@@ -210,6 +211,6 @@ BOOST_AUTO_TEST_CASE(elastostatic)
     mechanical_operator.vmult(dst_1, src);
     system_matrix.vmult(dst_2, src);
     for (unsigned int j = 0; j < n_dofs; ++j)
-      BOOST_CHECK_SMALL(dst_1[j] - dst_2[j], tolerance);
+      BOOST_TEST(dst_1[j] - dst_2[j] == 0.);
   }
 }

--- a/tests/test_newton_solver.cc
+++ b/tests/test_newton_solver.cc
@@ -11,6 +11,8 @@
 
 #include "main.cc"
 
+namespace utf = boost::unit_test;
+
 dealii::LA::distributed::Vector<double>
 compute_residual(dealii::LA::distributed::Vector<double> const &x)
 {
@@ -31,7 +33,7 @@ compute_inv_jacobian(dealii::LA::distributed::Vector<double> const &x)
   return inv_jacobian;
 }
 
-BOOST_AUTO_TEST_CASE(newton_solver)
+BOOST_AUTO_TEST_CASE(newton_solver, *utf::tolerance(1e-5))
 {
   dealii::LA::distributed::Vector<double> src(2);
   src[0] = 2.;
@@ -40,7 +42,6 @@ BOOST_AUTO_TEST_CASE(newton_solver)
   adamantine::NewtonSolver newton_solver(10, 1e-7);
   newton_solver.solve(&compute_residual, &compute_inv_jacobian, src);
 
-  double const tolerance = 1e-5;
-  BOOST_CHECK_CLOSE(1., src[0], tolerance);
-  BOOST_CHECK_CLOSE(1., src[1], tolerance);
+  BOOST_TEST(1. == src[0]);
+  BOOST_TEST(1. == src[1]);
 }

--- a/tests/test_post_processor.cc
+++ b/tests/test_post_processor.cc
@@ -115,13 +115,13 @@ BOOST_AUTO_TEST_CASE(post_processor)
   post_processor.output_pvd();
 
   // Check that the files exist
-  BOOST_CHECK(boost::filesystem::exists("test.pvd"));
-  BOOST_CHECK(boost::filesystem::exists("test.01.000000.pvtu"));
-  BOOST_CHECK(boost::filesystem::exists("test.01.000001.pvtu"));
-  BOOST_CHECK(boost::filesystem::exists("test.01.000002.pvtu"));
-  BOOST_CHECK(boost::filesystem::exists("test.01.000000.000000.vtu"));
-  BOOST_CHECK(boost::filesystem::exists("test.01.000001.000000.vtu"));
-  BOOST_CHECK(boost::filesystem::exists("test.01.000002.000000.vtu"));
+  BOOST_TEST(boost::filesystem::exists("test.pvd"));
+  BOOST_TEST(boost::filesystem::exists("test.01.000000.pvtu"));
+  BOOST_TEST(boost::filesystem::exists("test.01.000001.pvtu"));
+  BOOST_TEST(boost::filesystem::exists("test.01.000002.pvtu"));
+  BOOST_TEST(boost::filesystem::exists("test.01.000000.000000.vtu"));
+  BOOST_TEST(boost::filesystem::exists("test.01.000001.000000.vtu"));
+  BOOST_TEST(boost::filesystem::exists("test.01.000002.000000.vtu"));
 
   // Delete the files
   std::remove("test.pvd");

--- a/tests/test_scan_path.cc
+++ b/tests/test_scan_path.cc
@@ -11,6 +11,8 @@
 
 #include "main.cc"
 
+namespace utf = boost::unit_test;
+
 namespace adamantine
 {
 
@@ -29,7 +31,7 @@ public:
   };
 };
 
-BOOST_AUTO_TEST_CASE(scan_path)
+BOOST_AUTO_TEST_CASE(scan_path, *utf::tolerance(1e-12))
 {
   ScanPathTester tester;
 
@@ -37,73 +39,65 @@ BOOST_AUTO_TEST_CASE(scan_path)
   std::vector<ScanPathSegment> segment_format_list =
       tester.get_segment_format_list();
 
-  double const tolerance = 1e-12;
+  BOOST_TEST(segment_format_list.size() == 2);
 
-  BOOST_CHECK(segment_format_list.size() == 2);
+  BOOST_TEST(segment_format_list[0].end_time == 1.0e-6);
+  BOOST_TEST(segment_format_list[0].end_point[0] == 0.0);
+  BOOST_TEST(segment_format_list[0].end_point[1] == 0.0);
+  BOOST_TEST(segment_format_list[0].power_modifier == 0.0);
 
-  BOOST_CHECK_CLOSE(segment_format_list[0].end_time, 1.0e-6, tolerance);
-  BOOST_CHECK_CLOSE(segment_format_list[0].end_point[0], 0.0, tolerance);
-  BOOST_CHECK_CLOSE(segment_format_list[0].end_point[1], 0.0, tolerance);
-  BOOST_CHECK_CLOSE(segment_format_list[0].power_modifier, 0.0, tolerance);
-
-  BOOST_CHECK_CLOSE(segment_format_list[1].end_time, 1.0e-6 + 0.002 / 0.8,
-                    tolerance);
-  BOOST_CHECK_CLOSE(segment_format_list[1].end_point[0], 0.002, tolerance);
-  BOOST_CHECK_CLOSE(segment_format_list[1].end_point[1], 0.0, tolerance);
-  BOOST_CHECK_CLOSE(segment_format_list[1].power_modifier, 1.0, tolerance);
+  BOOST_TEST(segment_format_list[1].end_time == (1.0e-6 + 0.002 / 0.8));
+  BOOST_TEST(segment_format_list[1].end_point[0] == 0.002);
+  BOOST_TEST(segment_format_list[1].end_point[1] == 0.0);
+  BOOST_TEST(segment_format_list[1].power_modifier == 1.0);
 
   // Test the segments from a ScanPathFileFormat::event_series file
   std::vector<ScanPathSegment> segment_event_series_list =
       tester.get_event_series_format_list();
 
-  BOOST_CHECK(segment_event_series_list.size() == 3);
+  BOOST_TEST(segment_event_series_list.size() == 3);
 
-  BOOST_CHECK_CLOSE(segment_event_series_list[0].end_time, 0.1, tolerance);
-  BOOST_CHECK_CLOSE(segment_event_series_list[0].end_point[0], 0.0, tolerance);
-  BOOST_CHECK_CLOSE(segment_event_series_list[0].end_point[1], 0.0, tolerance);
-  BOOST_CHECK_CLOSE(segment_event_series_list[0].power_modifier, 0.0,
-                    tolerance);
+  BOOST_TEST(segment_event_series_list[0].end_time == 0.1);
+  BOOST_TEST(segment_event_series_list[0].end_point[0] == 0.0);
+  BOOST_TEST(segment_event_series_list[0].end_point[1] == 0.0);
+  BOOST_TEST(segment_event_series_list[0].power_modifier == 0.0);
 
-  BOOST_CHECK_CLOSE(segment_event_series_list[1].end_time, 1.0, tolerance);
-  BOOST_CHECK_CLOSE(segment_event_series_list[1].end_point[0], 0.5, tolerance);
-  BOOST_CHECK_CLOSE(segment_event_series_list[1].end_point[1], 0.0, tolerance);
-  BOOST_CHECK_CLOSE(segment_event_series_list[1].power_modifier, 1.0,
-                    tolerance);
+  BOOST_TEST(segment_event_series_list[1].end_time == 1.0);
+  BOOST_TEST(segment_event_series_list[1].end_point[0] == 0.5);
+  BOOST_TEST(segment_event_series_list[1].end_point[1] == 0.0);
+  BOOST_TEST(segment_event_series_list[1].power_modifier == 1.0);
 
-  BOOST_CHECK_CLOSE(segment_event_series_list[2].end_time, 2.0, tolerance);
-  BOOST_CHECK_CLOSE(segment_event_series_list[2].end_point[0], 0.5, tolerance);
-  BOOST_CHECK_CLOSE(segment_event_series_list[2].end_point[1], 0.5, tolerance);
-  BOOST_CHECK_CLOSE(segment_event_series_list[2].power_modifier, 0.5,
-                    tolerance);
+  BOOST_TEST(segment_event_series_list[2].end_time == 2.0);
+  BOOST_TEST(segment_event_series_list[2].end_point[0] == 0.5);
+  BOOST_TEST(segment_event_series_list[2].end_point[1] == 0.5);
+  BOOST_TEST(segment_event_series_list[2].power_modifier == 0.5);
 }
 
-BOOST_AUTO_TEST_CASE(scan_path_location)
+BOOST_AUTO_TEST_CASE(scan_path_location, *utf::tolerance(1e-10))
 {
-  double const tolerance = 1e-10;
-
   ScanPath scan_path("scan_path.txt", "segment");
   double time = 1.0e-7;
   dealii::Point<3> p1 = scan_path.value(time);
 
-  BOOST_CHECK_CLOSE(p1[0], 0.0, tolerance);
-  BOOST_CHECK_CLOSE(p1[1], 0.0, tolerance);
-  BOOST_CHECK_CLOSE(p1[2], 0.0, tolerance);
+  BOOST_TEST(p1[0] == 0.0);
+  BOOST_TEST(p1[1] == 0.0);
+  BOOST_TEST(p1[2] == 0.0);
 
   time = 0.001001;
 
   dealii::Point<3> p2 = scan_path.value(time);
 
-  BOOST_CHECK_CLOSE(p2[0], 8.0e-4, tolerance);
-  BOOST_CHECK_CLOSE(p2[1], 0.0, tolerance);
-  BOOST_CHECK_CLOSE(p2[2], 0.0, tolerance);
+  BOOST_TEST(p2[0] == 8.0e-4);
+  BOOST_TEST(p2[1] == 0.0);
+  BOOST_TEST(p2[2] == 0.0);
 
   time = 100.0;
   dealii::Point<3> p3 = scan_path.value(time);
-  BOOST_CHECK_CLOSE(p3[0], std::numeric_limits<double>::lowest(), tolerance);
-  BOOST_CHECK_CLOSE(p3[1], std::numeric_limits<double>::lowest(), tolerance);
-  BOOST_CHECK_CLOSE(p3[2], std::numeric_limits<double>::lowest(), tolerance);
+  BOOST_TEST(p3[0] == std::numeric_limits<double>::lowest());
+  BOOST_TEST(p3[1] == std::numeric_limits<double>::lowest());
+  BOOST_TEST(p3[2] == std::numeric_limits<double>::lowest());
   double power = scan_path.get_power_modifier(time);
-  BOOST_CHECK_CLOSE(power, 0.0, tolerance);
+  BOOST_TEST(power == 0.0);
 }
 
 } // namespace adamantine

--- a/tests/test_thermal_physics.hh
+++ b/tests/test_thermal_physics.hh
@@ -10,6 +10,8 @@
 
 #include <deal.II/base/quadrature_lib.h>
 
+namespace tt = boost::test_tools;
+
 template <typename MemorySpaceType>
 void thermal_2d(boost::property_tree::ptree &database, double time_step)
 {
@@ -70,11 +72,11 @@ void thermal_2d(boost::property_tree::ptree &database, double time_step)
   }
 
   double const tolerance = 1e-3;
-  BOOST_CHECK(time == 0.1);
-  BOOST_CHECK_CLOSE(solution.l2_norm(), 0.291705, tolerance);
+  BOOST_TEST(time == 0.1, tt::tolerance(tolerance));
+  BOOST_TEST(solution.l2_norm() == 0.291705, tt::tolerance(tolerance));
 
   physics.initialize_dof_vector(1000., solution);
-  BOOST_CHECK(solution.l1_norm() == 1000. * solution.size());
+  BOOST_TEST(solution.l1_norm() == 1000. * solution.size());
 }
 
 template <typename MemorySpaceType>
@@ -139,15 +141,15 @@ void thermal_2d_manufactured_solution()
 
   double const tolerance = 1e-5;
 
-  BOOST_CHECK(time == 0.1);
+  BOOST_TEST(time == 0.1);
 
-  BOOST_CHECK_SMALL(std::abs(physics.get_current_source_height() - 0.0),
-                    tolerance);
+  BOOST_TEST(physics.get_current_source_height() == 0.0,
+             tt::tolerance(tolerance));
 
   if (std::is_same<MemorySpaceType, dealii::MemorySpace::Host>::value)
   {
     for (unsigned int i = 0; i < solution.locally_owned_size(); ++i)
-      BOOST_CHECK_CLOSE(solution.local_element(i), 0.1, tolerance);
+      BOOST_TEST(solution.local_element(i) == 0.1, tt::tolerance(tolerance));
   }
   else
   {
@@ -155,7 +157,7 @@ void thermal_2d_manufactured_solution()
         solution_host(solution.get_partitioner());
     solution_host.import(solution, dealii::VectorOperation::insert);
     for (unsigned int i = 0; i < solution.size(); ++i)
-      BOOST_CHECK_CLOSE(solution_host[i], 0.1, tolerance);
+      BOOST_TEST(solution_host[i] == 0.1, tt::tolerance(tolerance));
   }
 }
 
@@ -215,7 +217,7 @@ void initial_temperature()
   dealii::LA::distributed::Vector<double, MemorySpaceType> solution;
   physics.initialize_dof_vector(1000., solution);
   physics.get_state_from_material_properties();
-  BOOST_CHECK(solution.l1_norm() == 1000. * solution.size());
+  BOOST_TEST(solution.l1_norm() == 1000. * solution.size());
 }
 
 template <typename MemorySpaceType>
@@ -308,8 +310,9 @@ void energy_conservation()
   }
 
   double constexpr tolerance = 1e-9;
-  BOOST_CHECK_CLOSE(solution.mean_value(), final_temperature, tolerance);
-  BOOST_CHECK_CLOSE(min, max, tolerance);
+  BOOST_TEST(solution.mean_value() == final_temperature,
+             tt::tolerance(tolerance));
+  BOOST_TEST(min == max, tt::tolerance(tolerance));
 }
 
 template <typename MemorySpaceType>
@@ -403,8 +406,10 @@ void radiation_bcs()
     }
   }
 
-  BOOST_CHECK(min >= 10. && min <= 20.);
-  BOOST_CHECK(max > 10. && max <= 20.);
+  BOOST_TEST(min >= 10.);
+  BOOST_TEST(min <= 20.);
+  BOOST_TEST(max > 10.);
+  BOOST_TEST(max <= 20.);
 }
 
 template <typename MemorySpaceType>
@@ -498,6 +503,8 @@ void convection_bcs()
     }
   }
 
-  BOOST_CHECK(min >= 10. && min <= 20.);
-  BOOST_CHECK(max > 10. && max <= 20.);
+  BOOST_TEST(min >= 10.);
+  BOOST_TEST(min <= 20.);
+  BOOST_TEST(max > 10.);
+  BOOST_TEST(max <= 20.);
 }


### PR DESCRIPTION
`BOOST_TEST` is the modern version of `BOOST_CHECK`. It has extra capabilities and most importantly the error message is better. I didn't use it before because there was a problem with CUDA but it is supposed to be fixed. I made the change on a computer without a GPU so let's see if the CI passes.