### PR TITLE
Refactor PostProcessor to output result of mechanical simulation

### DIFF
--- a/source/PostProcessor.cc
+++ b/source/PostProcessor.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 - 2021, the adamantine authors.
+/* Copyright (c) 2016 - 2022, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -16,12 +16,54 @@
 namespace adamantine
 {
 template <int dim>
+StrainPostProcessor<dim>::StrainPostProcessor()
+    : dealii::DataPostprocessorTensor<dim>("strain", dealii::update_gradients)
+{
+}
+
+template <int dim>
+void StrainPostProcessor<dim>::evaluate_vector_field(
+    const dealii::DataPostprocessorInputs::Vector<dim> &displacement_data,
+    std::vector<dealii::Vector<double>> &strain) const
+{
+  for (unsigned int i = 0; i < displacement_data.solution_gradients.size(); ++i)
+  {
+    for (unsigned int j = 0; j < dim; ++j)
+    {
+      for (unsigned int k = 0; k < dim; ++k)
+      {
+        // strain = (\nabla u + (\nabla u)^T)/2
+        strain[i][dealii::Tensor<2, dim>::component_to_unrolled_index(
+            dealii::TableIndices<2>(j, k))] =
+            (displacement_data.solution_gradients[i][j][k] +
+             displacement_data.solution_gradients[i][k][j]) /
+            2.;
+      }
+    }
+  }
+}
+
+template <int dim>
 PostProcessor<dim>::PostProcessor(MPI_Comm const &communicator,
                                   boost::property_tree::ptree const &database,
                                   dealii::DoFHandler<dim> &dof_handler,
                                   int ensemble_member_index)
-    : _communicator(communicator), _dof_handler(dof_handler)
+    : _communicator(communicator)
 {
+  // This is internal data we embed in the database that is intended to be set
+  // in the application (not by the user in the input file)
+  _thermal_output = database.get("thermal_output", false);
+  _mechanical_output = database.get("mechanical_output", false);
+  ASSERT(_thermal_output != _mechanical_output, "Internal error");
+  if (_thermal_output)
+  {
+    _thermal_dof_handler = &dof_handler;
+  }
+  else
+  {
+    _mechanical_dof_handler = &dof_handler;
+  }
+
   // PropertyTreeInput post_processor.file_name
   _filename_prefix = database.get<std::string>("filename_prefix");
   if (ensemble_member_index >= 0)
@@ -32,23 +74,132 @@ PostProcessor<dim>::PostProcessor(MPI_Comm const &communicator,
 }
 
 template <int dim>
-void PostProcessor<dim>::output_pvtu(
+PostProcessor<dim>::PostProcessor(
+    MPI_Comm const &communicator, boost::property_tree::ptree const &database,
+    dealii::DoFHandler<dim> &thermal_dof_handler,
+    dealii::DoFHandler<dim> &mechanical_dof_handler, int ensemble_member_index)
+    : _communicator(communicator)
+{
+  _thermal_output = database.get("thermal_output", false);
+  _mechanical_output = database.get("mechanical_output", false);
+  ASSERT(_thermal_output, "Internal error");
+  ASSERT(_mechanical_output, "Internal error");
+  _thermal_dof_handler = &thermal_dof_handler;
+  _mechanical_dof_handler = &mechanical_dof_handler;
+
+  // PropertyTreeInput post_processor.file_name
+  _filename_prefix = database.get<std::string>("filename_prefix");
+  if (ensemble_member_index >= 0)
+  {
+    _filename_prefix =
+        _filename_prefix + "_m" + std::to_string(ensemble_member_index);
+  }
+}
+
+template <int dim>
+void PostProcessor<dim>::write_thermal_output(
     unsigned int cycle, unsigned int time_step, double time,
-    dealii::LA::distributed::Vector<double> const &solution,
+    dealii::LA::distributed::Vector<double> const &temperature,
     MemoryBlockView<double, dealii::MemorySpace::Host> state,
-    std::unordered_map<dealii::types::global_dof_index, unsigned int> dofs_map,
+    std::unordered_map<dealii::types::global_dof_index, unsigned int> const
+        &dofs_map,
     dealii::DoFHandler<dim> const &material_dof_handler)
 {
-  // Add the DoFHandler and the temperature.
+  ASSERT(_thermal_dof_handler != nullptr, "Internal Error");
   _data_out.clear();
-  _data_out.attach_dof_handler(_dof_handler);
-  solution.update_ghost_values();
-  _data_out.add_data_vector(solution, "temperature");
+  thermal_dataout(temperature);
+  material_dataout(state, dofs_map, material_dof_handler);
+  subdomain_dataout();
+  write_pvtu(cycle, time_step, time);
+}
 
-  // Add MaterialState ratio. We need to copy the data because state is attached
-  // to a different DoFHandler.
+template <int dim>
+void PostProcessor<dim>::write_mechanical_output(
+    unsigned int cycle, unsigned int time_step, double time,
+    dealii::LA::distributed::Vector<double> const &displacement,
+    MemoryBlockView<double, dealii::MemorySpace::Host> state,
+    std::unordered_map<dealii::types::global_dof_index, unsigned int> const
+        &dofs_map,
+    dealii::DoFHandler<dim> const &material_dof_handler)
+{
+  ASSERT(_mechanical_dof_handler != nullptr, "Internal Error");
+  _data_out.clear();
+  // We need the StrainPostProcessor to live until write_pvtu is done
+  StrainPostProcessor<dim> strain;
+  mechanical_dataout(displacement, strain);
+  material_dataout(state, dofs_map, material_dof_handler);
+  subdomain_dataout();
+  write_pvtu(cycle, time_step, time);
+}
+
+template <int dim>
+void PostProcessor<dim>::write_output(
+    unsigned int cycle, unsigned int time_step, double time,
+    dealii::LA::distributed::Vector<double> const &temperature,
+    dealii::LA::distributed::Vector<double> const &displacement,
+    MemoryBlockView<double, dealii::MemorySpace::Host> state,
+    std::unordered_map<dealii::types::global_dof_index, unsigned int> const
+        &dofs_map,
+    dealii::DoFHandler<dim> const &material_dof_handler)
+{
+  ASSERT(_thermal_dof_handler != nullptr, "Internal Error");
+  ASSERT(_mechanical_dof_handler != nullptr, "Internal Error");
+  _data_out.clear();
+  thermal_dataout(temperature);
+  // We need the StrainPostProcessor to live until write_pvtu is done
+  StrainPostProcessor<dim> strain;
+  mechanical_dataout(displacement, strain);
+  material_dataout(state, dofs_map, material_dof_handler);
+  subdomain_dataout();
+  write_pvtu(cycle, time_step, time);
+}
+
+template <int dim>
+void PostProcessor<dim>::write_pvd() const
+{
+  std::ofstream output(_filename_prefix + ".pvd");
+  dealii::DataOutBase::write_pvd_record(output, _times_filenames);
+}
+
+template <int dim>
+void PostProcessor<dim>::thermal_dataout(
+    dealii::LA::distributed::Vector<double> const &temperature)
+{
+  temperature.update_ghost_values();
+  _data_out.add_data_vector(*_thermal_dof_handler, temperature, "temperature");
+}
+
+template <int dim>
+void PostProcessor<dim>::mechanical_dataout(
+    dealii::LA::distributed::Vector<double> const &displacement,
+    StrainPostProcessor<dim> const &strain)
+{
+  // Add the displacement to the output
+  displacement.update_ghost_values();
+  std::vector<std::string> displacement_names(dim, "displacement");
+  std::vector<dealii::DataComponentInterpretation::DataComponentInterpretation>
+      displacement_data_component_interpretation(
+          dim,
+          dealii::DataComponentInterpretation::component_is_part_of_vector);
+  _data_out.add_data_vector(*_mechanical_dof_handler, displacement,
+                            displacement_names,
+                            displacement_data_component_interpretation);
+
+  // Add the strain tensor to the output
+  _data_out.add_data_vector(*_mechanical_dof_handler, displacement, strain);
+
+  // TODO add the stress tensor
+}
+
+template <int dim>
+void PostProcessor<dim>::material_dataout(
+    MemoryBlockView<double, dealii::MemorySpace::Host> state,
+    std::unordered_map<dealii::types::global_dof_index, unsigned int> const
+        &dofs_map,
+    dealii::DoFHandler<dim> const &material_dof_handler)
+{
   unsigned int const n_active_cells =
-      _dof_handler.get_triangulation().n_active_cells();
+      material_dof_handler.get_triangulation().n_active_cells();
   dealii::Vector<double> powder(n_active_cells);
   dealii::Vector<double> liquid(n_active_cells);
   dealii::Vector<double> solid(n_active_cells);
@@ -74,16 +225,31 @@ void PostProcessor<dim>::output_pvtu(
   _data_out.add_data_vector(powder, "powder");
   _data_out.add_data_vector(liquid, "liquid");
   _data_out.add_data_vector(solid, "solid");
+}
 
-  // Add the subdomain IDs.
+template <int dim>
+void PostProcessor<dim>::subdomain_dataout()
+{
+  dealii::DoFHandler<dim> *dof_handler =
+      (_thermal_dof_handler) ? _thermal_dof_handler : _mechanical_dof_handler;
+  unsigned int const n_active_cells =
+      dof_handler->get_triangulation().n_active_cells();
   dealii::types::subdomain_id subdomain_id =
-      _dof_handler.get_triangulation().locally_owned_subdomain();
+      dof_handler->get_triangulation().locally_owned_subdomain();
   dealii::Vector<float> subdomain(n_active_cells);
   for (unsigned int i = 0; i < subdomain.size(); ++i)
     subdomain[i] = subdomain_id;
   _data_out.add_data_vector(subdomain, "subdomain");
+}
 
-  // Output the data.
+template <int dim>
+void PostProcessor<dim>::write_pvtu(unsigned int cycle, unsigned int time_step,
+                                    double time)
+{
+  dealii::DoFHandler<dim> *dof_handler =
+      (_thermal_dof_handler) ? _thermal_dof_handler : _mechanical_dof_handler;
+  dealii::types::subdomain_id subdomain_id =
+      dof_handler->get_triangulation().locally_owned_subdomain();
   _data_out.build_patches();
   std::string local_filename =
       _filename_prefix + "." + dealii::Utilities::int_to_string(cycle, 2) +
@@ -94,7 +260,6 @@ void PostProcessor<dim>::output_pvtu(
   _data_out.set_flags(flags);
   _data_out.write_vtu(output);
 
-  // Output the pvtu record.
   unsigned int rank = dealii::Utilities::MPI::this_mpi_process(_communicator);
   if (rank == 0)
   {
@@ -120,14 +285,6 @@ void PostProcessor<dim>::output_pvtu(
         std::pair<double, std::string>(time, pvtu_filename));
   }
 }
-
-template <int dim>
-void PostProcessor<dim>::output_pvd()
-{
-  std::ofstream output(_filename_prefix + ".pvd");
-  dealii::DataOutBase::write_pvd_record(output, _times_filenames);
-}
-
 } // namespace adamantine
 
 INSTANTIATE_DIM(PostProcessor)

--- a/tests/test_integration_2d.cc
+++ b/tests/test_integration_2d.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 - 2021, the adamantine authors.
+/* Copyright (c) 2016 - 2022, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -39,9 +39,7 @@ BOOST_AUTO_TEST_CASE(integration_2D, *utf::tolerance(0.1))
     gold_file >> gold_value;
     BOOST_TEST(result.local_element(i) == gold_value);
   }
-} // namespace
-  // boost::unit_testBOOST_AUTO_TEST_CASE(integration_2D,*utf::tolerance(0.1))
-  // boost::unit_testBOOST_AUTO_TEST_CASE(integration_2D,*utf::tolerance(0.1))
+}
 
 BOOST_AUTO_TEST_CASE(integration_2D_ensemble, *utf::tolerance(0.1))
 {

--- a/tests/test_post_processor.cc
+++ b/tests/test_post_processor.cc
@@ -10,17 +10,21 @@
 #include <Geometry.hh>
 #include <GoldakHeatSource.hh>
 #include <MaterialProperty.hh>
+#include <MechanicalOperator.hh>
 #include <PostProcessor.hh>
 #include <ThermalOperator.hh>
 
+#include <deal.II/dofs/dof_tools.h>
 #include <deal.II/fe/fe_nothing.h>
 #include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/numerics/vector_tools.h>
 
 #include <boost/filesystem.hpp>
 
 #include "main.cc"
 
-BOOST_AUTO_TEST_CASE(post_processor)
+BOOST_AUTO_TEST_CASE(thermal_post_processor)
 {
   MPI_Comm communicator = MPI_COMM_WORLD;
 
@@ -94,6 +98,7 @@ BOOST_AUTO_TEST_CASE(post_processor)
   // Create the PostProcessor
   boost::property_tree::ptree post_processor_database;
   post_processor_database.put("filename_prefix", "test");
+  post_processor_database.put("thermal_output", true);
   adamantine::PostProcessor<2> post_processor(
       communicator, post_processor_database, dof_handler);
   dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> src;
@@ -103,16 +108,121 @@ BOOST_AUTO_TEST_CASE(post_processor)
   for (unsigned int i = 0; i < src.size(); ++i)
     src[i] = 1.;
 
-  post_processor.output_pvtu(1, 0, 0., src, mat_properties->get_state(),
-                             mat_properties->get_dofs_map(),
-                             mat_properties->get_dof_handler());
-  post_processor.output_pvtu(1, 1, 0.1, src, mat_properties->get_state(),
-                             mat_properties->get_dofs_map(),
-                             mat_properties->get_dof_handler());
-  post_processor.output_pvtu(1, 2, 0.2, src, mat_properties->get_state(),
-                             mat_properties->get_dofs_map(),
-                             mat_properties->get_dof_handler());
-  post_processor.output_pvd();
+  post_processor.write_thermal_output(
+      1, 0, 0., src, mat_properties->get_state(),
+      mat_properties->get_dofs_map(), mat_properties->get_dof_handler());
+  post_processor.write_thermal_output(
+      1, 1, 0.1, src, mat_properties->get_state(),
+      mat_properties->get_dofs_map(), mat_properties->get_dof_handler());
+  post_processor.write_thermal_output(
+      1, 2, 0.2, src, mat_properties->get_state(),
+      mat_properties->get_dofs_map(), mat_properties->get_dof_handler());
+  post_processor.write_pvd();
+
+  // Check that the files exist
+  BOOST_CHECK(boost::filesystem::exists("test.pvd"));
+  BOOST_CHECK(boost::filesystem::exists("test.01.000000.pvtu"));
+  BOOST_CHECK(boost::filesystem::exists("test.01.000001.pvtu"));
+  BOOST_CHECK(boost::filesystem::exists("test.01.000002.pvtu"));
+  BOOST_CHECK(boost::filesystem::exists("test.01.000000.000000.vtu"));
+  BOOST_CHECK(boost::filesystem::exists("test.01.000001.000000.vtu"));
+  BOOST_CHECK(boost::filesystem::exists("test.01.000002.000000.vtu"));
+
+  // Delete the files
+  std::remove("test.pvd");
+  std::remove("test.01.000000.pvtu");
+  std::remove("test.01.000001.pvtu");
+  std::remove("test.01.000002.pvtu");
+  std::remove("test.01.000000.000000.vtu");
+  std::remove("test.01.000001.000000.vtu");
+  std::remove("test.01.000002.000000.vtu");
+}
+
+#ifdef ADAMANTINE_WITH_DEALII_WEAK_FORMS
+BOOST_AUTO_TEST_CASE(mechanical_post_processor)
+{
+  MPI_Comm communicator = MPI_COMM_WORLD;
+  int constexpr dim = 3;
+
+  // Create the Geometry
+  boost::property_tree::ptree geometry_database;
+  geometry_database.put("import_mesh", false);
+  geometry_database.put("length", 6);
+  geometry_database.put("length_divisions", 3);
+  geometry_database.put("height", 6);
+  geometry_database.put("height_divisions", 3);
+  geometry_database.put("width", 6);
+  geometry_database.put("width_divisions", 3);
+  adamantine::Geometry<dim> geometry(communicator, geometry_database);
+  // Create the DoFHandler
+  dealii::hp::FECollection<dim> fe_collection;
+  fe_collection.push_back(dealii::FESystem<dim>(dealii::FE_Q<dim>(2) ^ dim));
+  fe_collection.push_back(
+      dealii::FESystem<dim>(dealii::FE_Nothing<dim>() ^ dim));
+  dealii::DoFHandler<dim> dof_handler(geometry.get_triangulation());
+  dof_handler.distribute_dofs(fe_collection);
+  dealii::AffineConstraints<double> affine_constraints;
+  dealii::DoFTools::make_hanging_node_constraints(dof_handler,
+                                                  affine_constraints);
+  dealii::VectorTools::interpolate_boundary_values(
+      dof_handler, 0, dealii::Functions::ZeroFunction<dim>(dim),
+      affine_constraints);
+  affine_constraints.close();
+  dealii::hp::QCollection<dim> q_collection;
+  q_collection.push_back(dealii::QGauss<dim>(3));
+  q_collection.push_back(dealii::QGauss<dim>(1));
+  // Create the MaterialProperty
+  boost::property_tree::ptree mat_prop_database;
+  mat_prop_database.put("property_format", "polynomial");
+  mat_prop_database.put("n_materials", 1);
+  mat_prop_database.put("material_0.solid.density", 1.);
+  mat_prop_database.put("material_0.powder.density", 1.);
+  mat_prop_database.put("material_0.liquid.density", 1.);
+  mat_prop_database.put("material_0.solid.specific_heat", 1.);
+  mat_prop_database.put("material_0.powder.specific_heat", 1.);
+  mat_prop_database.put("material_0.liquid.specific_heat", 1.);
+  mat_prop_database.put("material_0.solid.thermal_conductivity_x", 10.);
+  mat_prop_database.put("material_0.solid.thermal_conductivity_z", 10.);
+  mat_prop_database.put("material_0.powder.thermal_conductivity_x", 10.);
+  mat_prop_database.put("material_0.powder.thermal_conductivity_z", 10.);
+  mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 10.);
+  mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 10.);
+  std::shared_ptr<adamantine::MaterialProperty<dim, dealii::MemorySpace::Host>>
+      mat_properties(
+          new adamantine::MaterialProperty<dim, dealii::MemorySpace::Host>(
+              communicator, geometry.get_triangulation(), mat_prop_database));
+  // Create the mechanical database
+  boost::property_tree::ptree mechanical_database;
+  double const lame_first = 2.;
+  double const lame_second = 3.;
+  mechanical_database.put("lame_first_param", lame_first);
+  mechanical_database.put("lame_second_param", lame_second);
+
+  adamantine::MechanicalOperator<dim> mechanical_operator(communicator,
+                                                          mechanical_database);
+  mechanical_operator.reinit(dof_handler, affine_constraints, q_collection);
+
+  // Create the PostProcessor
+  boost::property_tree::ptree post_processor_database;
+  post_processor_database.put("filename_prefix", "test");
+  post_processor_database.put("mechanical_output", true);
+  adamantine::PostProcessor<dim> post_processor(
+      communicator, post_processor_database, dof_handler);
+  dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> src(
+      dof_handler.n_dofs());
+  for (unsigned int i = 0; i < src.size(); ++i)
+    src[i] = i % (dim + 1);
+
+  post_processor.write_mechanical_output(
+      1, 0, 0., src, mat_properties->get_state(),
+      mat_properties->get_dofs_map(), mat_properties->get_dof_handler());
+  post_processor.write_mechanical_output(
+      1, 1, 0.1, src, mat_properties->get_state(),
+      mat_properties->get_dofs_map(), mat_properties->get_dof_handler());
+  post_processor.write_mechanical_output(
+      1, 2, 0.2, src, mat_properties->get_state(),
+      mat_properties->get_dofs_map(), mat_properties->get_dof_handler());
+  post_processor.write_pvd();
 
   // Check that the files exist
   BOOST_TEST(boost::filesystem::exists("test.pvd"));
@@ -132,3 +242,4 @@ BOOST_AUTO_TEST_CASE(post_processor)
   std::remove("test.01.000001.000000.vtu");
   std::remove("test.01.000002.000000.vtu");
 }
+#endif


### PR DESCRIPTION
Refactor `PostProcessor`  to be able to output thermal results, mechanical results, or thermo-mechanical results. For now, the mechanical output is limited to displacement and strain. Adding stress is not difficult but it requires to also pass the `MaterialProperty`. I've let that for later.