### PR TITLE
Add support for mechanical properties in MaterialProperty

### DIFF
--- a/source/MechanicalPhysics.hh
+++ b/source/MechanicalPhysics.hh
@@ -39,6 +39,11 @@ public:
    */
   dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> solve();
 
+  /**
+   * Return the DoFHandler.
+   */
+  dealii::DoFHandler<dim> const &get_dof_handler() const;
+
 private:
   /**
    * Associated Geometry.
@@ -65,6 +70,14 @@ private:
    */
   std::unique_ptr<MechanicalOperator<dim>> _mechanical_operator;
 };
+
+template <int dim>
+inline dealii::DoFHandler<dim> const &
+MechanicalPhysics<dim>::get_dof_handler() const
+{
+  return _dof_handler;
+}
+
 } // namespace adamantine
 
 #endif

--- a/source/MechanicalPhysics.hh
+++ b/source/MechanicalPhysics.hh
@@ -18,16 +18,17 @@
 namespace adamantine
 {
 // TODO Inherit from Physics or remove Physics entirely?
-template <int dim>
+template <int dim, typename MemorySpaceType>
 class MechanicalPhysics
 {
 public:
   /**
    * Constructor.
    */
-  MechanicalPhysics(MPI_Comm const &communicator,
-                    boost::property_tree::ptree const &database,
-                    Geometry<dim> &geometry);
+  MechanicalPhysics(
+      MPI_Comm const &communicator, boost::property_tree::ptree const &database,
+      Geometry<dim> &geometry,
+      MaterialProperty<dim, MemorySpaceType> &material_properties);
 
   /**
    * Setup the DoFHandler, the AffineConstraints, and the MechanicalOperator.
@@ -42,7 +43,7 @@ public:
   /**
    * Return the DoFHandler.
    */
-  dealii::DoFHandler<dim> const &get_dof_handler() const;
+  dealii::DoFHandler<dim> &get_dof_handler();
 
 private:
   /**
@@ -68,12 +69,13 @@ private:
   /**
    * Pointer to the MechanicalOperator
    */
-  std::unique_ptr<MechanicalOperator<dim>> _mechanical_operator;
+  std::unique_ptr<MechanicalOperator<dim, MemorySpaceType>>
+      _mechanical_operator;
 };
 
-template <int dim>
-inline dealii::DoFHandler<dim> const &
-MechanicalPhysics<dim>::get_dof_handler() const
+template <int dim, typename MemorySpaceType>
+inline dealii::DoFHandler<dim> &
+MechanicalPhysics<dim, MemorySpaceType>::get_dof_handler()
 {
   return _dof_handler;
 }

--- a/source/Physics.hh
+++ b/source/Physics.hh
@@ -141,12 +141,6 @@ public:
    * Return the AffineConstraints<double>.
    */
   virtual dealii::AffineConstraints<double> &get_affine_constraints() = 0;
-
-  /**
-   * Return a shared pointer of the MaterialProperty.
-   */
-  virtual std::shared_ptr<MaterialProperty<dim, MemorySpaceType>>
-  get_material_property() = 0;
 };
 } // namespace adamantine
 #endif

--- a/source/ThermalOperator.hh
+++ b/source/ThermalOperator.hh
@@ -26,8 +26,7 @@ class ThermalOperator final : public ThermalOperatorBase<dim, MemorySpaceType>
 public:
   ThermalOperator(
       MPI_Comm const &communicator, BoundaryType boundary_type,
-      std::shared_ptr<MaterialProperty<dim, MemorySpaceType>> const
-          &material_properties,
+      MaterialProperty<dim, MemorySpaceType> &material_properties,
       std::vector<std::shared_ptr<HeatSource<dim>>> const &heat_sources);
 
   /**
@@ -184,7 +183,7 @@ private:
   /**
    * Material properties associated with the domain.
    */
-  std::shared_ptr<MaterialProperty<dim, MemorySpaceType>> _material_properties;
+  MaterialProperty<dim, MemorySpaceType> &_material_properties;
   /**
    * Vector of heat sources.
    */

--- a/source/ThermalOperatorDevice.cu
+++ b/source/ThermalOperatorDevice.cu
@@ -403,8 +403,7 @@ namespace adamantine
 template <int dim, int fe_degree, typename MemorySpaceType>
 ThermalOperatorDevice<dim, fe_degree, MemorySpaceType>::ThermalOperatorDevice(
     MPI_Comm const &communicator, BoundaryType boundary_type,
-    std::shared_ptr<MaterialProperty<dim, MemorySpaceType>> const
-        &material_properties)
+    MaterialProperty<dim, MemorySpaceType> &material_properties)
     : _communicator(communicator), _boundary_type(boundary_type), _m(0),
       _n_owned_cells(0), _material_properties(material_properties),
       _inverse_mass_matrix(
@@ -537,12 +536,12 @@ void ThermalOperatorDevice<dim, fe_degree, MemorySpaceType>::vmult_add(
   ASSERT(material_id_view.extent(0), "material_id has not been initialized");
 
   LocalThermalOperatorDevice<dim, fe_degree> local_operator(
-      _material_properties->properties_use_table(),
-      _material_properties->polynomial_order(), _deposition_cos.get_values(),
+      _material_properties.properties_use_table(),
+      _material_properties.polynomial_order(), _deposition_cos.get_values(),
       _deposition_sin.get_values(), powder_ratio_view, liquid_ratio_view,
-      material_id_view, _inv_rho_cp, _material_properties->get_properties(),
-      _material_properties->get_state_property_tables(),
-      _material_properties->get_state_property_polynomials());
+      material_id_view, _inv_rho_cp, _material_properties.get_properties(),
+      _material_properties.get_state_property_tables(),
+      _material_properties.get_state_property_polynomials());
   _matrix_free.cell_loop(local_operator, src, dst);
   _matrix_free.copy_constrained_values(src, dst);
 }
@@ -584,9 +583,9 @@ void ThermalOperatorDevice<
     // Cast to Triangulation<dim>::cell_iterator to access the material_id
     typename dealii::Triangulation<dim>::active_cell_iterator cell_tria(cell);
     double const cell_liquid_ratio =
-        _material_properties->get_state_ratio(cell_tria, MaterialState::liquid);
+        _material_properties.get_state_ratio(cell_tria, MaterialState::liquid);
     double const cell_powder_ratio =
