### PR TITLE
Use MPI groups to parallelize data assimilation

### DIFF
--- a/source/DataAssimilator.hh
+++ b/source/DataAssimilator.hh
@@ -111,6 +111,33 @@ public:
                                      const unsigned int parameter_size);
 
 private:
+  using block_size_type =
+      dealii::LA::distributed::BlockVector<double>::size_type;
+
+  /**
+   * Gather the augmented ensemble members on the global root node in order to
+   * apply the Kalman gain.
+   */
+  void gather_ensemble_members(
+      std::vector<dealii::LA::distributed::BlockVector<double>>
+          &augmented_state_ensemble,
+      std::vector<dealii::LA::distributed::BlockVector<double>>
+          &global_augmented_state_ensemble,
+      std::vector<unsigned int> &local_n_ensemble_members,
+      std::vector<block_size_type> &block_sizes);
+
+  /**
+   * Scatter the @p global_augmented_state_ensemble back into @p
+   * augmented_state_ensemble.
+   */
+  void scatter_ensemble_members(
+      std::vector<dealii::LA::distributed::BlockVector<double>>
+          &augmented_state_ensemble,
+      std::vector<dealii::LA::distributed::BlockVector<double>> const
+          &global_augmented_state_ensemble,
+      std::vector<unsigned int> const &local_n_ensemble_members,
+      std::vector<block_size_type> const &block_sizes);
+
   /**
    * This calculates the Kalman gain and applies it to the perturbed innovation.
    */
@@ -160,13 +187,29 @@ private:
       std::vector<dealii::LA::distributed::BlockVector<double>> const
           &vec_ensemble) const;
 
-  // TODO
+  /**
+   * Global MPI communicator.
+   */
   MPI_Comm _global_communicator;
 
+  /**
+   * Local MPI communicator split off the global MPI communicator.
+   */
   MPI_Comm _local_communicator;
 
+  /**
+   * Rank of the process when using the global MPI communicator.
+   */
   int _global_rank = -1;
 
+  /**
+   * Number of processes in the gglbal MPI communicator.
+   */
+  int _global_comm_size = -1;
+
+  /**
+   * Color associated with the local
+   */
   int _color = -1;
 
   /**

--- a/source/DataAssimilator.hh
+++ b/source/DataAssimilator.hh
@@ -66,7 +66,9 @@ public:
   /**
    * Constructor.
    */
-  DataAssimilator(boost::property_tree::ptree const &database);
+  DataAssimilator(MPI_Comm const &global_communicator,
+                  MPI_Comm const &local_communicator, int my_color,
+                  boost::property_tree::ptree const &database);
 
   /**
    * This is the main public interface for the class and is called to perform
@@ -83,8 +85,7 @@ public:
    * u is a perturbation to the observed solution
    * H is the observation matrix
    */
-  void update_ensemble(MPI_Comm const &communicator,
-                       std::vector<dealii::LA::distributed::BlockVector<double>>
+  void update_ensemble(std::vector<dealii::LA::distributed::BlockVector<double>>
                            &augmented_state_ensemble,
                        std::vector<double> const &expt_data,
                        dealii::SparseMatrix<double> const &R);
@@ -159,25 +160,34 @@ private:
       std::vector<dealii::LA::distributed::BlockVector<double>> const
           &vec_ensemble) const;
 
+  // TODO
+  MPI_Comm _global_communicator;
+
+  MPI_Comm _local_communicator;
+
+  int _global_rank = -1;
+
+  int _color = -1;
+
   /**
    * The number of ensemble members in the simulation.
    */
-  unsigned int _num_ensemble_members;
+  unsigned int _num_ensemble_members = 0;
 
   /**
    * The length of the data vector for each simulation ensemble member.
    */
-  unsigned int _sim_size;
+  unsigned int _sim_size = 0;
 
   /**
    * The length of the parameter vector for each simulation ensemble member.
    */
-  unsigned int _parameter_size;
+  unsigned int _parameter_size = 0;
 
   /**
    * The length of the data vector the experimental observations.
    */
