### PR TITLE
Move computation of temperature powers out of MaterialProperty 

### DIFF
--- a/source/MaterialProperty.hh
+++ b/source/MaterialProperty.hh
@@ -13,6 +13,7 @@
 #include <types.hh>
 #include <utils.hh>
 
+#include <deal.II/base/aligned_vector.h>
 #include <deal.II/base/memory_space.h>
 #include <deal.II/base/types.h>
 #include <deal.II/distributed/tria.h>
@@ -129,11 +130,13 @@ public:
   /**
    * Compute a material property at a quadrature point for a mix of states.
    */
-  dealii::VectorizedArray<double>
-  compute_material_property(StateProperty state_property,
-                            dealii::types::material_id const *material_id,
-                            dealii::VectorizedArray<double> const *state_ratios,
-                            dealii::VectorizedArray<double> temperature) const;
+  dealii::VectorizedArray<double> compute_material_property(
+      StateProperty state_property,
+      dealii::types::material_id const *material_id,
+      dealii::VectorizedArray<double> const *state_ratios,
+      dealii::VectorizedArray<double> const &temperature,
+      dealii::AlignedVector<dealii::VectorizedArray<double>> const
+          &temperature_powers) const;
 
   /**
    * Compute a material property at a quadrature point for a mix of states.

--- a/source/MaterialProperty.templates.hh
+++ b/source/MaterialProperty.templates.hh
@@ -9,11 +9,13 @@
 #include <MemoryBlock.hh>
 #include <MemoryBlockView.hh>
 
+#include <deal.II/base/aligned_vector.h>
 #include <deal.II/base/array_view.h>
 #include <deal.II/base/cuda.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/types.h>
+#include <deal.II/base/vectorization.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/fe/mapping.h>
@@ -476,7 +478,9 @@ dealii::VectorizedArray<double>
 MaterialProperty<dim, MemorySpaceType>::compute_material_property(
     StateProperty state_property, dealii::types::material_id const *material_id,
     dealii::VectorizedArray<double> const *state_ratios,
-    dealii::VectorizedArray<double> temperature) const
+    dealii::VectorizedArray<double> const &temperature,
+    dealii::AlignedVector<dealii::VectorizedArray<double>> const
+        &temperature_powers) const
 {
   dealii::VectorizedArray<double> value = 0.0;
   unsigned int const property_index = static_cast<unsigned int>(state_property);
@@ -515,7 +519,7 @@ MaterialProperty<dim, MemorySpaceType>::compute_material_property(
           value[n] += state_ratios[material_state][n] *
                       state_property_polynomials_view(m_id, material_state,
                                                       property_index, i) *
-                      std::pow(temperature[n], i);
+                      temperature_powers[i][n];
         }
       }
     }

--- a/source/ThermalOperator.hh
+++ b/source/ThermalOperator.hh
@@ -12,6 +12,7 @@
 #include <MaterialProperty.hh>
 #include <ThermalOperatorBase.hh>
 
+#include <deal.II/base/aligned_vector.h>
 #include <deal.II/matrix_free/matrix_free.h>
 
 namespace adamantine
@@ -135,12 +136,14 @@ private:
    * Return the value of \f$ \frac{1}{\rho C_p} \f$ for a given matrix-free cell
    * and quadrature point.
    */
-  dealii::VectorizedArray<double>
-  get_inv_rho_cp(unsigned int cell, unsigned int q,
-                 std::array<dealii::VectorizedArray<double>,
-                            static_cast<unsigned int>(MaterialState::SIZE)>
-                     state_ratios,
-                 dealii::VectorizedArray<double> temperature) const;
+  dealii::VectorizedArray<double> get_inv_rho_cp(
+      unsigned int cell, unsigned int q,
+      std::array<dealii::VectorizedArray<double>,
+                 static_cast<unsigned int>(MaterialState::SIZE)> const
+          &state_ratios,
+      dealii::VectorizedArray<double> const &temperature,
+      dealii::AlignedVector<dealii::VectorizedArray<double>> const
+          &temperature_powers) const;
 
   /**
    * Apply the operator on a given set of quadrature points.


### PR DESCRIPTION
When using `adiabatic` boundary condition, the majority of the time is spent computing the powers of the temperature in order to evaluate material properties. Instead of computing the powers every time we need to get a material property, we compute them once and give them to `MaterialProperty`. While this improves performance a lot, computing the powers of the temperature is still the most expensive part of performing one time step.

Related to #172
[CI](https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/adamantine/detail/adamantine/300/pipeline)