-        _material_properties->get_state_ratio(cell_tria, MaterialState::powder);
+        _material_properties.get_state_ratio(cell_tria, MaterialState::powder);
     double const cell_material_id = cell_tria->material_id();
 
     for (unsigned int i = 0; i < n_q_points_per_cell; ++i)
@@ -608,9 +607,9 @@ template <int dim, int fe_degree, typename MemorySpaceType>
 void ThermalOperatorDevice<dim, fe_degree,
                            MemorySpaceType>::set_state_to_material_properties()
 {
-  _material_properties->set_state_device(_liquid_ratio, _powder_ratio,
-                                         _cell_it_to_mf_pos,
-                                         _matrix_free.get_dof_handler());
+  _material_properties.set_state_device(_liquid_ratio, _powder_ratio,
+                                        _cell_it_to_mf_pos,
+                                        _matrix_free.get_dof_handler());
 }
 
 template <int dim, int fe_degree, typename MemorySpaceType>
@@ -620,7 +619,7 @@ void ThermalOperatorDevice<dim, fe_degree, MemorySpaceType>::
             &temperature)
 {
   if (!(_boundary_type & BoundaryType::adiabatic))
-    _material_properties->update_boundary_material_properties(
+    _material_properties.update_boundary_material_properties(
         _matrix_free.get_dof_handler(), temperature);
 }
 

--- a/source/ThermalOperatorDevice.hh
+++ b/source/ThermalOperatorDevice.hh
@@ -23,8 +23,7 @@ class ThermalOperatorDevice final
 public:
   ThermalOperatorDevice(
       MPI_Comm const &communicator, BoundaryType boundary_type,
-      std::shared_ptr<MaterialProperty<dim, MemorySpaceType>> const
-          &material_properties);
+      MaterialProperty<dim, MemorySpaceType> &material_properties);
 
   void reinit(dealii::DoFHandler<dim> const &dof_handler,
               dealii::AffineConstraints<double> const &affine_constraints,
@@ -107,13 +106,22 @@ public:
                  unsigned int q) const override;
 
 private:
+  /**
+   * MPI communicator.
+   */
   MPI_Comm const &_communicator;
+  /**
+   * Type of boundary.
+   */
   BoundaryType _boundary_type;
   dealii::types::global_dof_index _m;
   unsigned int _n_owned_cells;
   typename dealii::CUDAWrappers::MatrixFree<dim, double>::AdditionalData
       _matrix_free_data;
-  std::shared_ptr<MaterialProperty<dim, MemorySpaceType>> _material_properties;
+  /**
+   * Material properties associated with the domain.
+   */
+  MaterialProperty<dim, MemorySpaceType> &_material_properties;
   dealii::CUDAWrappers::MatrixFree<dim, double> _matrix_free;
   MemoryBlock<double, dealii::MemorySpace::CUDA> _liquid_ratio;
   MemoryBlock<double, dealii::MemorySpace::CUDA> _powder_ratio;

--- a/source/types.hh
+++ b/source/types.hh
@@ -49,6 +49,10 @@ enum class StateProperty
   emissivity,
   radiation_heat_transfer_coef,
   convection_heat_transfer_coef,
+  // Mechanical properties only make sense for the solid state. They do not make
+  // sense for the powder and the liquid state
+  lame_first_parameter,
+  lame_second_parameter,
   SIZE
 };
 
@@ -73,21 +77,22 @@ static std::array<std::string, 3> material_state_names = {
     {"powder", "solid", "liquid"}};
 
 /**
- * Array continaing the possible material properties that depend on the state of
- * the material.
+ * Array continaing the possible material properties that do not depend on the
+ * state of the material.
  */
 static std::array<std::string, 5> property_names = {
     {"liquidus", "solidus", "latent_heat", "radiation_temperature_infty",
      "convection_temperature_infty"}};
 
 /**
- * Array containing the possible material properties that do not depend on the
+ * Array containing the possible material properties that depend on the
  * state of the material.
  */
-static std::array<std::string, 8> state_property_names = {
+static std::array<std::string, 10> state_property_names = {
     {"density", "specific_heat", "thermal_conductivity_x",
      "thermal_conductivity_y", "thermal_conductivity_z", "emissivity",
-     "radiation_heat_transfer_coef", "convection_heat_transfer_coef"}};
+     "radiation_heat_transfer_coef", "convection_heat_transfer_coef",
+     "lame_first_parameter", "lame_second_parameter"}};
 
 /**
  * Enum on the possible timers.

--- a/tests/test_implicit_operator.cc
+++ b/tests/test_implicit_operator.cc
@@ -66,10 +66,8 @@ BOOST_AUTO_TEST_CASE(implicit_operator)
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 10.);
-  std::shared_ptr<adamantine::MaterialProperty<2, dealii::MemorySpace::Host>>
-      mat_properties(
-          new adamantine::MaterialProperty<2, dealii::MemorySpace::Host>(
-              communicator, geometry.get_triangulation(), mat_prop_database));
+  adamantine::MaterialProperty<2, dealii::MemorySpace::Host> mat_properties(
+      communicator, geometry.get_triangulation(), mat_prop_database);
 
   boost::property_tree::ptree beam_database;
   beam_database.put("depth", 0.1);
@@ -118,7 +116,8 @@ BOOST_AUTO_TEST_CASE(implicit_operator)
   adamantine::ImplicitOperator<dealii::MemorySpace::Host>
       implicit_operator_jfnk(thermal_operator, true);
 
-  // Check that ImplicitOperator with and without JFNK give the same results.
+  // Check that ImplicitOperator with and without JFNK give the same
+  // results.
   unsigned int const size = thermal_operator->m();
   dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> source(
       size);

--- a/tests/test_material_deposition.cc
+++ b/tests/test_material_deposition.cc
@@ -5,6 +5,7 @@
  * for the text and further information on this license.
  */
 
+#include "MaterialProperty.hh"
 #define BOOST_TEST_MODULE MaterialDeposition
 
 #include <Geometry.hh>
@@ -255,7 +256,7 @@ BOOST_AUTO_TEST_CASE(material_deposition)
       database.get_child("geometry");
   adamantine::Geometry<dim> geometry(communicator, geometry_database);
 
-  // Material property
+  // MaterialProperty database
   database.put("materials.property_format", "polynomial");
   database.put("materials.initial_temperature", initial_temperature);
   database.put("materials.new_material_temperature", initial_temperature);
