### PR TITLE
Use FE_Nothing for everything but solid for mechanical simulation

### DIFF
--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 - 2022, the adamantine authors.
+/* Copyright (c) 2016 - 2023, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -1143,6 +1143,8 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
       {
         if (use_thermal_physics)
         {
+          // Update the material state
+          thermal_physics->set_state_to_material_properties();
           dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host>
               temperature_host(temperature.get_partitioner());
           temperature_host.import(temperature, dealii::VectorOperation::insert);

--- a/source/MaterialProperty.templates.hh
+++ b/source/MaterialProperty.templates.hh
@@ -862,12 +862,15 @@ void MaterialProperty<dim, MemorySpaceType>::fill_properties(
                 }
                 else
                 {
-                  mechanical_property_tables_host_view(
-                      material_id, p - _n_thermal_state_properties, i, 0) =
-                      std::stod(t_v[0]);
-                  mechanical_property_tables_host_view(
-                      material_id, p - _n_thermal_state_properties, i, 1) =
-                      std::stod(t_v[1]);
+                  if (state == static_cast<unsigned int>(MaterialState::solid))
+                  {
+                    mechanical_property_tables_host_view(
+                        material_id, p - _n_thermal_state_properties, i, 0) =
+                        std::stod(t_v[0]);
+                    mechanical_property_tables_host_view(
+                        material_id, p - _n_thermal_state_properties, i, 1) =
+                        std::stod(t_v[1]);
+                  }
                 }
               }
               // fill the rest  with the last value
@@ -884,16 +887,19 @@ void MaterialProperty<dim, MemorySpaceType>::fill_properties(
                 }
                 else
                 {
-                  mechanical_property_tables_host_view(
-                      material_id, p - _n_thermal_state_properties, i, 0) =
-                      mechanical_property_tables_host_view(
-                          material_id, p - _n_thermal_state_properties, i - 1,
-                          0);
-                  mechanical_property_tables_host_view(
-                      material_id, p - _n_thermal_state_properties, i, 1) =
-                      mechanical_property_tables_host_view(
-                          material_id, p - _n_thermal_state_properties, i - 1,
-                          1);
+                  if (state == static_cast<unsigned int>(MaterialState::solid))
+                  {
+                    mechanical_property_tables_host_view(
+                        material_id, p - _n_thermal_state_properties, i, 0) =
+                        mechanical_property_tables_host_view(
+                            material_id, p - _n_thermal_state_properties, i - 1,
+                            0);
+                    mechanical_property_tables_host_view(
+                        material_id, p - _n_thermal_state_properties, i, 1) =
+                        mechanical_property_tables_host_view(
+                            material_id, p - _n_thermal_state_properties, i - 1,
+                            1);
+                  }
                 }
               }
             }

--- a/source/MechanicalOperator.cc
+++ b/source/MechanicalOperator.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, the adamantine authors.
+/* Copyright (c) 2022 - 2023, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -153,7 +153,8 @@ void MechanicalOperator<dim, MemorySpaceType>::assemble_system()
 
   // FIXME the formulation below is more widespread but it doesn't work in
   // dealii-weak_forms yet. Keeping the implementation to use it in the
-  // future. assembler +=
+  // future.
+  // assembler +=
   //     dealiiWeakForms::WeakForms::bilinear_form(test_grad, lambda + mu,
   //                                               trial_grad)
   //         .dV() +

--- a/source/MechanicalPhysics.cc
+++ b/source/MechanicalPhysics.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, the adamantine authors.
+/* Copyright (c) 2022 - 2023, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -23,7 +23,8 @@ MechanicalPhysics<dim, MemorySpaceType>::MechanicalPhysics(
     Geometry<dim> &geometry,
     MaterialProperty<dim, MemorySpaceType> &material_properties,
     std::vector<double> reference_temperatures, bool include_gravity)
-    : _geometry(geometry), _dof_handler(_geometry.get_triangulation()),
+    : _geometry(geometry), _material_properties(material_properties),
+      _dof_handler(_geometry.get_triangulation()),
       _include_gravity(include_gravity)
 {
   // Create the FECollection
@@ -36,10 +37,26 @@ MechanicalPhysics<dim, MemorySpaceType>::MechanicalPhysics(
   _q_collection.push_back(dealii::QGauss<dim>(fe_degree + 1));
   _q_collection.push_back(dealii::QGauss<dim>(1));
 
+  // Solve the mechanical problem only on the part of the domain that has solid
+  // material.
+  for (auto const &cell :
+       dealii::filter_iterators(_dof_handler.active_cell_iterators(),
+                                dealii::IteratorFilters::LocallyOwnedCell()))
+  {
+    if (_material_properties.get_state_ratio(cell, MaterialState::solid) > 0.99)
+    {
+      cell->set_active_fe_index(0);
+    }
+    else
+    {
+      cell->set_active_fe_index(1);
+    }
+  }
+
   // Create the mechanical operator
   _mechanical_operator =
       std::make_unique<MechanicalOperator<dim, MemorySpaceType>>(
-          communicator, material_properties, reference_temperatures,
+          communicator, _material_properties, reference_temperatures,
           include_gravity);
 }
 
@@ -77,6 +94,20 @@ void MechanicalPhysics<dim, MemorySpaceType>::setup_dofs(
 {
   _mechanical_operator->update_temperature(thermal_dof_handler, temperature,
                                            has_melted);
+  // Update the active fe indices
+  for (auto const &cell :
+       dealii::filter_iterators(_dof_handler.active_cell_iterators(),
+                                dealii::IteratorFilters::LocallyOwnedCell()))
+  {
+    if (_material_properties.get_state_ratio(cell, MaterialState::solid) > 0.99)
+    {
+      cell->set_active_fe_index(0);
+    }
+    else
+    {
+      cell->set_active_fe_index(1);
+    }
+  }
   setup_dofs();
 }
 

--- a/source/MechanicalPhysics.hh
+++ b/source/MechanicalPhysics.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, the adamantine authors.
+/* Copyright (c) 2022 - 2023, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -64,6 +64,10 @@ private:
    * Associated Geometry.
    */
   Geometry<dim> &_geometry;
+  /**
+   * Associated MaterialProperty.
+   */
+  MaterialProperty<dim, MemorySpaceType> &_material_properties;
   /**
    * Associated FECollection.
    */

--- a/tests/test_thermal_physics.hh
+++ b/tests/test_thermal_physics.hh
@@ -621,7 +621,6 @@ void reference_temperature()
   physics.get_state_from_material_properties();
 
   // Now check that the melting indicator works as expected
-  double tol = 1e-10;
   std::vector<double> reference_temperatures({1500.0, 300.0});
 
   auto has_melted = physics.get_has_melted_vector();


### PR DESCRIPTION
Changes are trivial because we already supported `FE_Nothing`. I just had to tag the cells that are not solid with `FE_Nothing`.

Closes #185 and #187