### PR TITLE
Fix timer print-out text

### DIFF
--- a/application/adamantine.cc
+++ b/application/adamantine.cc
@@ -124,18 +124,20 @@ int main(int argc, char *argv[])
     int const dim = geometry_database.get<int>("dim");
 
     unsigned int rank = dealii::Utilities::MPI::this_mpi_process(communicator);
-    if (rank == 0)
-      std::cout << "Starting simulation" << std::endl;
 
     if (dim == 2)
     {
       if (ensemble_calc)
       {
+        if (rank == 0)
+          std::cout << "Starting ensemble simulation" << std::endl;
         run_ensemble<2, dealii::MemorySpace::Host>(communicator, database,
                                                    timers);
       }
       else
       {
+        if (rank == 0)
+          std::cout << "Starting non-ensemble simulation" << std::endl;
         run<2, dealii::MemorySpace::Host>(communicator, database, timers);
       }
     }
@@ -143,11 +145,15 @@ int main(int argc, char *argv[])
     {
       if (ensemble_calc)
       {
+        if (rank == 0)
+          std::cout << "Starting ensemble simulation" << std::endl;
         run_ensemble<3, dealii::MemorySpace::Host>(communicator, database,
                                                    timers);
       }
       else
       {
+        if (rank == 0)
+          std::cout << "Starting non-ensemble simulation" << std::endl;
         run<3, dealii::MemorySpace::Host>(communicator, database, timers);
       }
     }

--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -171,8 +171,6 @@ inline void initialize_timers(MPI_Comm const &communicator,
       adamantine::Timer(communicator, "Data Assimilation, Exp. Cov."));
   timers.push_back(
       adamantine::Timer(communicator, "Data Assimilation, Update Ensemble"));
-  timers.push_back(
-      adamantine::Timer(communicator, "Data Assimilation, Exp. Data"));
   timers.push_back(adamantine::Timer(communicator, "Evolve One Time Step"));
   timers.push_back(adamantine::Timer(
       communicator, "Evolve One Time Step: evaluate_thermal_physics"));


### PR DESCRIPTION
The text for the timer for reading in experimental data was added twice to the `timers` vector. This lead to incorrect matching between the timer text and the timer counters.

I also changed the simulation start notification to say whether it is an ensemble simulation or not.