@@ -268,6 +269,13 @@ BOOST_AUTO_TEST_CASE(material_deposition)
   database.put("materials.material_0.solid.thermal_conductivity_z", 1.);
   database.put("materials.material_0.liquid.thermal_conductivity_x", 1.);
   database.put("materials.material_0.liquid.thermal_conductivity_z", 1.);
+  // Build MaterialProperty
+  boost::property_tree::ptree material_property_database =
+      database.get_child("materials");
+  adamantine::MaterialProperty<dim, dealii::MemorySpace::Host>
+      material_properties(communicator, geometry.get_triangulation(),
+                          material_property_database);
+
   // Source database
   database.put("sources.n_beams", 0);
   // Time-stepping database
@@ -278,7 +286,7 @@ BOOST_AUTO_TEST_CASE(material_deposition)
   // Build ThermalPhysics
   adamantine::ThermalPhysics<dim, dim, dealii::MemorySpace::Host,
                              dealii::QGauss<1>>
-      thermal_physics(communicator, database, geometry);
+      thermal_physics(communicator, database, geometry, material_properties);
   thermal_physics.setup_dofs();
   thermal_physics.update_material_deposition_orientation();
   thermal_physics.compute_inverse_mass_matrix();

--- a/tests/test_material_property.hh
+++ b/tests/test_material_property.hh
@@ -49,6 +49,8 @@ void material_property()
   database.put("material_0.powder.thermal_conductivity_z", 10.);
   database.put("material_0.liquid", "");
   database.put("material_0.liquidus", "100");
+  database.put("material_0.solid.lame_first_parameter", 2.);
+  database.put("material_0.solid.lame_second_parameter", 3.);
   adamantine::MaterialProperty<2, MemorySpaceType> mat_prop(
       communicator, triangulation, database);
   // Evaluate the material property at the given temperature
@@ -74,6 +76,12 @@ void material_property()
     double const liquidus =
         mat_prop.get_cell_value(cell, adamantine::Property::liquidus);
     BOOST_TEST(liquidus == 100.);
+    double const lambda = mat_prop.get_mechanical_property(
+        cell, adamantine::StateProperty::lame_first_parameter);
+    BOOST_TEST(lambda == 2.);
+    double const mu = mat_prop.get_mechanical_property(
+        cell, adamantine::StateProperty::lame_second_parameter);
+    BOOST_TEST(mu == 3.);
   }
 }
 

--- a/tests/test_post_processor.cc
+++ b/tests/test_post_processor.cc
@@ -64,10 +64,8 @@ BOOST_AUTO_TEST_CASE(thermal_post_processor)
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 10.);
-  std::shared_ptr<adamantine::MaterialProperty<2, dealii::MemorySpace::Host>>
-      mat_properties(
-          new adamantine::MaterialProperty<2, dealii::MemorySpace::Host>(
-              communicator, geometry.get_triangulation(), mat_prop_database));
+  adamantine::MaterialProperty<2, dealii::MemorySpace::Host> mat_properties(
+      communicator, geometry.get_triangulation(), mat_prop_database);
 
   boost::property_tree::ptree beam_database;
   beam_database.put("depth", 0.1);
@@ -108,15 +106,15 @@ BOOST_AUTO_TEST_CASE(thermal_post_processor)
   for (unsigned int i = 0; i < src.size(); ++i)
     src[i] = 1.;
 
+  post_processor.write_thermal_output(1, 0, 0., src, mat_properties.get_state(),
+                                      mat_properties.get_dofs_map(),
+                                      mat_properties.get_dof_handler());
   post_processor.write_thermal_output(
-      1, 0, 0., src, mat_properties->get_state(),
-      mat_properties->get_dofs_map(), mat_properties->get_dof_handler());
+      1, 1, 0.1, src, mat_properties.get_state(), mat_properties.get_dofs_map(),
+      mat_properties.get_dof_handler());
   post_processor.write_thermal_output(
-      1, 1, 0.1, src, mat_properties->get_state(),
-      mat_properties->get_dofs_map(), mat_properties->get_dof_handler());
-  post_processor.write_thermal_output(
-      1, 2, 0.2, src, mat_properties->get_state(),
-      mat_properties->get_dofs_map(), mat_properties->get_dof_handler());
+      1, 2, 0.2, src, mat_properties.get_state(), mat_properties.get_dofs_map(),
+      mat_properties.get_dof_handler());
   post_processor.write_pvd();
 
   // Check that the files exist
@@ -187,10 +185,8 @@ BOOST_AUTO_TEST_CASE(mechanical_post_processor)
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 10.);
-  std::shared_ptr<adamantine::MaterialProperty<dim, dealii::MemorySpace::Host>>
-      mat_properties(
-          new adamantine::MaterialProperty<dim, dealii::MemorySpace::Host>(
-              communicator, geometry.get_triangulation(), mat_prop_database));
+  adamantine::MaterialProperty<dim, dealii::MemorySpace::Host> mat_properties(
+      communicator, geometry.get_triangulation(), mat_prop_database);
   // Create the mechanical database
   boost::property_tree::ptree mechanical_database;
   double const lame_first = 2.;
@@ -214,14 +210,14 @@ BOOST_AUTO_TEST_CASE(mechanical_post_processor)
     src[i] = i % (dim + 1);
 
   post_processor.write_mechanical_output(
-      1, 0, 0., src, mat_properties->get_state(),
-      mat_properties->get_dofs_map(), mat_properties->get_dof_handler());
+      1, 0, 0., src, mat_properties.get_state(), mat_properties.get_dofs_map(),
+      mat_properties.get_dof_handler());
   post_processor.write_mechanical_output(
-      1, 1, 0.1, src, mat_properties->get_state(),
-      mat_properties->get_dofs_map(), mat_properties->get_dof_handler());
+      1, 1, 0.1, src, mat_properties.get_state(), mat_properties.get_dofs_map(),
+      mat_properties.get_dof_handler());
   post_processor.write_mechanical_output(
-      1, 2, 0.2, src, mat_properties->get_state(),
-      mat_properties->get_dofs_map(), mat_properties->get_dof_handler());
+      1, 2, 0.2, src, mat_properties.get_state(), mat_properties.get_dofs_map(),
+      mat_properties.get_dof_handler());
   post_processor.write_pvd();
 
   // Check that the files exist

