### PR TITLE
Use set_future_fe_index instead of set_active_fe_index before refining the mesh

### DIFF
--- a/source/ThermalPhysics.templates.hh
+++ b/source/ThermalPhysics.templates.hh
@@ -739,7 +739,7 @@ void ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::
     {
       if (cell->active_fe_index() != 0)
       {
-        cell->set_active_fe_index(0);
+        cell->set_future_fe_index(0);
         data_to_transfer[cell_to_id[cell]][n_dofs_per_cell] =
             new_deposition_cos[i];
         data_to_transfer[cell_to_id[cell]][n_dofs_per_cell + 1] =


### PR DESCRIPTION
This is a small clean up. It doesn't make a different in this case but it's the correct way to do. [CI](https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/adamantine/detail/adamantine/376/pipeline)