### PR TITLE
Make polynomial_order and table_size constexpr

### DIFF
--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -362,6 +362,10 @@ void refine_and_transfer(
     dealii::DoFHandler<dim> &dof_handler,
     dealii::LA::distributed::Vector<double, MemorySpaceType> &solution)
 {
+#ifdef ADAMANTINE_WITH_CALIPER
+  CALI_CXX_MARK_FUNCTION;
+#endif
+
   dealii::parallel::distributed::Triangulation<dim> &triangulation =
       dynamic_cast<dealii::parallel::distributed::Triangulation<dim> &>(
           const_cast<dealii::Triangulation<dim> &>(
@@ -459,8 +463,14 @@ void refine_and_transfer(
       cell_data_trans(triangulation);
   cell_data_trans.prepare_for_coarsening_and_refinement(data_to_transfer);
 
+#ifdef ADAMANTINE_WITH_CALIPER
+  CALI_MARK_BEGIN("refine triangulation");
+#endif
   // Execute the refinement
   triangulation.execute_coarsening_and_refinement();
+#ifdef ADAMANTINE_WITH_CALIPER
+  CALI_MARK_END("refine triangulation");
+#endif
 
   // Update the AffineConstraints and resize the solution
   thermal_physics->setup_dofs();

--- a/source/MaterialProperty.hh
+++ b/source/MaterialProperty.hh
@@ -54,11 +54,6 @@ public:
   bool properties_use_table() const;
 
   /**
-   * Return the order of the polynomial used to set the material properties
-   */
-  unsigned int polynomial_order() const;
-
-  /**
    * Return the value of the given StateProperty for a given cell.
    */
   double get_cell_value(
@@ -214,6 +209,17 @@ public:
       unsigned int const material_id, unsigned int const material_state,
       unsigned int const property, double const temperature);
 
+  /**
+   * Order of the polynomial used to describe the material properties.
+   */
+  static unsigned int constexpr polynomial_order = 4;
+
+  /**
+   * Size of the table, i.e. number of temperature/property pairs, used to
+   * describe the material properties.
+   */
+  static unsigned int constexpr table_size = 4;
+
 private:
   /**
    * Maximum different number of states a given material can be.
@@ -244,17 +250,6 @@ private:
    */
   static unsigned int constexpr _n_properties =
       static_cast<unsigned int>(Property::SIZE);
-
-  /**
-   * Order of the polynomial used to describe the material properties.
-   */
-  unsigned int _polynomial_order = 0;
-
-  /**
-   * Size of the table, i.e. number of temperature/property pairs, used to
-   * describe the material properties.
-   */
-  unsigned int _table_size = 0;
 
   /**
    * Fill the _properties map.
@@ -368,13 +363,6 @@ template <int dim, typename MemorySpaceType>
 inline bool MaterialProperty<dim, MemorySpaceType>::properties_use_table() const
 {
   return _use_table;
-}
-
-template <int dim, typename MemorySpaceType>
-inline unsigned int
-MaterialProperty<dim, MemorySpaceType>::polynomial_order() const
-{
-  return _polynomial_order;
 }
 
 template <int dim, typename MemorySpaceType>

--- a/source/ThermalOperator.cc
+++ b/source/ThermalOperator.cc
@@ -398,9 +398,8 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::cell_local_apply(
   // could compute it in MaterialProperty but because it's in a hot loop.
   // It's really worth to compute it once and pass it when we compute a
   // material property.
-  unsigned int const polynomial_order = _material_properties.polynomial_order();
   dealii::AlignedVector<dealii::VectorizedArray<double>> temperature_powers(
-      polynomial_order + 1);
+      _material_properties.polynomial_order + 1);
 
   // Loop over the "cells". Note that we don't really work on a cell but on a
   // set of quadrature point.
@@ -420,7 +419,7 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::cell_local_apply(
     {
       auto temperature = fe_eval.get_value(q);
       // Precompute the powers of temperature.
-      for (unsigned int i = 0; i <= polynomial_order; ++i)
+      for (unsigned int i = 0; i <= _material_properties.polynomial_order; ++i)
       {
         // FIXME Need to cast i to double due to a limitation in deal.II 9.5
         temperature_powers[i] = std::pow(temperature, static_cast<double>(i));
@@ -566,9 +565,8 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::face_local_apply(
   // could compute it in MaterialProperty but because it's in a hot loop.
   // It's really worth to compute it once and pass it when we compute a
   // material property.
-  unsigned int const polynomial_order = _material_properties.polynomial_order();
   dealii::AlignedVector<dealii::VectorizedArray<double>> temperature_powers(
-      polynomial_order + 1);
+      _material_properties.polynomial_order + 1);
 
   // Loop over the faces
   for (unsigned int face = face_range.first; face < face_range.second; ++face)
@@ -585,7 +583,7 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::face_local_apply(
     {
       auto temperature = fe_face_eval.get_value(q);
       // Precompute the powers of temperature.
-      for (unsigned int i = 0; i <= polynomial_order; ++i)
+      for (unsigned int i = 0; i <= _material_properties.polynomial_order; ++i)
       {
         // FIXME Need to cast i to double due to a limitation in deal.II 9.5
         temperature_powers[i] = std::pow(temperature, static_cast<double>(i));

--- a/source/ThermalOperatorDevice.cu
+++ b/source/ThermalOperatorDevice.cu
@@ -538,7 +538,7 @@ void ThermalOperatorDevice<dim, fe_degree, MemorySpaceType>::vmult_add(
 
   LocalThermalOperatorDevice<dim, fe_degree> local_operator(
       _material_properties.properties_use_table(),
-      _material_properties.polynomial_order(), _deposition_cos.get_values(),
+      _material_properties.polynomial_order, _deposition_cos.get_values(),
       _deposition_sin.get_values(), powder_ratio_view, liquid_ratio_view,
       material_id_view, _inv_rho_cp, _material_properties.get_properties(),
       _material_properties.get_state_property_tables(),

--- a/source/ThermalPhysics.templates.hh
+++ b/source/ThermalPhysics.templates.hh
@@ -690,7 +690,13 @@ void ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::
       cell_data_trans(triangulation);
   cell_data_trans.prepare_for_coarsening_and_refinement(data_to_transfer);
 
+#ifdef ADAMANTINE_WITH_CALIPER
+  CALI_MARK_BEGIN("refine triangulation");
+#endif
   triangulation.execute_coarsening_and_refinement();
+#ifdef ADAMANTINE_WITH_CALIPER
+  CALI_MARK_END("refine triangulation");
+#endif
 
   setup_dofs();
 


### PR DESCRIPTION
With this PR, the compiler removes the call to `pow`. Now the execution time is dominated by adding material and refining the mesh.