--- a/tests/test_post_processor.cc
+++ b/tests/test_post_processor.cc
@@ -185,17 +185,13 @@ BOOST_AUTO_TEST_CASE(mechanical_post_processor)
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 10.);
+  mat_prop_database.put("material_0.solid.lame_first_parameter", 2.);
+  mat_prop_database.put("material_0.solid.lame_second_parameter", 3.);
   adamantine::MaterialProperty<dim, dealii::MemorySpace::Host> mat_properties(
       communicator, geometry.get_triangulation(), mat_prop_database);
-  // Create the mechanical database
-  boost::property_tree::ptree mechanical_database;
-  double const lame_first = 2.;
-  double const lame_second = 3.;
-  mechanical_database.put("lame_first_param", lame_first);
-  mechanical_database.put("lame_second_param", lame_second);
 
-  adamantine::MechanicalOperator<dim> mechanical_operator(communicator,
-                                                          mechanical_database);
+  adamantine::MechanicalOperator<dim, dealii::MemorySpace::Host>
+      mechanical_operator(communicator, mat_properties);
   mechanical_operator.reinit(dof_handler, affine_constraints, q_collection);
 
   // Create the PostProcessor

--- a/tests/test_thermal_operator.cc
+++ b/tests/test_thermal_operator.cc
@@ -67,10 +67,8 @@ BOOST_AUTO_TEST_CASE(thermal_operator, *utf::tolerance(1e-15))
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 10.);
-  std::shared_ptr<adamantine::MaterialProperty<2, dealii::MemorySpace::Host>>
-      mat_properties(
-          new adamantine::MaterialProperty<2, dealii::MemorySpace::Host>(
-              communicator, geometry.get_triangulation(), mat_prop_database));
+  adamantine::MaterialProperty<2, dealii::MemorySpace::Host> mat_properties(
+      communicator, geometry.get_triangulation(), mat_prop_database);
 
   // Create the heat sources
   boost::property_tree::ptree beam_database;
@@ -172,10 +170,8 @@ BOOST_AUTO_TEST_CASE(spmv, *utf::tolerance(1e-12))
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 1.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 1.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 1.);
-  std::shared_ptr<adamantine::MaterialProperty<2, dealii::MemorySpace::Host>>
-      mat_properties(
-          new adamantine::MaterialProperty<2, dealii::MemorySpace::Host>(
-              communicator, geometry.get_triangulation(), mat_prop_database));
+  adamantine::MaterialProperty<2, dealii::MemorySpace::Host> mat_properties(
+      communicator, geometry.get_triangulation(), mat_prop_database);
 
   // Create the heat sources
   boost::property_tree::ptree beam_database;
@@ -281,10 +277,8 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic, *utf::tolerance(1e-12))
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 0.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 1.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 0.);
-  std::shared_ptr<adamantine::MaterialProperty<2, dealii::MemorySpace::Host>>
-      mat_properties(
-          new adamantine::MaterialProperty<2, dealii::MemorySpace::Host>(
-              communicator, geometry.get_triangulation(), mat_prop_database));
+  adamantine::MaterialProperty<2, dealii::MemorySpace::Host> mat_properties(
+      communicator, geometry.get_triangulation(), mat_prop_database);
 
   // Create the heat sources
   boost::property_tree::ptree beam_database;
@@ -430,10 +424,8 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic_angle, *utf::tolerance(1e-10))
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", th_cond_x);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_y", th_cond_y);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", th_cond_z);
-  std::shared_ptr<adamantine::MaterialProperty<3, dealii::MemorySpace::Host>>
-      mat_properties(
-          new adamantine::MaterialProperty<3, dealii::MemorySpace::Host>(
-              communicator, geometry.get_triangulation(), mat_prop_database));
+  adamantine::MaterialProperty<3, dealii::MemorySpace::Host> mat_properties(
+      communicator, geometry.get_triangulation(), mat_prop_database);
 
   // Create the heat sources
   std::vector<std::shared_ptr<adamantine::HeatSource<3>>> heat_sources;
@@ -590,10 +582,8 @@ BOOST_AUTO_TEST_CASE(spmv_rad, *utf::tolerance(1e-12))
   mat_prop_database.put("material_0.liquid.convection_heat_transfer_coef", 1.);
   mat_prop_database.put("material_0.radiation_temperature_infty", 0.0);
   mat_prop_database.put("material_0.convection_temperature_infty", 0.0);
-  std::shared_ptr<adamantine::MaterialProperty<2, dealii::MemorySpace::Host>>
-      mat_properties(
-          new adamantine::MaterialProperty<2, dealii::MemorySpace::Host>(
-              communicator, geometry.get_triangulation(), mat_prop_database));
+  adamantine::MaterialProperty<2, dealii::MemorySpace::Host> mat_properties(
+      communicator, geometry.get_triangulation(), mat_prop_database);
 
   // Create the heat sources
   boost::property_tree::ptree beam_database;

--- a/tests/test_thermal_operator_device.cu
+++ b/tests/test_thermal_operator_device.cu
@@ -68,10 +68,8 @@ BOOST_AUTO_TEST_CASE(thermal_operator_dev, *utf::tolerance(1e-10))
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 10.);
-  std::shared_ptr<adamantine::MaterialProperty<2, dealii::MemorySpace::CUDA>>
-      mat_properties(
-          new adamantine::MaterialProperty<2, dealii::MemorySpace::CUDA>(
-              communicator, geometry.get_triangulation(), mat_prop_database));
+  adamantine::MaterialProperty<2, dealii::MemorySpace::CUDA> mat_properties(
+      communicator, geometry.get_triangulation(), mat_prop_database);
 
   // Initialize the ThermalOperator
   adamantine::ThermalOperatorDevice<2, 2, dealii::MemorySpace::CUDA>
@@ -158,10 +156,8 @@ BOOST_AUTO_TEST_CASE(spmv, *utf::tolerance(1e-12))
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 1.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 1.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 1.);
-  std::shared_ptr<adamantine::MaterialProperty<2, dealii::MemorySpace::CUDA>>
-      mat_properties(
-          new adamantine::MaterialProperty<2, dealii::MemorySpace::CUDA>(
-              communicator, geometry.get_triangulation(), mat_prop_database));
+  adamantine::MaterialProperty<2, dealii::MemorySpace::CUDA> mat_properties(
+      communicator, geometry.get_triangulation(), mat_prop_database);
 
   // Initialize the ThermalOperator
   adamantine::ThermalOperatorDevice<2, 2, dealii::MemorySpace::CUDA>