-  unsigned int _expt_size;
+  unsigned int _expt_size = 0;
 
   /**
    * The sparsity pattern for the localized covariance matrix.

--- a/source/ensemble_management.hh
+++ b/source/ensemble_management.hh
@@ -17,7 +17,10 @@ namespace adamantine
 /**
  * Return a vector of size @p length, with random values drawn following a
  * normal distribution of average @p mean and standard deviation @stddev. The
- * first @p n_rejected_draws are rejected.
+ * first @p n_rejected_draws are rejected. @p n_rejected_draws is used to
+ * ensure that wether we use one MPI rank or ten, we use the same random
+ * numbers. If we don't reject the first few draws, all the processors will use
+ * the same "random" numbers since they have the same seed.
  */
 std::vector<double> get_normal_random_vector(unsigned int length,
                                              unsigned int n_rejected_draws,

--- a/source/ensemble_management.hh
+++ b/source/ensemble_management.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, the adamantine authors.
+/* Copyright (c) 2021-2023, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -14,8 +14,14 @@
 #include <vector>
 namespace adamantine
 {
-std::vector<double> fill_and_sync_random_vector(unsigned int length,
-                                                double mean, double stddev);
+/**
+ * Return a vector of size @p length, with random values drawn following a
+ * normal distribution of average @p mean and standard deviation @stddev. The
+ * first @p n_rejected_draws are rejected.
+ */
+std::vector<double> get_normal_random_vector(unsigned int length,
+                                             unsigned int n_rejected_draws,
+                                             double mean, double stddev);
 } // namespace adamantine
 
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,8 +22,6 @@ list(APPEND
      test_timer
      test_utils
      test_integration_3d_amr
-     test_integration_da
-     test_integration_da_augmented
      test_validate_input_database
      )
 
