### PR TITLE
Fix clang-tidy warnings

### DIFF
--- a/source/DataAssimilator.cc
+++ b/source/DataAssimilator.cc
@@ -721,7 +721,7 @@ DataAssimilator::calc_sample_covariance_sparse(
     element_value /= (_num_ensemble_members - 1.0);
 
     // Apply localization
-    double localization_scaling;
+    double localization_scaling = 1.0;
     if (i < _sim_size && j < _sim_size)
     {
       double dist = _covariance_distance_map.find(std::make_pair(i, j))->second;
@@ -730,22 +730,12 @@ DataAssimilator::calc_sample_covariance_sparse(
         localization_scaling =
             gaspari_cohn_function(2.0 * dist / _localization_cutoff_distance);
       }
-      else if (_localization_cutoff_function ==
-               LocalizationCutoff::step_function)
+      else if ((_localization_cutoff_function ==
+                LocalizationCutoff::step_function) &&
+               (dist > _localization_cutoff_distance))
       {
-        if (dist <= _localization_cutoff_distance)
-          localization_scaling = 1.0;
-        else
-          localization_scaling = 0.0;
+        localization_scaling = 0.0;
       }
-      else
-      {
-        localization_scaling = 1.0;
-      }
-    }
-    else
-    {
-      localization_scaling = 1.0;
     }
 
     conv_iter->value() = element_value * localization_scaling;

--- a/source/MechanicalOperator.cc
+++ b/source/MechanicalOperator.cc
@@ -233,16 +233,10 @@ void MechanicalOperator<dim, MemorySpaceType>::assemble_system(
       // Get the appropriate reference temperature for the cell. If the cell
       // is not in the unmelted substrate, the reference temperature depends
       // on the material.
-      double reference_temperature;
-      if (_has_melted[cell_indices[cell->active_cell_index()]])
-      {
-        reference_temperature =
-            _reference_temperatures[temperature_cell->material_id()];
-      }
-      else
-      {
-        reference_temperature = initial_temperature;
-      }
+      double reference_temperature =
+          _has_melted[cell_indices[cell->active_cell_index()]]
+              ? _reference_temperatures[temperature_cell->material_id()]
+              : initial_temperature;
 
       displacement_hp_fe_values.reinit(cell);
       auto const &fe_values = displacement_hp_fe_values.get_present_fe_values();

--- a/source/Timer.cc
+++ b/source/Timer.cc
@@ -25,7 +25,7 @@ void Timer::reset() { _elapsed_time = boost::chrono::milliseconds(0); }
 
 void Timer::print()
 {
-  int rank;
+  int rank = -1;
   MPI_Comm_rank(_communicator, &rank);
   if (rank == 0)
   {


### PR DESCRIPTION
I ran clang-tidy a couple of months ago and forgot to push the changes. There is nothing really important. Here is the clang-tidy options that I have used:
```
Checks: >
  -*,
  bugprone-too-small-loop-variable,
  bugprone-unchecked-optional-access,
  bugprone-use-after-move,
  bugprone-virtual-near-miss,
  cppcoreguidelines-init-variables,
  modernize-deprecated-headers,
  modernize-use-nullptr,
  modernize-use-override,
  modernize-use-using,
  mpi-*
  performance-*,
  -performance-inefficient-string-concatenation,
  -performance-avoid-endl
```