@@ -261,14 +257,11 @@ BOOST_AUTO_TEST_CASE(mf_spmv, *utf::tolerance(1.5e-12))
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 0.266);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 0.266);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 0.266);
-  std::shared_ptr<adamantine::MaterialProperty<2, dealii::MemorySpace::Host>>
-      mat_properties_host(
-          new adamantine::MaterialProperty<2, dealii::MemorySpace::Host>(
-              communicator, geometry.get_triangulation(), mat_prop_database));
-  std::shared_ptr<adamantine::MaterialProperty<2, dealii::MemorySpace::CUDA>>
-      mat_properties(
-          new adamantine::MaterialProperty<2, dealii::MemorySpace::CUDA>(
-              communicator, geometry.get_triangulation(), mat_prop_database));
+  adamantine::MaterialProperty<2, dealii::MemorySpace::Host>
+      mat_properties_host(communicator, geometry.get_triangulation(),
+                          mat_prop_database);
+  adamantine::MaterialProperty<2, dealii::MemorySpace::CUDA> mat_properties(
+      communicator, geometry.get_triangulation(), mat_prop_database);
 
   // Create the heat sources
   boost::property_tree::ptree beam_database;
@@ -395,10 +388,8 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic_angle, *utf::tolerance(1e-10))
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", th_cond_x);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_y", th_cond_y);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", th_cond_z);
-  std::shared_ptr<adamantine::MaterialProperty<3, dealii::MemorySpace::CUDA>>
-      mat_properties(
-          new adamantine::MaterialProperty<3, dealii::MemorySpace::CUDA>(
-              communicator, geometry.get_triangulation(), mat_prop_database));
+  adamantine::MaterialProperty<3, dealii::MemorySpace::CUDA> mat_properties(
+      communicator, geometry.get_triangulation(), mat_prop_database);
 
   // Initialize the ThermalOperatorDevice
   adamantine::ThermalOperatorDevice<3, 2, dealii::MemorySpace::CUDA>

--- a/tests/test_thermal_physics.hh
+++ b/tests/test_thermal_physics.hh
@@ -5,6 +5,7 @@
  * for the text and further information on this license.
  */
 
+#include "MaterialProperty.hh"
 #include <Geometry.hh>
 #include <ThermalPhysics.hh>
 
@@ -26,21 +27,29 @@ void thermal_2d(boost::property_tree::ptree &database, double time_step)
   geometry_database.put("height_divisions", 5);
   // Build Geometry
   adamantine::Geometry<2> geometry(communicator, geometry_database);
-  // Material property
-  database.put("materials.property_format", "polynomial");
-  database.put("materials.n_materials", 1);
-  database.put("materials.material_0.solid.density", 1.);
-  database.put("materials.material_0.powder.density", 1.);
-  database.put("materials.material_0.liquid.density", 1.);
-  database.put("materials.material_0.solid.specific_heat", 1.);
-  database.put("materials.material_0.powder.specific_heat", 1.);
-  database.put("materials.material_0.liquid.specific_heat", 1.);
-  database.put("materials.material_0.solid.thermal_conductivity_x", 1.);
-  database.put("materials.material_0.solid.thermal_conductivity_z", 1.);
-  database.put("materials.material_0.powder.thermal_conductivity_x", 1.);
-  database.put("materials.material_0.powder.thermal_conductivity_z", 1.);
-  database.put("materials.material_0.liquid.thermal_conductivity_x", 1.);
-  database.put("materials.material_0.liquid.thermal_conductivity_z", 1.);
+  // MaterialProperty database
+  boost::property_tree::ptree material_property_database;
+  material_property_database.put("property_format", "polynomial");
+  material_property_database.put("n_materials", 1);
+  material_property_database.put("material_0.solid.density", 1.);
+  material_property_database.put("material_0.powder.density", 1.);
+  material_property_database.put("material_0.liquid.density", 1.);
+  material_property_database.put("material_0.solid.specific_heat", 1.);
+  material_property_database.put("material_0.powder.specific_heat", 1.);
+  material_property_database.put("material_0.liquid.specific_heat", 1.);
+  material_property_database.put("material_0.solid.thermal_conductivity_x", 1.);
+  material_property_database.put("material_0.solid.thermal_conductivity_z", 1.);
+  material_property_database.put("material_0.powder.thermal_conductivity_x",
+                                 1.);
+  material_property_database.put("material_0.powder.thermal_conductivity_z",
+                                 1.);
+  material_property_database.put("material_0.liquid.thermal_conductivity_x",
+                                 1.);
+  material_property_database.put("material_0.liquid.thermal_conductivity_z",
+                                 1.);
+  // Build MaterialProperty
+  adamantine::MaterialProperty<2, MemorySpaceType> material_properties(
+      communicator, geometry.get_triangulation(), material_property_database);
   // Source database
   database.put("sources.n_beams", 1);
   database.put("sources.beam_0.depth", 1e100);
@@ -56,7 +65,7 @@ void thermal_2d(boost::property_tree::ptree &database, double time_step)
 
   // Build ThermalPhysics
   adamantine::ThermalPhysics<2, 2, MemorySpaceType, dealii::QGauss<1>> physics(
-      communicator, database, geometry);
+      communicator, database, geometry, material_properties);
   physics.setup_dofs();
   physics.update_material_deposition_orientation();
   physics.compute_inverse_mass_matrix();
@@ -94,22 +103,31 @@ void thermal_2d_manufactured_solution()
   // Build Geometry
   adamantine::Geometry<2> geometry(communicator, geometry_database);
 
