### PR TITLE
Add support for material addition when using GPU.

### DIFF
--- a/source/ThermalOperatorDevice.cu
+++ b/source/ThermalOperatorDevice.cu
@@ -371,9 +371,9 @@ __device__ void LocalThermalOperatorDevice<dim, fe_degree>::operator()(
   dealii::CUDAWrappers::FEEvaluation<dim, fe_degree, fe_degree + 1, 1, double>
       fe_eval(cell, gpu_data, shared_data);
   fe_eval.read_dof_values(src);
-  fe_eval.evaluate(/*values*/ false, /*gradients*/ true);
+  fe_eval.evaluate(/*values*/ true, /*gradients*/ true);
 
-  double temperature = src[pos];
+  double temperature = fe_eval.get_value();
   double
       state_ratios[static_cast<unsigned int>(adamantine::MaterialState::SIZE)];
   update_state_ratios(pos, temperature, state_ratios);
@@ -420,8 +420,10 @@ void ThermalOperatorDevice<dim, fe_degree, MemorySpaceType>::reinit(
     dealii::AffineConstraints<double> const &affine_constraints,
     dealii::hp::QCollection<1> const &q_collection)
 {
-  // FIXME deal.II does not support QCollection on GPU
-  _matrix_free.reinit(dof_handler, affine_constraints, q_collection[0],
+  dealii::IteratorFilters::ActiveFEIndexEqualTo filter(0, true);
+  // deal.II does not support QCollection on GPU
+  _matrix_free.reinit(dealii::StaticMappingQ1<dim>::mapping, dof_handler,
+                      affine_constraints, q_collection[0], filter,
                       _matrix_free_data);
   dealii::LA::distributed::Vector<double, MemorySpaceType> tmp;
   _matrix_free.initialize_dof_vector(tmp);
@@ -477,7 +479,9 @@ void ThermalOperatorDevice<dim, fe_degree, MemorySpaceType>::
       mf_data;
   mf_data.mapping_update_flags =
       dealii::update_values | dealii::update_JxW_values;
-  mass_matrix_free.reinit(dof_handler, affine_constraints, mass_matrix_quad,
+  dealii::IteratorFilters::ActiveFEIndexEqualTo filter(0, true);
+  mass_matrix_free.reinit(dealii::StaticMappingQ1<dim>::mapping, dof_handler,
+                          affine_constraints, mass_matrix_quad, filter,
                           mf_data);
   mass_matrix_free.initialize_dof_vector(*_inverse_mass_matrix);
   // We don't save memory by not allocating the vector. Instead this is done in

--- a/source/ThermalPhysics.templates.hh
+++ b/source/ThermalPhysics.templates.hh
@@ -9,6 +9,9 @@
 #define THERMAL_PHYSICS_TEMPLATES_HH
 
 #include <ThermalOperator.hh>
+
+#include <deal.II/base/index_set.h>
+#include <deal.II/lac/read_write_vector.h>
 #if defined(ADAMANTINE_HAVE_CUDA) && defined(__CUDACC__)
 #include <ThermalOperatorDevice.hh>
 #endif
@@ -612,6 +615,13 @@ void ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::
                         material_state_view.data(), memspace,
                         material_state_view.size());
 
+  // We need to move the solution on the host because we cannot use
+  // CellDataTransfer on the device.
+  dealii::IndexSet rw_index_set = solution.locally_owned_elements();
+  rw_index_set.add_indices(solution.get_partitioner()->ghost_indices());
+  dealii::LA::ReadWriteVector<double> rw_solution(rw_index_set);
+  rw_solution.import(solution, dealii::VectorOperation::insert);
+
   adamantine::MemoryBlockView<double, dealii::MemorySpace::Host>
       state_host_view(material_state_host);
   unsigned int cell_id = 0;
@@ -625,7 +635,7 @@ void ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::
       if (cell->active_fe_index() == 0)
       {
         std::vector<double> cell_data(direction_data_size + n_material_states);
-        cell->get_dof_values(solution, cell_solution);
+        cell->get_dof_values(rw_solution, cell_solution);
         cell_data.insert(cell_data.begin(), cell_solution.begin(),
                          cell_solution.end());
         cell_data[n_dofs_per_cell] = _deposition_cos[cell_id];
@@ -690,7 +700,12 @@ void ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::
   // Recompute the inverse of the mass matrix
   compute_inverse_mass_matrix();
 
-  initialize_dof_vector(new_material_temperature, solution);
+  initialize_dof_vector(std::numeric_limits<double>::infinity(), solution);
+  rw_index_set = solution.locally_owned_elements();
+  rw_index_set.add_indices(solution.get_partitioner()->ghost_indices());
+  rw_solution.reinit(rw_index_set);
+  for (auto val : solution.locally_owned_elements())
+    rw_solution[val] = new_material_temperature;
 
   // Unpack the material state and repopulate the material state
   std::vector<std::vector<double>> transferred_data(
@@ -714,7 +729,7 @@ void ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::
         std::copy(transferred_data[active_cell_id].begin(),
                   transferred_data[active_cell_id].begin() + n_dofs_per_cell,
                   cell_solution.begin());
-        cell->set_dof_values(cell_solution, solution);
+        cell->set_dof_values(cell_solution, rw_solution);
       }
 
       if (cell->active_fe_index() == 0)
@@ -740,7 +755,7 @@ void ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::
                                                          _deposition_sin);
 
   // Communicate the results.
-  solution.compress(dealii::VectorOperation::min);
+  solution.import(rw_solution, dealii::VectorOperation::min);
 
   // Set the value to the newly create DoFs. Here we need to be careful with the
   // hanging nodes. When there is a hanging node, the dofs at the vertices are
@@ -748,7 +763,9 @@ void ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::
   // associated to the fine cell. The final value is decided by
   // AffineConstraints. Thus, we need to make sure that the newly activated
   // cells are at the same level than their neighbors.
-  std::for_each(solution.begin(), solution.end(),
+  rw_solution.reinit(solution.locally_owned_elements());
+  rw_solution.import(solution, dealii::VectorOperation::insert);
+  std::for_each(rw_solution.begin(), rw_solution.end(),
                 [&](double &val)
                 {
                   if (val == std::numeric_limits<double>::infinity())
@@ -756,6 +773,7 @@ void ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::
                     val = new_material_temperature;
                   }
                 });
+  solution.import(rw_solution, dealii::VectorOperation::insert);
 }
 
 template <int dim, int fe_degree, typename MemorySpaceType,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ set(CUDA_UNIT_TESTS "")
 list(APPEND
      CUDA_UNIT_TESTS
      test_integration_2d_device
+     test_integration_3d_device
      test_material_property_device
      test_thermal_operator_device
      test_thermal_physics_device

--- a/tests/test_integration_3d_device.cu
+++ b/tests/test_integration_3d_device.cu
@@ -1,0 +1,43 @@
+/* Copyright (c) 2022, the adamantine authors.
+ *
+ * This file is subject to the Modified BSD License and may not be distributed
+ * without copyright and license information. Please refer to the file LICENSE
+ * for the text and further information on this license.
+ */
+
+#define BOOST_TEST_MODULE Integration_3D_Device
+
+#include "../application/adamantine.hh"
+
+#include <fstream>
+
+#include "main.cc"
+
+namespace utf = boost::unit_test;
+
+BOOST_AUTO_TEST_CASE(integration_3D_device, *utf::tolerance(0.1))
+{
+  MPI_Comm communicator = MPI_COMM_WORLD;
+
+  std::vector<adamantine::Timer> timers;
+  initialize_timers(communicator, timers);
+
+  // Read the input.
+  std::string const filename = "demo_316_short_anisotropic.info";
+  adamantine::ASSERT_THROW(boost::filesystem::exists(filename) == true,
+                           "The file " + filename + " does not exist.");
+  boost::property_tree::ptree database;
+  boost::property_tree::info_parser::read_info(filename, database);
+
+  auto [temperature, displacement] =
+      run<3, dealii::MemorySpace::CUDA>(communicator, database, timers);
+
+  std::ifstream gold_file("integration_3d_gold.txt");
+  for (unsigned int i = 0; i < temperature.locally_owned_size(); ++i)
+  {
+    double gold_value = -1.;
+    gold_file >> gold_value;
+    BOOST_TEST(temperature.local_element(i) == gold_value);
+  }
+}
+


### PR DESCRIPTION
After this PR is merged, AMR will be the only capability missing on GPU. Some of these capabilities are actually run on the CPU but hopefully we can move them on the GPU later on.

[ci](https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/adamantine/detail/adamantine/327/pipeline)