### PR TITLE
Remove unused variable in input file

### DIFF
--- a/tests/data/thermoelastic_bare_plate.info
+++ b/tests/data/thermoelastic_bare_plate.info
@@ -33,7 +33,6 @@ discretization
   mechanical 
   {
     fe_degree 1
-    quadrature gauss ; Optional parameter. Possibilities: gauss or lobatto
   }
 }
 


### PR DESCRIPTION
User cannot set the quadrature type for the mechanical simulation. The reason it is allowed for the thermal simulation is that it simplifies a lot the computation of the inverse of the mass matrix (it is a diagonal matrix with the `lobatto` quadrature) which is interesting for explicit time-stepping.

[CI](https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/adamantine/detail/adamantine/345/pipeline)