+  // MaterialProperty database
+  boost::property_tree::ptree material_property_database;
+  material_property_database.put("property_format", "polynomial");
+  material_property_database.put("n_materials", 1);
+  material_property_database.put("material_0.solid.density", 1.);
+  material_property_database.put("material_0.powder.density", 1.);
+  material_property_database.put("material_0.liquid.density", 1.);
+  material_property_database.put("material_0.solid.specific_heat", 1.);
+  material_property_database.put("material_0.powder.specific_heat", 1.);
+  material_property_database.put("material_0.liquid.specific_heat", 1.);
+  material_property_database.put("material_0.solid.thermal_conductivity_x", 1.);
+  material_property_database.put("material_0.solid.thermal_conductivity_z", 1.);
+  material_property_database.put("material_0.powder.thermal_conductivity_x",
+                                 1.);
+  material_property_database.put("material_0.powder.thermal_conductivity_z",
+                                 1.);
+  material_property_database.put("material_0.liquid.thermal_conductivity_x",
+                                 1.);
+  material_property_database.put("material_0.liquid.thermal_conductivity_z",
+                                 1.);
+  // Build MaterialProperty
+  adamantine::MaterialProperty<2, MemorySpaceType> material_properties(
+      communicator, geometry.get_triangulation(), material_property_database);
+
   boost::property_tree::ptree database;
-  // Material property
-  database.put("materials.property_format", "polynomial");
-  database.put("materials.n_materials", 1);
-  database.put("materials.material_0.solid.density", 1.);
-  database.put("materials.material_0.powder.density", 1.);
-  database.put("materials.material_0.liquid.density", 1.);
-  database.put("materials.material_0.solid.specific_heat", 1.);
-  database.put("materials.material_0.powder.specific_heat", 1.);
-  database.put("materials.material_0.liquid.specific_heat", 1.);
-  database.put("materials.material_0.solid.thermal_conductivity_x", 1.);
-  database.put("materials.material_0.solid.thermal_conductivity_z", 1.);
-  database.put("materials.material_0.powder.thermal_conductivity_x", 1.);
-  database.put("materials.material_0.powder.thermal_conductivity_z", 1.);
-  database.put("materials.material_0.liquid.thermal_conductivity_x", 1.);
-  database.put("materials.material_0.liquid.thermal_conductivity_z", 1.);
   // Source database
   database.put("sources.n_beams", 1);
   database.put("sources.beam_0.depth", 1e100);
@@ -128,7 +146,7 @@ void thermal_2d_manufactured_solution()
   database.put("time_stepping.method", "rk_fourth_order");
   // Build ThermalPhysics
   adamantine::ThermalPhysics<2, 2, MemorySpaceType, dealii::QGauss<1>> physics(
-      communicator, database, geometry);
+      communicator, database, geometry, material_properties);
   physics.setup_dofs();
   physics.update_material_deposition_orientation();
   physics.compute_inverse_mass_matrix();
@@ -175,22 +193,30 @@ void initial_temperature()
   geometry_database.put("height_divisions", 1);
   // Build Geometry
   adamantine::Geometry<2> geometry(communicator, geometry_database);
+  // MaterialProperty database
+  boost::property_tree::ptree material_property_database;
+  material_property_database.put("property_format", "polynomial");
+  material_property_database.put("n_materials", 1);
+  material_property_database.put("material_0.solid.density", 1.);
+  material_property_database.put("material_0.powder.density", 10.);
+  material_property_database.put("material_0.liquid.density", 1.);
+  material_property_database.put("material_0.solid.specific_heat", 1.);
+  material_property_database.put("material_0.powder.specific_heat", 2.);
+  material_property_database.put("material_0.liquid.specific_heat", 1.);
+  material_property_database.put("material_0.solid.thermal_conductivity_x", 1.);
+  material_property_database.put("material_0.solid.thermal_conductivity_z", 1.);
+  material_property_database.put("material_0.powder.thermal_conductivity_x",
+                                 1.);
+  material_property_database.put("material_0.powder.thermal_conductivity_z",
+                                 1.);
+  material_property_database.put("material_0.liquid.thermal_conductivity_x",
+                                 1.);
+  material_property_database.put("material_0.liquid.thermal_conductivity_z",
+                                 1.);
+  // Build MaterialProperty
+  adamantine::MaterialProperty<2, MemorySpaceType> material_properties(
+      communicator, geometry.get_triangulation(), material_property_database);
   boost::property_tree::ptree database;
-  // Material property
-  database.put("materials.property_format", "polynomial");
-  database.put("materials.n_materials", 1);
-  database.put("materials.material_0.solid.density", 1.);
-  database.put("materials.material_0.powder.density", 10.);
-  database.put("materials.material_0.liquid.density", 1.);
-  database.put("materials.material_0.solid.specific_heat", 1.);
-  database.put("materials.material_0.powder.specific_heat", 2.);
-  database.put("materials.material_0.liquid.specific_heat", 1.);
-  database.put("materials.material_0.solid.thermal_conductivity_x", 1.);
-  database.put("materials.material_0.solid.thermal_conductivity_z", 1.);
-  database.put("materials.material_0.powder.thermal_conductivity_x", 1.);
-  database.put("materials.material_0.powder.thermal_conductivity_z", 1.);
-  database.put("materials.material_0.liquid.thermal_conductivity_x", 1.);
-  database.put("materials.material_0.liquid.thermal_conductivity_z", 1.);
   // Source database
   database.put("sources.n_beams", 1);
   database.put("sources.beam_0.depth", 1e100);
@@ -209,7 +235,7 @@ void initial_temperature()
   database.put("time_stepping.method", "rk_fourth_order");
   // Build ThermalPhysics
   adamantine::ThermalPhysics<2, 2, MemorySpaceType, dealii::QGauss<1>> physics(
-      communicator, database, geometry);
+      communicator, database, geometry, material_properties);
   physics.setup_dofs();
   physics.update_material_deposition_orientation();
   physics.compute_inverse_mass_matrix();
@@ -234,22 +260,30 @@ void energy_conservation()
   geometry_database.put("height_divisions", 10);
   // Build Geometry
   adamantine::Geometry<2> geometry(communicator, geometry_database);
+  boost::property_tree::ptree material_property_database;
+  // MaterialProperty database
+  material_property_database.put("property_format", "polynomial");
+  material_property_database.put("n_materials", 1);
+  material_property_database.put("material_0.solid.density", 0.5);
+  material_property_database.put("material_0.powder.density", 0.5);
+  material_property_database.put("material_0.liquid.density", 0.5);
+  material_property_database.put("material_0.solid.specific_heat", 4.);
+  material_property_database.put("material_0.powder.specific_heat", 4.);
+  material_property_database.put("material_0.liquid.specific_heat", 4.);
+  material_property_database.put("material_0.solid.thermal_conductivity_x", 2.);
+  material_property_database.put("material_0.solid.thermal_conductivity_z", 2.);
+  material_property_database.put("material_0.powder.thermal_conductivity_x",
+                                 2.);
+  material_property_database.put("material_0.powder.thermal_conductivity_z",
+                                 2.);
+  material_property_database.put("material_0.liquid.thermal_conductivity_x",
+                                 2.);
+  material_property_database.put("material_0.liquid.thermal_conductivity_z",
+                                 2.);
+  // Build MaterialProperty
+  adamantine::MaterialProperty<2, MemorySpaceType> material_properties(
+      communicator, geometry.get_triangulation(), material_property_database);
   boost::property_tree::ptree database;
