### PR TITLE
Use MatrixFree framework to compute the inverse of the mass matrix

### DIFF
--- a/source/ThermalOperator.hh
+++ b/source/ThermalOperator.hh
@@ -38,12 +38,11 @@ public:
               dealii::hp::QCollection<1> const &quad) override;
 
   /**
-   * Compute the inverse of the mass matrix and update the material properties.
+   * Compute the inverse of the mass matrix.
    */
   void compute_inverse_mass_matrix(
       dealii::DoFHandler<dim> const &dof_handler,
-      dealii::AffineConstraints<double> const &affine_constraints,
-      dealii::hp::FECollection<dim> const &fe_collection) override;
+      dealii::AffineConstraints<double> const &affine_constraints) override;
 
   /**
    * Clear the MatrixFree object and resize the inverse of the mass matrix to
@@ -147,6 +146,15 @@ private:
    * Apply the operator on a given set of quadrature points.
    */
   void cell_local_apply(
+      dealii::MatrixFree<dim, double> const &data,
+      dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
+      dealii::LA::distributed::Vector<double, MemorySpaceType> const &src,
+      std::pair<unsigned int, unsigned int> const &cell_range) const;
+
+  /**
+   * Apply the mass operator on a given set of quadrature points.
+   */
+  void cell_local_mass(
       dealii::MatrixFree<dim, double> const &data,
       dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
       dealii::LA::distributed::Vector<double, MemorySpaceType> const &src,

--- a/source/ThermalOperatorBase.hh
+++ b/source/ThermalOperatorBase.hh
@@ -31,8 +31,7 @@ public:
 
   virtual void compute_inverse_mass_matrix(
       dealii::DoFHandler<dim> const &dof_handler,
-      dealii::AffineConstraints<double> const &affine_constraints,
-      dealii::hp::FECollection<dim> const &fe_collection) = 0;
+      dealii::AffineConstraints<double> const &affine_constraints) = 0;
 
   virtual std::shared_ptr<
       dealii::LA::distributed::Vector<double, MemorySpaceType>>

--- a/source/ThermalOperatorDevice.cu
+++ b/source/ThermalOperatorDevice.cu
@@ -467,8 +467,7 @@ template <int dim, int fe_degree, typename MemorySpaceType>
 void ThermalOperatorDevice<dim, fe_degree, MemorySpaceType>::
     compute_inverse_mass_matrix(
         dealii::DoFHandler<dim> const &dof_handler,
-        dealii::AffineConstraints<double> const &affine_constraints,
-        dealii::hp::FECollection<dim> const & /*fe_collection*/)
+        dealii::AffineConstraints<double> const &affine_constraints)
 {
   // Compute the inverse of the mass matrix
   dealii::QGaussLobatto<1> mass_matrix_quad(fe_degree + 1);
@@ -476,10 +475,8 @@ void ThermalOperatorDevice<dim, fe_degree, MemorySpaceType>::
 
   typename dealii::CUDAWrappers::MatrixFree<dim, double>::AdditionalData
       mf_data;
-  // FIXME update_gradients is necessary because of a bug in deal.II
   mf_data.mapping_update_flags =
-      dealii::update_values | dealii::update_gradients |
-      dealii::update_JxW_values | dealii::update_quadrature_points;
+      dealii::update_values | dealii::update_JxW_values;
   mass_matrix_free.reinit(dof_handler, affine_constraints, mass_matrix_quad,
                           mf_data);
   mass_matrix_free.initialize_dof_vector(*_inverse_mass_matrix);

--- a/source/ThermalOperatorDevice.hh
+++ b/source/ThermalOperatorDevice.hh
@@ -31,8 +31,7 @@ public:
 
   void compute_inverse_mass_matrix(
       dealii::DoFHandler<dim> const &dof_handler,
-      dealii::AffineConstraints<double> const &affine_constraints,
-      dealii::hp::FECollection<dim> const &fe_collection) override;
+      dealii::AffineConstraints<double> const &affine_constraints) override;
 
   void clear() override;
 

