### PR TITLE
Remove remnant of data_columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,14 +189,13 @@ The following options are available:
     * file: format of the file names. The format is pretty arbitrary, the keywords \#frame
     and \#camera are replaced by the frame and the camera number. The format of
     the file itself should be csv with a header line. (required)
-    * format: The format of the experimental data, either "point_cloud", with (x,y,z,value) per line, or "ray", with (pt0_x,pt0_y,pt0_z,pt1_x,pt1_y,pt1_z,value) per line, where the ray starts at pt0 and passes through pt1. (required)
+    * format: The format of the experimental data, either `point_cloud`, with (x,y,z,value) per line, or `ray`, with (pt0_x,pt0_y,pt0_z,pt1_x,pt1_y,pt1_z,value) per line, where the ray starts at pt0 and passes through pt1. (required)
     * first\_frame: number associated to the first frame (default value: 0)
     * last\_frame: number associated to the last frame (required)
     * first\_camera\_id: number associated to the first camera (required)
     * last\_camera\_id: number associated to the last camera (required)
-    * data\_columns: columns associated with x, y, T (in 2D) and x, y, z, T (in 3D) (required)
     * log\_filename: The (full) filename of the log file that lists the timestamp for each frame 
-    from each camera. Note that the timestamps are not assumed to match the simulation time frame. The `first\_frame\_temporal\_offset` parameter (below) controls the simulation time corresponding to the first camera frame. (required)
+    from each camera. Note that the timestamps are not assumed to match the simulation time frame. The `first_frame_temporal_offset` parameter (below) controls the simulation time corresponding to the first camera frame. (required)
     * first\_frame\_temporal\_offset: A uniform shift to the timestamps from all cameras to match 
     the simulation time (default value: 0.0)
     * estimated\_uncertainty: The estimate of the uncertainty in the experimental data points as 

--- a/source/validate_input_database.cc
+++ b/source/validate_input_database.cc
@@ -440,13 +440,6 @@ void validate_input_database(boost::property_tree::ptree &database)
                    "Error: When reading experimental data, the last camera id "
                    "cannot be lower than the first camera id.");
 
-      std::string data_columns =
-          database.get<std::string>("experiment.data_columns");
-      ASSERT_THROW(std::count(data_columns.begin(), data_columns.end(), ',') ==
-                       dim,
-                   "Error: The experimental data column indices in the input "
-                   "file do not have the correct number of entries.");
-
       ASSERT_THROW(database.get_child("experiment").count("log_filename") != 0,
                    "Error: If reading experimental data, a log filename must "
                    "be given.");

--- a/tests/data/bare_plate_L_da.info
+++ b/tests/data/bare_plate_L_da.info
@@ -10,7 +10,6 @@ experiment
   log_filename bare_plate_L_expt_log.txt
   file bare_plate_L_expt_data_#camera_#frame.csv
   format point_cloud
-  data_columns 1,2,3,4
   first_frame 0
   last_frame 1
   first_camera_id 0

--- a/tests/data/bare_plate_L_da_augmented.info
+++ b/tests/data/bare_plate_L_da_augmented.info
@@ -10,7 +10,6 @@ experiment
   log_filename bare_plate_L_da_aug_ref_log.txt
   file bare_plate_L_da_aug_ref_data_#camera_#frame.csv
   format point_cloud
-  data_columns 1,2,3,4
   first_frame 0
   last_frame 1
   first_camera_id 0

--- a/tests/data/integration_da_add_material.info
+++ b/tests/data/integration_da_add_material.info
@@ -11,7 +11,6 @@ experiment
   log_filename integration_da_add_material_expt_log.txt
   file integration_da_add_material_expt_pc_#camera_#frame.csv
   format point_cloud
-  data_columns 1,2,3,4
   first_frame 0
   last_frame 0
   first_camera_id 0

--- a/tests/test_validate_input_database.cc
+++ b/tests/test_validate_input_database.cc
@@ -428,7 +428,6 @@ BOOST_AUTO_TEST_CASE(expected_failures)
   database.put("experiment.last_frame", 1);
   database.put("experiment.first_camera_id", 0);
   database.put("experiment.last_camera_id", 1);
-  database.put("experiment.data_columns", "1,2,3,4");
   BOOST_CHECK_THROW(validate_input_database(database), std::runtime_error);
   database.get_child("experiment").erase("file");
   database.put("experiment.log_filename", "log.txt");
@@ -442,7 +441,6 @@ BOOST_AUTO_TEST_CASE(expected_failures)
   database.get_child("experiment").erase("last_camera_id");
   BOOST_CHECK_THROW(validate_input_database(database), std::runtime_error);
   database.put("experiment.first_camera_id", 0);
-  database.get_child("experiment").erase("data_columns");
   BOOST_CHECK_THROW(validate_input_database(database), std::runtime_error);
   database.get_child("experiment").erase("file");
   database.get_child("experiment").erase("last_frame");
@@ -471,12 +469,9 @@ BOOST_AUTO_TEST_CASE(expected_failures)
   // Check 30: Incorrect number of entries for the experimental data column
   // indices
   database.put("experiment.read_in_experimental_data", true);
-  database.put("experiment.data_columns", "1,2,3");
   BOOST_CHECK_THROW(validate_input_database(database), std::runtime_error);
-  database.put("experiment.data_columns", "1,2,3,4");
   database.put("geometry.dim", 2);
   BOOST_CHECK_THROW(validate_input_database(database), std::runtime_error);
-  database.get_child("experiment").erase("data_columns");
   database.get_child("geometry").erase("dim");
   database.put("geometry.dim", 3);
   database.get_child("experiment").erase("read_in_experimental_data");


### PR DESCRIPTION
We removed `data_columns` a while back we forgot to remove it from the tests and from the input validation [CI](https://cloud.cees.ornl.gov/jenkins-ci/blue/organizations/jenkins/adamantine/detail/adamantine/405/pipeline)