-  // Material property
-  database.put("materials.property_format", "polynomial");
-  database.put("materials.n_materials", 1);
-  database.put("materials.material_0.solid.density", 0.5);
-  database.put("materials.material_0.powder.density", 0.5);
-  database.put("materials.material_0.liquid.density", 0.5);
-  database.put("materials.material_0.solid.specific_heat", 4.);
-  database.put("materials.material_0.powder.specific_heat", 4.);
-  database.put("materials.material_0.liquid.specific_heat", 4.);
-  database.put("materials.material_0.solid.thermal_conductivity_x", 2.);
-  database.put("materials.material_0.solid.thermal_conductivity_z", 2.);
-  database.put("materials.material_0.powder.thermal_conductivity_x", 2.);
-  database.put("materials.material_0.powder.thermal_conductivity_z", 2.);
-  database.put("materials.material_0.liquid.thermal_conductivity_x", 2.);
-  database.put("materials.material_0.liquid.thermal_conductivity_z", 2.);
   // Source database
   database.put("sources.n_beams", 1);
   database.put("sources.beam_0.type", "cube");
@@ -265,13 +299,13 @@ void energy_conservation()
   // Boundary database
   database.put("boundary.type", "adiabatic");
   // Build ThermalPhysics
-  adamantine::ThermalPhysics<2, 2, dealii::MemorySpace::Host, dealii::QGauss<1>>
-      physics(communicator, database, geometry);
+  adamantine::ThermalPhysics<2, 2, MemorySpaceType, dealii::QGauss<1>> physics(
+      communicator, database, geometry, material_properties);
   physics.setup_dofs();
   physics.update_material_deposition_orientation();
   physics.compute_inverse_mass_matrix();
 
-  dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> solution;
+  dealii::LA::distributed::Vector<double, MemorySpaceType> solution;
   double constexpr initial_temperature = 10;
   double constexpr final_temperature = 10.5;
   physics.initialize_dof_vector(initial_temperature, solution);
@@ -329,33 +363,49 @@ void radiation_bcs()
   geometry_database.put("height_divisions", 5);
   // Build Geometry
   adamantine::Geometry<2> geometry(communicator, geometry_database);
+  // MaterialProperty database
+  boost::property_tree::ptree material_property_database;
+  material_property_database.put("property_format", "polynomial");
+  material_property_database.put("n_materials", 1);
+  material_property_database.put("material_0.solid.density", 1.);
+  material_property_database.put("material_0.powder.density", 1.);
+  material_property_database.put("material_0.liquid.density", 1.);
+  material_property_database.put("material_0.solid.specific_heat", 1.);
+  material_property_database.put("material_0.powder.specific_heat", 1.);
+  material_property_database.put("material_0.liquid.specific_heat", 1.);
+  material_property_database.put("material_0.solid.thermal_conductivity_x", 1.);
+  material_property_database.put("material_0.solid.thermal_conductivity_z", 1.);
+  material_property_database.put("material_0.powder.thermal_conductivity_x",
+                                 1.);
+  material_property_database.put("material_0.powder.thermal_conductivity_z",
+                                 1.);
+  material_property_database.put("material_0.liquid.thermal_conductivity_x",
+                                 1.);
+  material_property_database.put("material_0.liquid.thermal_conductivity_z",
+                                 1.);
+  material_property_database.put("material_0.solid.emissivity", 1.);
+  material_property_database.put("material_0.powder.emissivity", 1.);
+  material_property_database.put("material_0.liquid.emissivity", 1.);
+  material_property_database.put(
+      "material_0.solid.radiation_heat_transfer_coef", 1.);
+  material_property_database.put(
+      "material_0.powder.radiation_heat_transfer_coef", 1.);
+  material_property_database.put(
+      "material_0.liquid.radiation_heat_transfer_coef", 1.);
+  material_property_database.put(
+      "material_0.solid.convection_heat_transfer_coef", 1.);
+  material_property_database.put(
+      "material_0.powder.convection_heat_transfer_coef", 1.);
+  material_property_database.put(
+      "material_0.liquid.convection_heat_transfer_coef", 1.);
+  material_property_database.put("material_0.radiation_temperature_infty",
+                                 20.0);
+  material_property_database.put("material_0.convection_temperature_infty",
+                                 0.0);
+  // Build MaterialProperty
+  adamantine::MaterialProperty<2, MemorySpaceType> material_properties(
+      communicator, geometry.get_triangulation(), material_property_database);
   boost::property_tree::ptree database;
-  // Material property
-  database.put("materials.property_format", "polynomial");
-  database.put("materials.n_materials", 1);
-  database.put("materials.material_0.solid.density", 1.);
-  database.put("materials.material_0.powder.density", 1.);
-  database.put("materials.material_0.liquid.density", 1.);
-  database.put("materials.material_0.solid.specific_heat", 1.);
-  database.put("materials.material_0.powder.specific_heat", 1.);
-  database.put("materials.material_0.liquid.specific_heat", 1.);
-  database.put("materials.material_0.solid.thermal_conductivity_x", 1.);
-  database.put("materials.material_0.solid.thermal_conductivity_z", 1.);
-  database.put("materials.material_0.powder.thermal_conductivity_x", 1.);
-  database.put("materials.material_0.powder.thermal_conductivity_z", 1.);
-  database.put("materials.material_0.liquid.thermal_conductivity_x", 1.);
-  database.put("materials.material_0.liquid.thermal_conductivity_z", 1.);
-  database.put("materials.material_0.solid.emissivity", 1.);
-  database.put("materials.material_0.powder.emissivity", 1.);
-  database.put("materials.material_0.liquid.emissivity", 1.);
-  database.put("materials.material_0.solid.radiation_heat_transfer_coef", 1.);
-  database.put("materials.material_0.powder.radiation_heat_transfer_coef", 1.);
-  database.put("materials.material_0.liquid.radiation_heat_transfer_coef", 1.);
-  database.put("materials.material_0.solid.convection_heat_transfer_coef", 1.);
-  database.put("materials.material_0.powder.convection_heat_transfer_coef", 1.);
-  database.put("materials.material_0.liquid.convection_heat_transfer_coef", 1.);
-  database.put("materials.material_0.radiation_temperature_infty", 20.0);
-  database.put("materials.material_0.convection_temperature_infty", 0.0);
   // Source database
   database.put("sources.n_beams", 0);
   // Time-stepping database