--- a/source/ThermalPhysics.templates.hh
+++ b/source/ThermalPhysics.templates.hh
@@ -554,8 +554,8 @@ template <int dim, int fe_degree, typename MemorySpaceType,
 void ThermalPhysics<dim, fe_degree, MemorySpaceType,
                     QuadratureType>::compute_inverse_mass_matrix()
 {
-  _thermal_operator->compute_inverse_mass_matrix(
-      _dof_handler, _affine_constraints, _fe_collection);
+  _thermal_operator->compute_inverse_mass_matrix(_dof_handler,
+                                                 _affine_constraints);
   if (_implicit_method == true)
     _implicit_operator->set_inverse_mass_matrix(
         _thermal_operator->get_inverse_mass_matrix());

--- a/tests/test_implicit_operator.cc
+++ b/tests/test_implicit_operator.cc
@@ -94,8 +94,8 @@ BOOST_AUTO_TEST_CASE(implicit_operator)
   thermal_operator->reinit(dof_handler, affine_constraints, q_collection);
   thermal_operator->set_material_deposition_orientation(deposition_cos,
                                                         deposition_sin);
-  thermal_operator->compute_inverse_mass_matrix(dof_handler, affine_constraints,
-                                                fe_collection);
+  thermal_operator->compute_inverse_mass_matrix(dof_handler,
+                                                affine_constraints);
   dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> dummy(
       thermal_operator->m());
   thermal_operator->get_state_from_material_properties();

--- a/tests/test_post_processor.cc
+++ b/tests/test_post_processor.cc
@@ -90,8 +90,7 @@ BOOST_AUTO_TEST_CASE(thermal_post_processor)
   thermal_operator.reinit(dof_handler, affine_constraints, q_collection);
   thermal_operator.set_material_deposition_orientation(deposition_cos,
                                                        deposition_sin);
-  thermal_operator.compute_inverse_mass_matrix(dof_handler, affine_constraints,
-                                               fe_collection);
+  thermal_operator.compute_inverse_mass_matrix(dof_handler, affine_constraints);
 
   // Create the PostProcessor
   boost::property_tree::ptree post_processor_database;

--- a/tests/test_thermal_operator.cc
+++ b/tests/test_thermal_operator.cc
@@ -94,8 +94,7 @@ BOOST_AUTO_TEST_CASE(thermal_operator, *utf::tolerance(1e-15))
   thermal_operator.reinit(dof_handler, affine_constraints, q_collection);
   thermal_operator.set_material_deposition_orientation(deposition_cos,
                                                        deposition_sin);
-  thermal_operator.compute_inverse_mass_matrix(dof_handler, affine_constraints,
-                                               fe_collection);
+  thermal_operator.compute_inverse_mass_matrix(dof_handler, affine_constraints);
   thermal_operator.get_state_from_material_properties();
 
   BOOST_TEST(thermal_operator.m() == 99);
@@ -197,8 +196,7 @@ BOOST_AUTO_TEST_CASE(spmv, *utf::tolerance(1e-12))
   thermal_operator.reinit(dof_handler, affine_constraints, q_collection);
   thermal_operator.set_material_deposition_orientation(deposition_cos,
                                                        deposition_sin);
-  thermal_operator.compute_inverse_mass_matrix(dof_handler, affine_constraints,
-                                               fe_collection);
+  thermal_operator.compute_inverse_mass_matrix(dof_handler, affine_constraints);
   thermal_operator.get_state_from_material_properties();
   BOOST_TEST(thermal_operator.m() == 99);
   BOOST_TEST(thermal_operator.m() == thermal_operator.n());
@@ -304,8 +302,7 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic, *utf::tolerance(1e-12))
   thermal_operator.reinit(dof_handler, affine_constraints, q_collection);
   thermal_operator.set_material_deposition_orientation(deposition_cos,
                                                        deposition_sin);
-  thermal_operator.compute_inverse_mass_matrix(dof_handler, affine_constraints,
-                                               fe_collection);
+  thermal_operator.compute_inverse_mass_matrix(dof_handler, affine_constraints);
   thermal_operator.get_state_from_material_properties();
   BOOST_TEST(thermal_operator.m() == 99);
   BOOST_TEST(thermal_operator.m() == thermal_operator.n());
@@ -444,8 +441,7 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic_angle, *utf::tolerance(1e-10))
   thermal_operator.reinit(dof_handler, affine_constraints, q_collection);
   thermal_operator.set_material_deposition_orientation(deposition_cos,
                                                        deposition_sin);
