### PR TITLE
Fix parsing of the elastic limit

### DIFF
--- a/source/MaterialProperty.templates.hh
+++ b/source/MaterialProperty.templates.hh
@@ -928,7 +928,8 @@ void MaterialProperty<dim, MemorySpaceType>::fill_properties(
               }
             }
           }
-          else if (state_property_names[p] == "elastic_limit")
+          else if (state_property_names[p] == "elastic_limit" &&
+                   state == static_cast<unsigned int>(MaterialState::solid))
           {
             // If the elastic limit is not provided, we solve a purely elastic
             // problem. We set the elastic limit to infinity.


### PR DESCRIPTION
MaterialProperty was checking each state for `elastic_limit`, and setting it to infinity if it wasn't there. The result was that the elastic limit for the solid was ignored.

This changes the logic so MaterialProperty only sets the elastic limit to infinity if it isn't listed for the solid.