@@ -33,6 +31,8 @@ list(APPEND
      test_experimental_data
      test_integration_2d
      test_integration_3d
+     test_integration_da
+     test_integration_da_augmented
      test_material_deposition
      test_thermal_physics
      test_ensemble_management

--- a/tests/test_data_assimilator.cc
+++ b/tests/test_data_assimilator.cc
@@ -27,7 +27,7 @@ public:
     boost::property_tree::ptree database;
 
     // First checking the dealii default values
-    DataAssimilator da0(database);
+    DataAssimilator da0(MPI_COMM_WORLD, MPI_COMM_WORLD, 0, database);
 
     double tol = 1.0e-12;
     BOOST_TEST(da0._solver_control.tolerance() - 1.0e-10 == 0.,
@@ -39,7 +39,7 @@ public:
     database.put("solver.convergence_tolerance", 1.0e-6);
     database.put("solver.max_iterations", 25);
     database.put("solver.max_number_of_temp_vectors", 4);
-    DataAssimilator da1(database);
+    DataAssimilator da1(MPI_COMM_WORLD, MPI_COMM_WORLD, 0, database);
     BOOST_TEST(da1._solver_control.tolerance() - 1.0e-6 == 0.,
                tt::tolerance(tol));
     BOOST_TEST(da1._solver_control.max_steps() == 25u);
@@ -81,7 +81,7 @@ public:
     expt_to_dof_mapping.second[1] = 3;
 
     boost::property_tree::ptree solver_settings_database;
-    DataAssimilator da(solver_settings_database);
+    DataAssimilator da(communicator, communicator, 0, solver_settings_database);
     da._sim_size = sim_size;
     da._expt_size = expt_size;
     da._parameter_size = 0;
@@ -183,7 +183,8 @@ public:
     expt_to_dof_mapping.second[2] = 3;
 
     boost::property_tree::ptree solver_settings_database;
-    DataAssimilator da(solver_settings_database);
+    DataAssimilator da(MPI_COMM_WORLD, MPI_COMM_WORLD, 0,
+                       solver_settings_database);
     da._sim_size = sim_size;
     da._expt_size = expt_size;
     da.update_dof_mapping<2>(expt_to_dof_mapping);
@@ -228,7 +229,7 @@ public:
     expt_to_dof_mapping.second[2] = 3;
 
     boost::property_tree::ptree solver_settings_database;
-    DataAssimilator da(solver_settings_database);
+    DataAssimilator da(communicator, communicator, 0, solver_settings_database);
     da._sim_size = sim_size;
     da._expt_size = expt_size;
     da.update_dof_mapping<2>(expt_to_dof_mapping);
@@ -296,7 +297,7 @@ public:
     expt_to_dof_mapping.second[2] = 3;
 
     boost::property_tree::ptree solver_settings_database;
-    DataAssimilator da(solver_settings_database);
+    DataAssimilator da(communicator, communicator, 0, solver_settings_database);
     da._sim_size = sim_size;
     da._expt_size = expt_size;
     da.update_dof_mapping<2>(expt_to_dof_mapping);
@@ -328,7 +329,7 @@ public:
 
     // Effectively a dense matrix
     boost::property_tree::ptree solver_settings_database;
-    DataAssimilator da(solver_settings_database);
+    DataAssimilator da(communicator, communicator, 0, solver_settings_database);
     da._localization_cutoff_distance = 100.0;
     da._localization_cutoff_function = LocalizationCutoff::step_function;
     da.update_covariance_sparsity_pattern<2>(dof_handler, 0);
@@ -389,7 +390,7 @@ public:
     solver_settings_database.put("localization_cutoff_distance", 100.0);
     solver_settings_database.put("localization_cutoff_function",
                                  "step_function");
-    DataAssimilator da(solver_settings_database);
+    DataAssimilator da(communicator, communicator, 0, solver_settings_database);
     da._sim_size = sim_vec.size();
     da._num_ensemble_members = vec_ensemble.size();
 
@@ -563,7 +564,8 @@ public:
     if (R_is_diagonal)
     {
       boost::property_tree::ptree solver_settings_database;
-      DataAssimilator da(solver_settings_database);
+      DataAssimilator da(MPI_COMM_WORLD, MPI_COMM_WORLD, 0,
+                         solver_settings_database);
 
       dealii::SparsityPattern pattern(3, 3, 1);
       pattern.add(0, 0);
@@ -596,7 +598,8 @@ public:
     else
     {
       boost::property_tree::ptree solver_settings_database;
-      DataAssimilator da(solver_settings_database);
+      DataAssimilator da(MPI_COMM_WORLD, MPI_COMM_WORLD, 0,
+                         solver_settings_database);
 
       dealii::SparsityPattern pattern(3, 3, 3);
       pattern.add(0, 0);
@@ -669,7 +672,7 @@ public:
     expt_to_dof_mapping.second[1] = 3;
 
     boost::property_tree::ptree solver_settings_database;
-    DataAssimilator da(solver_settings_database);
+    DataAssimilator da(communicator, communicator, 0, solver_settings_database);
     da._sim_size = sim_size;
     da._parameter_size = 0;
     da._expt_size = expt_size;
@@ -726,7 +729,7 @@ public:
     sim_at_expt_pt_2_before.push_back(augmented_state_ensemble[2].block(0)[3]);
 
     // Update the simulation data
-    da.update_ensemble(communicator, augmented_state_ensemble, expt_vec, R);
+    da.update_ensemble(augmented_state_ensemble, expt_vec, R);
 
     // Save the data at the observation points after assimilation
     std::vector<double> sim_at_expt_pt_1_after(3);
@@ -787,7 +790,7 @@ public:
     expt_to_dof_mapping.second[1] = 3;
 
     boost::property_tree::ptree solver_settings_database;
-    DataAssimilator da(solver_settings_database);
+    DataAssimilator da(communicator, communicator, 0, solver_settings_database);
     da._sim_size = sim_size;
     da._parameter_size = parameter_size;
     da._expt_size = expt_size;
@@ -855,7 +858,7 @@ public:
     sim_at_expt_pt_2_before.push_back(augmented_state_ensemble[2].block(0)[3]);
 
     // Update the simulation data
-    da.update_ensemble(communicator, augmented_state_ensemble, expt_vec, R);
+    da.update_ensemble(augmented_state_ensemble, expt_vec, R);
 
     // Save the data at the observation points after assimilation
     std::vector<double> sim_at_expt_pt_1_after(3);

--- a/tests/test_ensemble_management.cc
+++ b/tests/test_ensemble_management.cc
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE(fill_and_sync_random_vector, *utf::tolerance(10.))
   double stddev = 0.25;
   unsigned int ensemble_size = 5000;
   std::vector<double> vec =
-      adamantine::fill_and_sync_random_vector(ensemble_size, mean, stddev);
+      adamantine::get_normal_random_vector(ensemble_size, 0, mean, stddev);
 
   // Check vector size
   BOOST_TEST(vec.size() == ensemble_size);

--- a/tests/test_integration_2d.cc
+++ b/tests/test_integration_2d.cc
@@ -56,18 +56,18 @@ BOOST_AUTO_TEST_CASE(integration_2D_ensemble, *utf::tolerance(0.1))
   boost::property_tree::ptree database;
   boost::property_tree::info_parser::read_info(filename, database);
 
-  auto result = run_ensemble<2, dealii::MemorySpace::Host>(communicator,
-                                                           database, timers);
+  auto result_ensemble = run_ensemble<2, dealii::MemorySpace::Host>(
+      communicator, database, timers);
 
-  for (unsigned int member = 0; member < 3; ++member)
+  for (auto &result_member : result_ensemble)
   {
     std::ifstream gold_file("integration_2d_gold.txt");
-    for (unsigned int i = 0; i < result[member].block(0).locally_owned_size();
+    for (unsigned int i = 0; i < result_member.block(0).locally_owned_size();
          ++i)
     {
       double gold_value = -1.;
       gold_file >> gold_value;
-      BOOST_TEST(result[member].block(0).local_element(i) == gold_value);
+      BOOST_TEST(result_member.block(0).local_element(i) == gold_value);
     }
   }
 }

--- a/tests/test_integration_da_augmented.cc
+++ b/tests/test_integration_da_augmented.cc
@@ -37,7 +37,10 @@ BOOST_AUTO_TEST_CASE(integration_3D_data_assimilation_augmented,
                                                            database, timers);
 
   // Three ensemble members expected
-  BOOST_TEST(result.size() == 3);
+  unsigned int local_result_size = result.size();
+  unsigned int global_result_size =
+      dealii::Utilities::MPI::sum(local_result_size, communicator);
+  BOOST_TEST(global_result_size == 3);
 
   // Get the average absorption value for each ensemble member
   double sum = 0.0;
@@ -45,7 +48,9 @@ BOOST_AUTO_TEST_CASE(integration_3D_data_assimilation_augmented,
   {
     sum += result.at(member).block(1).local_element(0);
   }
-  double average_value = sum / result.size();
+  double partial_average_value = sum / global_result_size;
+  double average_value =
+      dealii::Utilities::MPI::sum(partial_average_value, communicator);
 
   // Based on the reference solution, the expected absorption efficiency is 0.3
   double gold_solution = 0.3;


### PR DESCRIPTION
With this PR, we can finally run data assimilation in parallel. We can use up to as many processors as there are ensemble members. The way this is done is by splitting the global MPI communicator (we use MPI_COMM_WORLD) in multiple local communicators and then using these local communicators where needed. A lot of the PR is just about choosing the right communicator. The data assimilation itself is still done in serial on rank 0. This means that all the vectors need to be move to the rank 0 and out of it after they have been updated. There are two difficulties with this operation: 
 1. there is no facility in deal.II to move an entire vector to a single processor and so we have to ship the data and rebuild the vector by hand
 2. the algorithm is more complicated than it should be because I wrote it to support more processors than there are ensemble members but it is not working right now. I think we should keep that extra code because it's still a step in the right direction and we can come back to the issue later.