### PR TITLE
Add Caliper, Adiak, and dealii-weak_forms to the adamantine docker image

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -18,5 +18,12 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
 RUN cd /home && git clone https://github.com/adamantine-sim/adamantine && \
     cd adamantine && \
     mkdir build && cd build && \
-    cmake -DDEAL_II_DIR=${DEAL_II_DIR} -DCMAKE_BUILD_TYPE=Release ../ && \
+    cmake \
+      -DDEAL_II_DIR=${DEAL_II_DIR} \
+      -DCMAKE_BUILD_TYPE=Release\
+      -DCMAKE_CXX_FLAGS="-g" \
+      -DADAMANTINE_ENABLE_ADIAK=ON \
+      -DADAMANTINE_ENABLE_CALIPER=ON \
+      -DADAMANTINE_ENABLE_DEALII_WEAK_FORMS=ON \
+    ../ && \
     make && mv bin ../ && cd ../ && rm -r build


### PR DESCRIPTION
- Adding `dealii-weak_forms` to the docker image that we produce on merge to allow people to use the mechanical simulation.
- Adding Caliper and Adiak, so user can send us a `cali` file to know why the code is slow.