-  thermal_operator.compute_inverse_mass_matrix(dof_handler, affine_constraints,
-                                               fe_collection);
+  thermal_operator.compute_inverse_mass_matrix(dof_handler, affine_constraints);
   thermal_operator.get_state_from_material_properties();
   BOOST_TEST(thermal_operator.m() == thermal_operator.n());
 
@@ -609,8 +605,7 @@ BOOST_AUTO_TEST_CASE(spmv_rad, *utf::tolerance(1e-12))
   thermal_operator.reinit(dof_handler, affine_constraints, q_collection);
   thermal_operator.set_material_deposition_orientation(deposition_cos,
                                                        deposition_sin);
-  thermal_operator.compute_inverse_mass_matrix(dof_handler, affine_constraints,
-                                               fe_collection);
+  thermal_operator.compute_inverse_mass_matrix(dof_handler, affine_constraints);
   dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host>
       temperature(thermal_operator.m());
   for (unsigned int i = 0; i < temperature.locally_owned_size(); ++i)

--- a/tests/test_thermal_operator_device.cu
+++ b/tests/test_thermal_operator_device.cu
@@ -75,8 +75,8 @@ BOOST_AUTO_TEST_CASE(thermal_operator_dev, *utf::tolerance(1e-10))
   adamantine::ThermalOperatorDevice<2, 2, dealii::MemorySpace::CUDA>
       thermal_operator_dev(communicator, adamantine::BoundaryType::adiabatic,
                            mat_properties);
-  thermal_operator_dev.compute_inverse_mass_matrix(
-      dof_handler, affine_constraints, fe_collection);
+  thermal_operator_dev.compute_inverse_mass_matrix(dof_handler,
+                                                   affine_constraints);
   std::vector<double> deposition_cos(
       geometry.get_triangulation().n_locally_owned_active_cells(), 1.);
   std::vector<double> deposition_sin(
@@ -163,8 +163,8 @@ BOOST_AUTO_TEST_CASE(spmv, *utf::tolerance(1e-12))
   adamantine::ThermalOperatorDevice<2, 2, dealii::MemorySpace::CUDA>
       thermal_operator_dev(communicator, adamantine::BoundaryType::adiabatic,
                            mat_properties);
-  thermal_operator_dev.compute_inverse_mass_matrix(
-      dof_handler, affine_constraints, fe_collection);
+  thermal_operator_dev.compute_inverse_mass_matrix(dof_handler,
+                                                   affine_constraints);
   std::vector<double> deposition_cos(
       geometry.get_triangulation().n_locally_owned_active_cells(), 1.);
   std::vector<double> deposition_sin(
@@ -280,8 +280,8 @@ BOOST_AUTO_TEST_CASE(mf_spmv, *utf::tolerance(1.5e-12))
   adamantine::ThermalOperatorDevice<2, 2, dealii::MemorySpace::CUDA>
       thermal_operator_dev(communicator, adamantine::BoundaryType::adiabatic,
                            mat_properties);
-  thermal_operator_dev.compute_inverse_mass_matrix(
-      dof_handler, affine_constraints, fe_collection);
+  thermal_operator_dev.compute_inverse_mass_matrix(dof_handler,
+                                                   affine_constraints);
   std::vector<double> deposition_cos(
       geometry.get_triangulation().n_locally_owned_active_cells(), 1.);
   std::vector<double> deposition_sin(
@@ -295,8 +295,8 @@ BOOST_AUTO_TEST_CASE(mf_spmv, *utf::tolerance(1.5e-12))
   adamantine::ThermalOperator<2, 2, dealii::MemorySpace::Host>
       thermal_operator_host(communicator, adamantine::BoundaryType::adiabatic,
                             mat_properties_host, heat_sources);
-  thermal_operator_host.compute_inverse_mass_matrix(
-      dof_handler, affine_constraints, fe_collection);
+  thermal_operator_host.compute_inverse_mass_matrix(dof_handler,
+                                                    affine_constraints);
   thermal_operator_host.reinit(dof_handler, affine_constraints, q_collection);
   thermal_operator_host.set_material_deposition_orientation(deposition_cos,
                                                             deposition_sin);


### PR DESCRIPTION
With this PR, computing the inverse of the mass matrix is negligible. Now when adding material, most of the time is spent in p4est.

Related to #172 

[CI](https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/adamantine/detail/adamantine/294/pipeline)