### PR TITLE
Add AMR test on the GPU

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ list(APPEND
      CUDA_UNIT_TESTS
      test_integration_2d_device
      test_integration_3d_device
+     test_integration_3d_amr_device
      test_material_property_device
      test_thermal_operator_device
      test_thermal_physics_device

--- a/tests/test_integration_3d_amr_device.cu
+++ b/tests/test_integration_3d_amr_device.cu
@@ -1,0 +1,56 @@
+/* Copyright (c) 2023, the adamantine authors.
+ *
+ * This file is subject to the Modified BSD License and may not be distributed
+ * without copyright and license information. Please refer to the file LICENSE
+ * for the text and further information on this license.
+ */
+
+#define BOOST_TEST_MODULE Integration_3D_AMR
+
+#include "../application/adamantine.hh"
+
+#include <fstream>
+
+#include "main.cc"
+
+namespace utf = boost::unit_test;
+
+BOOST_AUTO_TEST_CASE(integration_3D_amr_device, *utf::tolerance(0.1))
+{
+  MPI_Comm communicator = MPI_COMM_WORLD;
+
+  std::vector<adamantine::Timer> timers;
+  initialize_timers(communicator, timers);
+
+  // Read the input.
+  std::string const filename = "amr_test.info";
+  adamantine::ASSERT_THROW(boost::filesystem::exists(filename) == true,
+                           "The file " + filename + " does not exist.");
+  boost::property_tree::ptree database;
+  boost::property_tree::info_parser::read_info(filename, database);
+
+  auto [temperature, displacement] =
+      run<3, dealii::MemorySpace::CUDA>(communicator, database, timers);
+
+  double min_val = std::numeric_limits<double>::max();
+  double max_val = std::numeric_limits<double>::min();
+  for (unsigned int i = 0; i < temperature.locally_owned_size(); ++i)
+  {
+    if (temperature.local_element(i) < min_val)
+      min_val = temperature.local_element(i);
+
+    if (temperature.local_element(i) > max_val)
+      max_val = temperature.local_element(i);
+  }
+
+  double global_max =
+      dealii::Utilities::MPI::max(max_val, temperature.get_mpi_communicator());
+  double global_min =
+      dealii::Utilities::MPI::min(min_val, temperature.get_mpi_communicator());
+
+  double expected_max = 329.5;
+  double expected_min = 296.1;
+
+  BOOST_TEST(expected_max == global_max);
+  BOOST_TEST(expected_min == global_min);
+}


### PR DESCRIPTION
For the longest time I thought that AMR did not work with GPU but apparently it does. It looks like the GPU has now the same capabilities as the CPU backend. The only thing left to do is to profile it and fix the bottlenecks.

[CI](https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/adamantine/detail/adamantine/342/pipeline)