@@ -364,7 +414,7 @@ void radiation_bcs()
   database.put("boundary.type", "radiative");
   // Build ThermalPhysics
   adamantine::ThermalPhysics<2, 2, dealii::MemorySpace::Host, dealii::QGauss<1>>
-      physics(communicator, database, geometry);
+      physics(communicator, database, geometry, material_properties);
   physics.setup_dofs();
   physics.update_material_deposition_orientation();
   physics.compute_inverse_mass_matrix();
@@ -426,33 +476,48 @@ void convection_bcs()
   geometry_database.put("height_divisions", 5);
   // Build Geometry
   adamantine::Geometry<2> geometry(communicator, geometry_database);
+  boost::property_tree::ptree material_property_database;
+  // MaterialProperty database
+  material_property_database.put("property_format", "polynomial");
+  material_property_database.put("n_materials", 1);
+  material_property_database.put("material_0.solid.density", 1.);
+  material_property_database.put("material_0.powder.density", 1.);
+  material_property_database.put("material_0.liquid.density", 1.);
+  material_property_database.put("material_0.solid.specific_heat", 1.);
+  material_property_database.put("material_0.powder.specific_heat", 1.);
+  material_property_database.put("material_0.liquid.specific_heat", 1.);
+  material_property_database.put("material_0.solid.thermal_conductivity_x", 1.);
+  material_property_database.put("material_0.solid.thermal_conductivity_z", 1.);
+  material_property_database.put("material_0.powder.thermal_conductivity_x",
+                                 1.);
+  material_property_database.put("material_0.powder.thermal_conductivity_z",
+                                 1.);
+  material_property_database.put("material_0.liquid.thermal_conductivity_x",
+                                 1.);
+  material_property_database.put("material_0.liquid.thermal_conductivity_z",
+                                 1.);
+  material_property_database.put("material_0.solid.emissivity", 1.);
+  material_property_database.put("material_0.powder.emissivity", 1.);
+  material_property_database.put("material_0.liquid.emissivity", 1.);
+  material_property_database.put(
+      "material_0.solid.radiation_heat_transfer_coef", 1.);
+  material_property_database.put(
+      "material_0.powder.radiation_heat_transfer_coef", 1.);
+  material_property_database.put(
+      "material_0.liquid.radiation_heat_transfer_coef", 1.);
+  material_property_database.put(
+      "material_0.solid.convection_heat_transfer_coef", 1.);
+  material_property_database.put(
+      "material_0.powder.convection_heat_transfer_coef", 1.);
+  material_property_database.put(
+      "material_0.liquid.convection_heat_transfer_coef", 1.);
+  material_property_database.put("material_0.radiation_temperature_infty", 0.0);
+  material_property_database.put("material_0.convection_temperature_infty",
+                                 20.0);
+  // Build MaterialProperty
+  adamantine::MaterialProperty<2, MemorySpaceType> material_properties(
+      communicator, geometry.get_triangulation(), material_property_database);
   boost::property_tree::ptree database;
-  // Material property
-  database.put("materials.property_format", "polynomial");
-  database.put("materials.n_materials", 1);
-  database.put("materials.material_0.solid.density", 1.);
-  database.put("materials.material_0.powder.density", 1.);
-  database.put("materials.material_0.liquid.density", 1.);
-  database.put("materials.material_0.solid.specific_heat", 1.);
-  database.put("materials.material_0.powder.specific_heat", 1.);
-  database.put("materials.material_0.liquid.specific_heat", 1.);
-  database.put("materials.material_0.solid.thermal_conductivity_x", 1.);
-  database.put("materials.material_0.solid.thermal_conductivity_z", 1.);
-  database.put("materials.material_0.powder.thermal_conductivity_x", 1.);
-  database.put("materials.material_0.powder.thermal_conductivity_z", 1.);
-  database.put("materials.material_0.liquid.thermal_conductivity_x", 1.);
-  database.put("materials.material_0.liquid.thermal_conductivity_z", 1.);
-  database.put("materials.material_0.solid.emissivity", 1.);
-  database.put("materials.material_0.powder.emissivity", 1.);
-  database.put("materials.material_0.liquid.emissivity", 1.);
-  database.put("materials.material_0.solid.radiation_heat_transfer_coef", 1.);
-  database.put("materials.material_0.powder.radiation_heat_transfer_coef", 1.);
-  database.put("materials.material_0.liquid.radiation_heat_transfer_coef", 1.);
-  database.put("materials.material_0.solid.convection_heat_transfer_coef", 1.);
-  database.put("materials.material_0.powder.convection_heat_transfer_coef", 1.);
-  database.put("materials.material_0.liquid.convection_heat_transfer_coef", 1.);
-  database.put("materials.material_0.radiation_temperature_infty", 0.0);
-  database.put("materials.material_0.convection_temperature_infty", 20.0);
   // Source database
   database.put("sources.n_beams", 0);
   // Time-stepping database
@@ -461,7 +526,7 @@ void convection_bcs()
   database.put("boundary.type", "convective");
   // Build ThermalPhysics
   adamantine::ThermalPhysics<2, 2, dealii::MemorySpace::Host, dealii::QGauss<1>>
-      physics(communicator, database, geometry);
+      physics(communicator, database, geometry, material_properties);
   physics.setup_dofs();
   physics.update_material_deposition_orientation();
   physics.compute_inverse_mass_matrix();


### PR DESCRIPTION
This PR does two things:
 - Move `MaterialProperty` out of `ThermalPhysics` since we also need it in `MechanicalPhysics`
 - Add support for mechanical properties in `MaterialProperty`. Unlike thermal properties, mechanical properties only exist on the host so we cannot simply extend the current data structure to accommodate the mechanical properties. Instead part of the data structures needs to be duplicated.