### PR TITLE
Only loop over locally owned cells in get_dof_to_support_mapping

### DIFF
--- a/source/experimental_data.cc
+++ b/source/experimental_data.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2022, the adamantine authors.
+/* Copyright (c) 2021-2023, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -234,19 +234,15 @@ get_dof_to_support_mapping(dealii::DoFHandler<dim> const &dof_handler)
 
   for (auto const &cell : dealii::filter_iterators(
            dof_handler.active_cell_iterators(),
-           dealii::IteratorFilters::ActiveFEIndexEqualTo(0)))
+           dealii::IteratorFilters::ActiveFEIndexEqualTo(0, true)))
   {
-    // only work on locally relevant cells
-    if (cell->is_artificial() == false)
+    fe_values.reinit(cell);
+    cell->get_dof_indices(local_dof_indices);
+    const std::vector<dealii::Point<dim>> &points =
+        fe_values.get_quadrature_points();
+    for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
     {
-      fe_values.reinit(cell);
-      cell->get_dof_indices(local_dof_indices);
-      const std::vector<dealii::Point<dim>> &points =
-          fe_values.get_quadrature_points();
-      for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
-      {
-        indices_points[local_dof_indices[i]] = points[i];
-      }
+      indices_points[local_dof_indices[i]] = points[i];
     }
   }
 


### PR DESCRIPTION
There is no reason to loop over the ghost cells. On top of that the current code does not work on the MPI case with artificial cell because you cannot check the fe index on an artificial cell. One test needs to be changed because it won't pass with two processors anymore. However, it was passing just by chance. We have one processor that owns the four cells on the bottom of the domain and one processor that owns the four cells on the top and so the ghost + locally owned cells represent the entire mesh. So we are basically solving the same problem as the serial one.