### PR TITLE
More work towards using MPI with Data Assimilation

### DIFF
--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -8,8 +8,8 @@
 #ifndef ADAMANTINE_HH
 #define ADAMANTINE_HH
 
-#include "ExperimentalData.hh"
 #include <DataAssimilator.hh>
+#include <ExperimentalData.hh>
 #include <Geometry.hh>
 #include <MaterialProperty.hh>
 #ifdef ADAMANTINE_WITH_DEALII_WEAK_FORMS
@@ -29,12 +29,14 @@
 #include <material_deposition.hh>
 #include <utils.hh>
 
+#include <deal.II/base/index_set.h>
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/types.h>
 #include <deal.II/distributed/cell_data_transfer.templates.h>
 #include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/grid/filtered_iterator.h>
 #include <deal.II/grid/grid_refinement.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
 #include <deal.II/lac/vector_operation.h>
 #include <deal.II/numerics/error_estimator.h>
 

--- a/source/DataAssimilator.cc
+++ b/source/DataAssimilator.cc
@@ -362,12 +362,10 @@ void DataAssimilator::update_covariance_sparsity_pattern(
 dealii::Vector<double> DataAssimilator::calc_Hx(
     dealii::LA::distributed::Vector<double> const &sim_ensemble_member) const
 {
-  int num_expt_dof_map_entries = _expt_to_dof_mapping.first.size();
-
   dealii::Vector<double> out_vec(_expt_size);
 
   // Loop through the observation map to get the observation indices
-  for (auto i = 0; i < num_expt_dof_map_entries; ++i)
+  for (unsigned int i = 0; i < _expt_size; ++i)
   {
     auto sim_index = _expt_to_dof_mapping.second[i];
     auto expt_index = _expt_to_dof_mapping.first[i];

--- a/source/DataAssimilator.hh
+++ b/source/DataAssimilator.hh
@@ -133,14 +133,12 @@ private:
       dealii::LA::distributed::Vector<double> const &sim_ensemble_member) const;
 
   /**
-   * This fills a vector (vec) with noise from a multivariate normal
-   * distribution defined by a covariance matrix (R). Note: For non-diagonal R
-   * this method currently uses full matrices, which substantially limits the
-   * allowable problem size.
+   * This creates a vector with noise from a multivariate normal
+   * distribution defined by a covariance matrix (R). This function assumes that
+   * R is diagonal.
    */
-  void fill_noise_vector(dealii::Vector<double> &vec,
-                         dealii::SparseMatrix<double> const &R,
-                         bool const R_is_diagonal);
+  dealii::Vector<double>
+  get_noise_vector(dealii::SparseMatrix<double> const &R);
 
   /**
    * A standard localization function, resembles a Gaussian, but with finite

--- a/source/DataAssimilator.hh
+++ b/source/DataAssimilator.hh
@@ -87,7 +87,7 @@ public:
                        std::vector<dealii::LA::distributed::BlockVector<double>>
                            &augmented_state_ensemble,
                        std::vector<double> const &expt_data,
-                       dealii::SparseMatrix<double> const &R);
+                       dealii::TrilinosWrappers::SparseMatrix const &R);
 
   /**
    * This updates the internal mapping between the indices of the entries in
@@ -116,7 +116,7 @@ private:
   std::vector<dealii::LA::distributed::BlockVector<double>> apply_kalman_gain(
       std::vector<dealii::LA::distributed::BlockVector<double>>
           &augmented_state_ensemble,
-      dealii::SparseMatrix<double> const &R,
+      dealii::TrilinosWrappers::SparseMatrix const &R,
       std::vector<dealii::Vector<double>> const &perturbed_innovation);
 
   /**
@@ -138,7 +138,7 @@ private:
    * R is diagonal.
    */
   dealii::Vector<double>
-  get_noise_vector(dealii::SparseMatrix<double> const &R);
+  get_noise_vector(dealii::TrilinosWrappers::SparseMatrix const &R);
 
   /**
    * A standard localization function, resembles a Gaussian, but with finite

--- a/source/DataAssimilator.hh
+++ b/source/DataAssimilator.hh
@@ -155,9 +155,9 @@ private:
    * the use of member variables inside. If needed, the interface could be
    * redone to make it more generally applicable.
    */
-  template <typename VectorType>
   dealii::TrilinosWrappers::SparseMatrix calc_sample_covariance_sparse(
-      std::vector<VectorType> const vec_ensemble) const;
+      std::vector<dealii::LA::distributed::BlockVector<double>> const
+          &vec_ensemble) const;
 
   /**
    * The number of ensemble members in the simulation.

--- a/source/experimental_data_utils.cc
+++ b/source/experimental_data_utils.cc
@@ -40,6 +40,7 @@ get_dof_to_support_mapping(dealii::DoFHandler<dim> const &dof_handler)
 
   std::vector<dealii::types::global_dof_index> local_dof_indices(
       fe.n_dofs_per_cell());
+  auto locally_owned_dofs = dof_handler.locally_owned_dofs();
 
   for (auto const &cell : dealii::filter_iterators(
            dof_handler.active_cell_iterators(),
@@ -51,8 +52,10 @@ get_dof_to_support_mapping(dealii::DoFHandler<dim> const &dof_handler)
         fe_values.get_quadrature_points();
     for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
     {
-      // Skip duplicate points like vertices
-      if (visited_dof_indices.count(local_dof_indices[i]) == 0)
+      // Skip duplicate points like vertices and indices that correspond to
+      // ghosted elements
+      if ((visited_dof_indices.count(local_dof_indices[i]) == 0) &&
+          (locally_owned_dofs.is_element(local_dof_indices[i])))
       {
         dof_indices.push_back(local_dof_indices[i]);
         support_points.push_back(points[i]);

--- a/tests/test_data_assimilator.cc
+++ b/tests/test_data_assimilator.cc
@@ -5,6 +5,7 @@
  * for the text and further information on this license.
  */
 
+#include <deal.II/lac/vector_operation.h>
 #define BOOST_TEST_MODULE DataAssimilator
 
 #include <DataAssimilator.hh>
@@ -116,14 +117,10 @@ public:
     augmented_state_ensemble[2].collect_sizes();
 
     // Build the sparse experimental covariance matrix
-    dealii::SparsityPattern pattern(expt_size, expt_size, 1);
-    pattern.add(0, 0);
-    pattern.add(1, 1);
-    pattern.compress();
-
-    dealii::SparseMatrix<double> R(pattern);
+    dealii::TrilinosWrappers::SparseMatrix R(expt_size, expt_size, 1);
     R.add(0, 0, 0.002);
     R.add(1, 1, 0.001);
+    R.compress(dealii::VectorOperation::insert);
 
     // Create the (perturbed) innovation
     std::vector<dealii::Vector<double>> perturbed_innovation(3);
@@ -563,17 +560,11 @@ public:
     boost::property_tree::ptree solver_settings_database;
     DataAssimilator da(solver_settings_database);
 
-    dealii::SparsityPattern pattern(3, 3, 1);
-    pattern.add(0, 0);
-    pattern.add(1, 1);
-    pattern.add(2, 2);
-    pattern.compress();
-
-    dealii::SparseMatrix<double> R(pattern);
-
+    dealii::TrilinosWrappers::SparseMatrix R(3, 3, 1);
     R.add(0, 0, 0.1);
     R.add(1, 1, 1.0);
     R.add(2, 2, 0.2);
+    R.compress(dealii::VectorOperation::insert);
 
     std::vector<dealii::Vector<double>> data;
     for (unsigned int i = 0; i < 1000; ++i)
@@ -659,15 +650,10 @@ public:
     augmented_state_ensemble[2].block(0)(3) = 9.1;
     augmented_state_ensemble[2].collect_sizes();
 
-    // Build the sparse experimental covariance matrix
-    dealii::SparsityPattern pattern(expt_size, expt_size, 1);
-    pattern.add(0, 0);
-    pattern.add(1, 1);
-    pattern.compress();
-
-    dealii::SparseMatrix<double> R(pattern);
+    dealii::TrilinosWrappers::SparseMatrix R(expt_size, expt_size, 1);
     R.add(0, 0, 0.002);
     R.add(1, 1, 0.001);
+    R.compress(dealii::VectorOperation::insert);
 
     // Save the data at the observation points before assimilation
     std::vector<double> sim_at_expt_pt_1_before(3);
@@ -789,14 +775,10 @@ public:
     augmented_state_ensemble[2].collect_sizes();
 
     // Build the sparse experimental covariance matrix
-    dealii::SparsityPattern pattern(expt_size, expt_size, 1);
-    pattern.add(0, 0);
-    pattern.add(1, 1);
-    pattern.compress();
-
-    dealii::SparseMatrix<double> R(pattern);
+    dealii::TrilinosWrappers::SparseMatrix R(expt_size, expt_size, 1);
     R.add(0, 0, 0.002);
     R.add(1, 1, 0.001);
+    R.compress(dealii::VectorOperation::insert);
 
     // Save the data at the observation points before assimilation
     std::vector<double> sim_at_expt_pt_1_before(3);

--- a/tests/test_data_assimilator.cc
+++ b/tests/test_data_assimilator.cc
@@ -374,13 +374,14 @@ public:
 
     // Trivial case of identical vectors, effectively dense, covariance should
     // be the zero matrix
-    dealii::LA::distributed::Vector<double> sim_vec(dof_handler.n_dofs());
-    sim_vec(0) = 2.0;
-    sim_vec(1) = 4.0;
-    sim_vec(2) = 5.0;
-    sim_vec(3) = 7.0;
+    dealii::LA::distributed::BlockVector<double> sim_vec(1,
+                                                         dof_handler.n_dofs());
+    sim_vec[0] = 2.0;
+    sim_vec[1] = 4.0;
+    sim_vec[2] = 5.0;
+    sim_vec[3] = 7.0;
 
-    std::vector<dealii::LA::distributed::Vector<double>> vec_ensemble;
+    std::vector<dealii::LA::distributed::BlockVector<double>> vec_ensemble;
     vec_ensemble.push_back(sim_vec);
     vec_ensemble.push_back(sim_vec);
 
@@ -408,13 +409,14 @@ public:
 
     // Non-trivial case, still effectively dense, using NumPy solution as the
     // reference
-    dealii::LA::distributed::Vector<double> sim_vec1(dof_handler.n_dofs());
+    dealii::LA::distributed::BlockVector<double> sim_vec1(1,
+                                                          dof_handler.n_dofs());
     sim_vec1(0) = 2.1;
     sim_vec1(1) = 4.3;
     sim_vec1(2) = 5.2;
     sim_vec1(3) = 7.4;
 
-    std::vector<dealii::LA::distributed::Vector<double>> vec_ensemble1;
+    std::vector<dealii::LA::distributed::BlockVector<double>> vec_ensemble1;
     vec_ensemble1.push_back(sim_vec);
     vec_ensemble1.push_back(sim_vec1);
 
@@ -497,7 +499,8 @@ public:
     BOOST_TEST(cov3.el(3, 3) == 0.08, tt::tolerance(tol));
 
     // Non-trivial case with step-function sparsity and two augmented parameters
-    dealii::LA::distributed::Vector<double> sim_vec2(dof_handler.n_dofs() + 2);
+    dealii::LA::distributed::BlockVector<double> sim_vec2(
+        1, dof_handler.n_dofs() + 2);
     sim_vec2(0) = 2.0;
     sim_vec2(1) = 4.0;
     sim_vec2(2) = 5.0;
@@ -505,7 +508,8 @@ public:
     sim_vec2(4) = 1.0;
     sim_vec2(5) = 1.5;
 
-    dealii::LA::distributed::Vector<double> sim_vec3(dof_handler.n_dofs() + 2);
+    dealii::LA::distributed::BlockVector<double> sim_vec3(
+        1, dof_handler.n_dofs() + 2);
     sim_vec3(0) = 2.1;
     sim_vec3(1) = 4.3;
     sim_vec3(2) = 5.2;
@@ -513,7 +517,7 @@ public:
     sim_vec3(4) = 1.1;
     sim_vec3(5) = 1.4;
 
-    std::vector<dealii::LA::distributed::Vector<double>> vec_ensemble2;
+    std::vector<dealii::LA::distributed::BlockVector<double>> vec_ensemble2;
     vec_ensemble2.push_back(sim_vec2);
     vec_ensemble2.push_back(sim_vec3);
 


### PR DESCRIPTION
The biggest change is that when computing the noise vector, we only support diagonal covariance matrix. We don't need anything else in the foreseeable future and it's harder to do in parallel than it is in serial.

[CI](https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/adamantine/detail/adamantine/379/pipeline)