### PR TITLE
Make MaterialProperty::polynomial_order a template parameter

### DIFF
--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -55,7 +55,7 @@
 #include <cmath>
 #include <iostream>
 
-template <int dim, typename MemorySpaceType,
+template <int dim, int p_order, typename MemorySpaceType,
           std::enable_if_t<
               std::is_same<MemorySpaceType, dealii::MemorySpace::Host>::value,
               int> = 0>
@@ -67,11 +67,12 @@ void output_pvtu(
         &thermal_physics,
     dealii::LinearAlgebra::distributed::Vector<double, MemorySpaceType>
         &temperature,
-    std::unique_ptr<adamantine::MechanicalPhysics<dim, MemorySpaceType>> const
+    std::unique_ptr<
+        adamantine::MechanicalPhysics<dim, p_order, MemorySpaceType>> const
         &mechanical_physics,
     dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host>
         &displacement,
-    adamantine::MaterialProperty<dim, MemorySpaceType> const
+    adamantine::MaterialProperty<dim, p_order, MemorySpaceType> const
         &material_properties,
     std::vector<adamantine::Timer> &timers)
 {
@@ -114,7 +115,7 @@ void output_pvtu(
   timers[adamantine::output].stop();
 }
 
-template <int dim, typename MemorySpaceType,
+template <int dim, int p_order, typename MemorySpaceType,
           std::enable_if_t<std::is_same<MemorySpaceType,
                                         dealii::MemorySpace::Default>::value,
                            int> = 0>
@@ -126,11 +127,12 @@ void output_pvtu(
         &thermal_physics,
     dealii::LinearAlgebra::distributed::Vector<double, MemorySpaceType>
         &temperature,
-    std::unique_ptr<adamantine::MechanicalPhysics<dim, MemorySpaceType>> const
+    std::unique_ptr<
+        adamantine::MechanicalPhysics<dim, p_order, MemorySpaceType>> const
         &mechanical_physics,
     dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host>
         &displacement,
-    adamantine::MaterialProperty<dim, MemorySpaceType> const
+    adamantine::MaterialProperty<dim, p_order, MemorySpaceType> const
         &material_properties,
     std::vector<adamantine::Timer> &timers)
 {
@@ -253,85 +255,90 @@ inline void initialize_timers(MPI_Comm const &communicator,
   timers.push_back(adamantine::Timer(communicator, "Output"));
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType,
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType,
           typename QuadratureType>
 std::unique_ptr<adamantine::ThermalPhysicsInterface<dim, MemorySpaceType>>
-initialize(
-    MPI_Comm const &communicator, boost::property_tree::ptree const &database,
-    adamantine::Geometry<dim> &geometry,
-    adamantine::MaterialProperty<dim, MemorySpaceType> &material_properties)
+initialize(MPI_Comm const &communicator,
+           boost::property_tree::ptree const &database,
+           adamantine::Geometry<dim> &geometry,
+           adamantine::MaterialProperty<dim, p_order, MemorySpaceType>
+               &material_properties)
 {
   return std::make_unique<adamantine::ThermalPhysics<
-      dim, fe_degree, MemorySpaceType, QuadratureType>>(
+      dim, p_order, fe_degree, MemorySpaceType, QuadratureType>>(
       communicator, database, geometry, material_properties);
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
 std::unique_ptr<adamantine::ThermalPhysicsInterface<dim, MemorySpaceType>>
 initialize_quadrature(
     std::string const &quadrature_type, MPI_Comm const &communicator,
     boost::property_tree::ptree const &database,
     adamantine::Geometry<dim> &geometry,
-    adamantine::MaterialProperty<dim, MemorySpaceType> &material_properties)
+    adamantine::MaterialProperty<dim, p_order, MemorySpaceType>
+        &material_properties)
 {
   if (quadrature_type.compare("gauss") == 0)
-    return initialize<dim, fe_degree, MemorySpaceType, dealii::QGauss<1>>(
-        communicator, database, geometry, material_properties);
+    return initialize<dim, p_order, fe_degree, MemorySpaceType,
+                      dealii::QGauss<1>>(communicator, database, geometry,
+                                         material_properties);
   else
   {
     adamantine::ASSERT_THROW(quadrature_type.compare("lobatto") == 0,
                              "quadrature should be Gauss or Lobatto.");
-    return initialize<dim, fe_degree, MemorySpaceType,
+    return initialize<dim, p_order, fe_degree, MemorySpaceType,
                       dealii::QGaussLobatto<1>>(communicator, database,
                                                 geometry, material_properties);
   }
 }
 
-template <int dim, typename MemorySpaceType>
+template <int dim, int p_order, typename MemorySpaceType>
 std::unique_ptr<adamantine::ThermalPhysicsInterface<dim, MemorySpaceType>>
 initialize_thermal_physics(
     unsigned int fe_degree, std::string const &quadrature_type,
     MPI_Comm const &communicator, boost::property_tree::ptree const &database,
     adamantine::Geometry<dim> &geometry,
-    adamantine::MaterialProperty<dim, MemorySpaceType> &material_properties)
+    adamantine::MaterialProperty<dim, p_order, MemorySpaceType>
+        &material_properties)
 {
   switch (fe_degree)
   {
   case 1:
   {
-    return initialize_quadrature<dim, 1, MemorySpaceType>(
+    return initialize_quadrature<dim, p_order, 1, MemorySpaceType>(
         quadrature_type, communicator, database, geometry, material_properties);
   }
   case 2:
   {
-    return initialize_quadrature<dim, 2, MemorySpaceType>(
+    return initialize_quadrature<dim, p_order, 2, MemorySpaceType>(
         quadrature_type, communicator, database, geometry, material_properties);
   }
   case 3:
   {
-    return initialize_quadrature<dim, 3, MemorySpaceType>(
+    return initialize_quadrature<dim, p_order, 3, MemorySpaceType>(
         quadrature_type, communicator, database, geometry, material_properties);
   }
   case 4:
   {
-    return initialize_quadrature<dim, 4, MemorySpaceType>(
+    return initialize_quadrature<dim, p_order, 4, MemorySpaceType>(
         quadrature_type, communicator, database, geometry, material_properties);
   }
   default:
   {
     adamantine::ASSERT_THROW(fe_degree == 5,
                              "fe_degree should be between 1 and 5.");
-    return initialize_quadrature<dim, 5, MemorySpaceType>(
+    return initialize_quadrature<dim, p_order, 5, MemorySpaceType>(
         quadrature_type, communicator, database, geometry, material_properties);
   }
   }
 }
 
-template <int dim, typename MemorySpaceType>
+template <int dim, int p_order, typename MemorySpaceType>
 void refine_and_transfer(
     std::unique_ptr<adamantine::ThermalPhysicsInterface<dim, MemorySpaceType>>
         &thermal_physics,
-    adamantine::MaterialProperty<dim, MemorySpaceType> &material_properties,
+    adamantine::MaterialProperty<dim, p_order, MemorySpaceType>
+        &material_properties,
     dealii::DoFHandler<dim> &dof_handler,
     dealii::LA::distributed::Vector<double, MemorySpaceType> &solution)
 {
@@ -591,11 +598,12 @@ compute_cells_to_refine(
   return cells_to_refine;
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
 void refine_mesh(
     std::unique_ptr<adamantine::ThermalPhysicsInterface<dim, MemorySpaceType>>
         &thermal_physics,
-    adamantine::MaterialProperty<dim, MemorySpaceType> &material_properties,
+    adamantine::MaterialProperty<dim, p_order, MemorySpaceType>
+        &material_properties,
     dealii::LA::distributed::Vector<double, MemorySpaceType> &solution,
     std::vector<std::shared_ptr<adamantine::HeatSource<dim>>> &heat_sources,
     double const time, double const next_refinement_time,
@@ -659,16 +667,16 @@ void refine_mesh(
 
   // Refine the mesh along the trajectory of the sources.
   double current_source_height =
-      dynamic_cast<adamantine::ThermalPhysics<dim, fe_degree, MemorySpaceType,
-                                              dealii::QGauss<1>> *>(
+      dynamic_cast<adamantine::ThermalPhysics<
+          dim, p_order, fe_degree, MemorySpaceType, dealii::QGauss<1>> *>(
           thermal_physics.get())
           ? dynamic_cast<adamantine::ThermalPhysics<
-                dim, fe_degree, MemorySpaceType, dealii::QGauss<1>> *>(
+                dim, p_order, fe_degree, MemorySpaceType, dealii::QGauss<1>> *>(
                 thermal_physics.get())
                 ->get_current_source_height()
           : dynamic_cast<adamantine::ThermalPhysics<
-                dim, fe_degree, MemorySpaceType, dealii::QGaussLobatto<1>> *>(
-                thermal_physics.get())
+                dim, p_order, fe_degree, MemorySpaceType,
+                dealii::QGaussLobatto<1>> *>(thermal_physics.get())
                 ->get_current_source_height();
 
   for (unsigned int i = 0; i < n_beam_refinements; ++i)
@@ -714,11 +722,12 @@ void refine_mesh(
   thermal_physics->compute_inverse_mass_matrix();
 }
 
-template <int dim, typename MemorySpaceType>
+template <int dim, int p_order, typename MemorySpaceType>
 void refine_mesh(
     std::unique_ptr<adamantine::ThermalPhysicsInterface<dim, MemorySpaceType>>
         &thermal_physics,
-    adamantine::MaterialProperty<dim, MemorySpaceType> &material_properties,
+    adamantine::MaterialProperty<dim, p_order, MemorySpaceType>
+        &material_properties,
     dealii::LA::distributed::Vector<double, MemorySpaceType> &solution,
     std::vector<std::shared_ptr<adamantine::HeatSource<dim>>> &heat_sources,
     double const time, double const next_refinement_time,
@@ -732,37 +741,37 @@ void refine_mesh(
   {
   case 1:
   {
-    refine_mesh<dim, 1>(thermal_physics, material_properties, solution,
-                        heat_sources, time, next_refinement_time,
-                        time_steps_refinement, refinement_database);
+    refine_mesh<dim, p_order, 1>(thermal_physics, material_properties, solution,
+                                 heat_sources, time, next_refinement_time,
+                                 time_steps_refinement, refinement_database);
     break;
   }
   case 2:
   {
-    refine_mesh<dim, 2>(thermal_physics, material_properties, solution,
-                        heat_sources, time, next_refinement_time,
-                        time_steps_refinement, refinement_database);
+    refine_mesh<dim, p_order, 2>(thermal_physics, material_properties, solution,
+                                 heat_sources, time, next_refinement_time,
+                                 time_steps_refinement, refinement_database);
     break;
   }
   case 3:
   {
-    refine_mesh<dim, 3>(thermal_physics, material_properties, solution,
-                        heat_sources, time, next_refinement_time,
-                        time_steps_refinement, refinement_database);
+    refine_mesh<dim, p_order, 3>(thermal_physics, material_properties, solution,
+                                 heat_sources, time, next_refinement_time,
+                                 time_steps_refinement, refinement_database);
     break;
   }
   case 4:
   {
-    refine_mesh<dim, 4>(thermal_physics, material_properties, solution,
-                        heat_sources, time, next_refinement_time,
-                        time_steps_refinement, refinement_database);
+    refine_mesh<dim, p_order, 4>(thermal_physics, material_properties, solution,
+                                 heat_sources, time, next_refinement_time,
+                                 time_steps_refinement, refinement_database);
     break;
   }
   case 5:
   {
-    refine_mesh<dim, 5>(thermal_physics, material_properties, solution,
-                        heat_sources, time, next_refinement_time,
-                        time_steps_refinement, refinement_database);
+    refine_mesh<dim, p_order, 5>(thermal_physics, material_properties, solution,
+                                 heat_sources, time, next_refinement_time,
+                                 time_steps_refinement, refinement_database);
     break;
   }
   default:
@@ -772,7 +781,7 @@ void refine_mesh(
   }
 }
 
-template <int dim, typename MemorySpaceType>
+template <int dim, int p_order, typename MemorySpaceType>
 std::pair<dealii::LinearAlgebra::distributed::Vector<double,
                                                      dealii::MemorySpace::Host>,
           dealii::LinearAlgebra::distributed::Vector<double,
@@ -792,8 +801,9 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
   // Create the MaterialProperty
   boost::property_tree::ptree material_database =
       database.get_child("materials");
-  adamantine::MaterialProperty<dim, MemorySpaceType> material_properties(
-      communicator, geometry.get_triangulation(), material_database);
+  adamantine::MaterialProperty<dim, p_order, MemorySpaceType>
+      material_properties(communicator, geometry.get_triangulation(),
+                          material_database);
 
   // Extract the physics property tree
   boost::property_tree::ptree physics_database = database.get_child("physics");
@@ -854,17 +864,17 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
   material_reference_temps.push_back(initial_temperature);
 
   // Create MechanicalPhysics
-  std::unique_ptr<adamantine::MechanicalPhysics<dim, MemorySpaceType>>
+  std::unique_ptr<adamantine::MechanicalPhysics<dim, p_order, MemorySpaceType>>
       mechanical_physics;
   if (use_mechanical_physics)
   {
     // PropertyTreeInput discretization.mechanical.fe_degree
     unsigned int const fe_degree =
         discretization_database.get<unsigned int>("mechanical.fe_degree");
-    mechanical_physics =
-        std::make_unique<adamantine::MechanicalPhysics<dim, MemorySpaceType>>(
-            communicator, fe_degree, geometry, material_properties,
-            material_reference_temps);
+    mechanical_physics = std::make_unique<
+        adamantine::MechanicalPhysics<dim, p_order, MemorySpaceType>>(
+        communicator, fe_degree, geometry, material_properties,
+        material_reference_temps);
     post_processor_database.put("mechanical_output", true);
   }
 
@@ -1301,7 +1311,7 @@ void split_global_communicator(MPI_Comm global_communicator,
   MPI_Comm_split(global_communicator, my_color, 0, &local_communicator);
 }
 
-template <int dim, typename MemorySpaceType>
+template <int dim, int p_order, typename MemorySpaceType>
 std::vector<dealii::LA::distributed::BlockVector<double>>
 run_ensemble(MPI_Comm const &global_communicator,
              boost::property_tree::ptree const &database,
@@ -1438,8 +1448,8 @@ run_ensemble(MPI_Comm const &global_communicator,
 
   std::vector<std::unique_ptr<adamantine::Geometry<dim>>> geometry_ensemble;
 
-  std::vector<
-      std::unique_ptr<adamantine::MaterialProperty<dim, MemorySpaceType>>>
+  std::vector<std::unique_ptr<
+      adamantine::MaterialProperty<dim, p_order, MemorySpaceType>>>
       material_properties_ensemble;
 
   std::vector<std::unique_ptr<adamantine::PostProcessor<dim>>>
@@ -1574,7 +1584,8 @@ run_ensemble(MPI_Comm const &global_communicator,
         local_communicator, geometry_database));
 
     material_properties_ensemble.push_back(
-        std::make_unique<adamantine::MaterialProperty<dim, MemorySpaceType>>(
+        std::make_unique<
+            adamantine::MaterialProperty<dim, p_order, MemorySpaceType>>(
             local_communicator, geometry_ensemble.back()->get_triangulation(),
             material_database));
 
@@ -1706,7 +1717,7 @@ run_ensemble(MPI_Comm const &global_communicator,
       geometry_database.get<double>("deposition_time", 0.);
 
   // ----- Output the initial solution -----
-  std::unique_ptr<adamantine::MechanicalPhysics<dim, MemorySpaceType>>
+  std::unique_ptr<adamantine::MechanicalPhysics<dim, p_order, MemorySpaceType>>
       mechanical_physics;
   dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host>
       displacement;

--- a/source/BodyForce.cc
+++ b/source/BodyForce.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023, the adamantine authors.
+/* Copyright (c) 2023 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -11,15 +11,16 @@
 
 namespace adamantine
 {
-template <int dim, typename MemorySpaceType>
-GravityForce<dim, MemorySpaceType>::GravityForce(
-    MaterialProperty<dim, MemorySpaceType> &material_properties)
+template <int dim, int p_order, typename MemorySpaceType>
+GravityForce<dim, p_order, MemorySpaceType>::GravityForce(
+    MaterialProperty<dim, p_order, MemorySpaceType> &material_properties)
     : _material_properties(material_properties)
 {
 }
 
-template <int dim, typename MemorySpaceType>
-dealii::Tensor<1, dim, double> GravityForce<dim, MemorySpaceType>::eval(
+template <int dim, int p_order, typename MemorySpaceType>
+dealii::Tensor<1, dim, double>
+GravityForce<dim, p_order, MemorySpaceType>::eval(
     typename dealii::Triangulation<dim>::active_cell_iterator const &cell)
 {
   // Note that the density is independent of the temperature
@@ -32,5 +33,5 @@ dealii::Tensor<1, dim, double> GravityForce<dim, MemorySpaceType>::eval(
 }
 } // namespace adamantine
 
-INSTANTIATE_DIM_HOST(GravityForce)
-INSTANTIATE_DIM_DEVICE(GravityForce)
+INSTANTIATE_DIM_PORDER_HOST(TUPLE(GravityForce))
+INSTANTIATE_DIM_PORDER_DEVICE(TUPLE(GravityForce))

--- a/source/BodyForce.hh
+++ b/source/BodyForce.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023, the adamantine authors.
+/* Copyright (c) 2023 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -29,17 +29,18 @@ struct BodyForce
 };
 
 // Forward declaration
-template <int dim, typename MemorySpaceType>
+template <int dim, int p_order, typename MemorySpaceType>
 class MaterialProperty;
 
 /**
  * Gravity's body force.
  */
-template <int dim, typename MemorySpaceType>
+template <int dim, int p_order, typename MemorySpaceType>
 class GravityForce final : public BodyForce<dim>
 {
 public:
-  GravityForce(MaterialProperty<dim, MemorySpaceType> &material_properties);
+  GravityForce(
+      MaterialProperty<dim, p_order, MemorySpaceType> &material_properties);
 
   dealii::Tensor<1, dim, double>
   eval(typename dealii::Triangulation<dim>::active_cell_iterator const &cell)
@@ -50,7 +51,7 @@ private:
    * Gravity in \f$m/s^2\f$
    */
   static double constexpr g = 9.80665;
-  MaterialProperty<dim, MemorySpaceType> &_material_properties;
+  MaterialProperty<dim, p_order, MemorySpaceType> &_material_properties;
 };
 } // namespace adamantine
 

--- a/source/MaterialProperty.cc
+++ b/source/MaterialProperty.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 - 2023, the adamantine authors.
+/* Copyright (c) 2016 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -8,5 +8,5 @@
 #include <MaterialProperty.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_HOST(MaterialProperty)
-INSTANTIATE_DIM_DEVICE(MaterialProperty)
+INSTANTIATE_DIM_PORDER_HOST(TUPLE(MaterialProperty))
+INSTANTIATE_DIM_PORDER_DEVICE(TUPLE(MaterialProperty))

--- a/source/MechanicalOperator.cc
+++ b/source/MechanicalOperator.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022 - 2023, the adamantine authors.
+/* Copyright (c) 2022 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -26,10 +26,10 @@
 
 namespace adamantine
 {
-template <int dim, typename MemorySpaceType>
-MechanicalOperator<dim, MemorySpaceType>::MechanicalOperator(
+template <int dim, int p_order, typename MemorySpaceType>
+MechanicalOperator<dim, p_order, MemorySpaceType>::MechanicalOperator(
     MPI_Comm const &communicator,
-    MaterialProperty<dim, MemorySpaceType> &material_properties,
+    MaterialProperty<dim, p_order, MemorySpaceType> &material_properties,
     std::vector<double> const reference_temperatures)
     : _communicator(communicator),
       _reference_temperatures(reference_temperatures),
@@ -37,8 +37,8 @@ MechanicalOperator<dim, MemorySpaceType>::MechanicalOperator(
 {
 }
 
-template <int dim, typename MemorySpaceType>
-void MechanicalOperator<dim, MemorySpaceType>::reinit(
+template <int dim, int p_order, typename MemorySpaceType>
+void MechanicalOperator<dim, p_order, MemorySpaceType>::reinit(
     dealii::DoFHandler<dim> const &dof_handler,
     dealii::AffineConstraints<double> const &affine_constraints,
     dealii::hp::QCollection<dim> const &q_collection,
@@ -50,8 +50,8 @@ void MechanicalOperator<dim, MemorySpaceType>::reinit(
   assemble_system(body_forces);
 }
 
-template <int dim, typename MemorySpaceType>
-void MechanicalOperator<dim, MemorySpaceType>::vmult(
+template <int dim, int p_order, typename MemorySpaceType>
+void MechanicalOperator<dim, p_order, MemorySpaceType>::vmult(
     dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> &dst,
     dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> const
         &src) const
@@ -59,8 +59,8 @@ void MechanicalOperator<dim, MemorySpaceType>::vmult(
   _system_matrix.vmult(dst, src);
 }
 
-template <int dim, typename MemorySpaceType>
-void MechanicalOperator<dim, MemorySpaceType>::Tvmult(
+template <int dim, int p_order, typename MemorySpaceType>
+void MechanicalOperator<dim, p_order, MemorySpaceType>::Tvmult(
     dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> &dst,
     dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> const
         &src) const
@@ -68,8 +68,8 @@ void MechanicalOperator<dim, MemorySpaceType>::Tvmult(
   _system_matrix.Tvmult(dst, src);
 }
 
-template <int dim, typename MemorySpaceType>
-void MechanicalOperator<dim, MemorySpaceType>::vmult_add(
+template <int dim, int p_order, typename MemorySpaceType>
+void MechanicalOperator<dim, p_order, MemorySpaceType>::vmult_add(
     dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> &dst,
     dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> const
         &src) const
@@ -77,8 +77,8 @@ void MechanicalOperator<dim, MemorySpaceType>::vmult_add(
   _system_matrix.vmult_add(dst, src);
 }
 
-template <int dim, typename MemorySpaceType>
-void MechanicalOperator<dim, MemorySpaceType>::Tvmult_add(
+template <int dim, int p_order, typename MemorySpaceType>
+void MechanicalOperator<dim, p_order, MemorySpaceType>::Tvmult_add(
     dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> &dst,
     dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> const
         &src) const
@@ -86,8 +86,8 @@ void MechanicalOperator<dim, MemorySpaceType>::Tvmult_add(
   _system_matrix.Tvmult_add(dst, src);
 }
 
-template <int dim, typename MemorySpaceType>
-void MechanicalOperator<dim, MemorySpaceType>::update_temperature(
+template <int dim, int p_order, typename MemorySpaceType>
+void MechanicalOperator<dim, p_order, MemorySpaceType>::update_temperature(
     dealii::DoFHandler<dim> const &thermal_dof_handler,
     dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> const
         &temperature,
@@ -98,8 +98,8 @@ void MechanicalOperator<dim, MemorySpaceType>::update_temperature(
   _has_melted = has_melted;
 }
 
-template <int dim, typename MemorySpaceType>
-void MechanicalOperator<dim, MemorySpaceType>::assemble_system(
+template <int dim, int p_order, typename MemorySpaceType>
+void MechanicalOperator<dim, p_order, MemorySpaceType>::assemble_system(
     std::vector<std::shared_ptr<BodyForce<dim>>> const &body_forces)
 {
   // Create the sparsity pattern. Since we use a Trilinos matrix we don't need
@@ -323,5 +323,5 @@ void MechanicalOperator<dim, MemorySpaceType>::assemble_system(
 }
 } // namespace adamantine
 
-INSTANTIATE_DIM_HOST(MechanicalOperator)
-INSTANTIATE_DIM_DEVICE(MechanicalOperator)
+INSTANTIATE_DIM_PORDER_HOST(TUPLE(MechanicalOperator))
+INSTANTIATE_DIM_PORDER_DEVICE(TUPLE(MechanicalOperator))

--- a/source/MechanicalOperator.hh
+++ b/source/MechanicalOperator.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, the adamantine authors.
+/* Copyright (c) 2022 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -29,7 +29,7 @@ namespace adamantine
  * The class is templated on the MemorySpace because it use MaterialProperty
  * which itself is templated on the MemorySpace but the operator is CPU only.
  */
-template <int dim, typename MemorySpaceType>
+template <int dim, int p_order, typename MemorySpaceType>
 class MechanicalOperator : public Operator<dealii::MemorySpace::Host>
 {
 public:
@@ -39,7 +39,7 @@ public:
    */
   MechanicalOperator(
       MPI_Comm const &communicator,
-      MaterialProperty<dim, MemorySpaceType> &material_properties,
+      MaterialProperty<dim, p_order, MemorySpaceType> &material_properties,
       std::vector<double> reference_temperatures);
 
   void reinit(dealii::DoFHandler<dim> const &dof_handler,
@@ -106,7 +106,7 @@ private:
   /**
    * Reference to the MaterialProperty from MechanicalPhysics.
    */
-  MaterialProperty<dim, MemorySpaceType> &_material_properties;
+  MaterialProperty<dim, p_order, MemorySpaceType> &_material_properties;
   /**
    * Non-owning pointer to the DoFHandler from MechanicalPhysics
    */
@@ -145,31 +145,31 @@ private:
   std::vector<bool> _has_melted;
 };
 
-template <int dim, typename MemorySpaceType>
+template <int dim, int p_order, typename MemorySpaceType>
 inline dealii::types::global_dof_index
-MechanicalOperator<dim, MemorySpaceType>::m() const
+MechanicalOperator<dim, p_order, MemorySpaceType>::m() const
 {
   return _system_matrix.m();
 }
 
-template <int dim, typename MemorySpaceType>
+template <int dim, int p_order, typename MemorySpaceType>
 inline dealii::types::global_dof_index
-MechanicalOperator<dim, MemorySpaceType>::n() const
+MechanicalOperator<dim, p_order, MemorySpaceType>::n() const
 {
   return _system_matrix.n();
 }
 
-template <int dim, typename MemorySpaceType>
+template <int dim, int p_order, typename MemorySpaceType>
 inline dealii::LA::distributed::Vector<double,
                                        dealii::MemorySpace::Host> const &
-MechanicalOperator<dim, MemorySpaceType>::rhs() const
+MechanicalOperator<dim, p_order, MemorySpaceType>::rhs() const
 {
   return _system_rhs;
 }
 
-template <int dim, typename MemorySpaceType>
+template <int dim, int p_order, typename MemorySpaceType>
 inline dealii::TrilinosWrappers::SparseMatrix const &
-MechanicalOperator<dim, MemorySpaceType>::system_matrix() const
+MechanicalOperator<dim, p_order, MemorySpaceType>::system_matrix() const
 {
   return _system_matrix;
 }

--- a/source/MechanicalPhysics.cc
+++ b/source/MechanicalPhysics.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022 - 2023, the adamantine authors.
+/* Copyright (c) 2022 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -21,11 +21,11 @@
 
 namespace adamantine
 {
-template <int dim, typename MemorySpaceType>
-MechanicalPhysics<dim, MemorySpaceType>::MechanicalPhysics(
+template <int dim, int p_order, typename MemorySpaceType>
+MechanicalPhysics<dim, p_order, MemorySpaceType>::MechanicalPhysics(
     MPI_Comm const &communicator, unsigned int const fe_degree,
     Geometry<dim> &geometry,
-    MaterialProperty<dim, MemorySpaceType> &material_properties,
+    MaterialProperty<dim, p_order, MemorySpaceType> &material_properties,
     std::vector<double> const &reference_temperatures)
     : _geometry(geometry), _material_properties(material_properties),
       _dof_handler(_geometry.get_triangulation())
@@ -60,7 +60,7 @@ MechanicalPhysics<dim, MemorySpaceType>::MechanicalPhysics(
 
   // Create the mechanical operator
   _mechanical_operator =
-      std::make_unique<MechanicalOperator<dim, MemorySpaceType>>(
+      std::make_unique<MechanicalOperator<dim, p_order, MemorySpaceType>>(
           communicator, _material_properties, reference_temperatures);
 
   // Create the data used to compute the stress tensor
@@ -81,8 +81,8 @@ MechanicalPhysics<dim, MemorySpaceType>::MechanicalPhysics(
                       std::vector<dealii::SymmetricTensor<2, dim>>(n_quad_pts));
 }
 
-template <int dim, typename MemorySpaceType>
-void MechanicalPhysics<dim, MemorySpaceType>::setup_dofs(
+template <int dim, int p_order, typename MemorySpaceType>
+void MechanicalPhysics<dim, p_order, MemorySpaceType>::setup_dofs(
     std::vector<std::shared_ptr<BodyForce<dim>>> const &body_forces)
 {
   _dof_handler.distribute_dofs(_fe_collection);
@@ -106,8 +106,8 @@ void MechanicalPhysics<dim, MemorySpaceType>::setup_dofs(
                                body_forces);
 }
 
-template <int dim, typename MemorySpaceType>
-void MechanicalPhysics<dim, MemorySpaceType>::setup_dofs(
+template <int dim, int p_order, typename MemorySpaceType>
+void MechanicalPhysics<dim, p_order, MemorySpaceType>::setup_dofs(
     dealii::DoFHandler<dim> const &thermal_dof_handler,
     dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> const
         &temperature,
@@ -243,9 +243,9 @@ void MechanicalPhysics<dim, MemorySpaceType>::setup_dofs(
   }
 }
 
-template <int dim, typename MemorySpaceType>
+template <int dim, int p_order, typename MemorySpaceType>
 dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host>
-MechanicalPhysics<dim, MemorySpaceType>::solve()
+MechanicalPhysics<dim, p_order, MemorySpaceType>::solve()
 {
   dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host>
       displacement(_mechanical_operator->rhs().get_partitioner());
@@ -284,8 +284,8 @@ MechanicalPhysics<dim, MemorySpaceType>::solve()
   return _old_displacement;
 }
 
-template <int dim, typename MemorySpaceType>
-void MechanicalPhysics<dim, MemorySpaceType>::compute_stress(
+template <int dim, int p_order, typename MemorySpaceType>
+void MechanicalPhysics<dim, p_order, MemorySpaceType>::compute_stress(
     dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> const
         &displacement)
 {
@@ -370,5 +370,5 @@ void MechanicalPhysics<dim, MemorySpaceType>::compute_stress(
 
 } // namespace adamantine
 
-INSTANTIATE_DIM_HOST(MechanicalPhysics)
-INSTANTIATE_DIM_DEVICE(MechanicalPhysics)
+INSTANTIATE_DIM_PORDER_HOST(TUPLE(MechanicalPhysics))
+INSTANTIATE_DIM_PORDER_DEVICE(TUPLE(MechanicalPhysics))

--- a/source/MechanicalPhysics.hh
+++ b/source/MechanicalPhysics.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022 - 2023, the adamantine authors.
+/* Copyright (c) 2022 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -18,17 +18,18 @@
 
 namespace adamantine
 {
-template <int dim, typename MemorySpaceType>
+template <int dim, int p_order, typename MemorySpaceType>
 class MechanicalPhysics
 {
 public:
   /**
    * Constructor.
    */
-  MechanicalPhysics(MPI_Comm const &communicator, unsigned int const fe_degree,
-                    Geometry<dim> &geometry,
-                    MaterialProperty<dim, MemorySpaceType> &material_properties,
-                    std::vector<double> const &initial_temperatures);
+  MechanicalPhysics(
+      MPI_Comm const &communicator, unsigned int const fe_degree,
+      Geometry<dim> &geometry,
+      MaterialProperty<dim, p_order, MemorySpaceType> &material_properties,
+      std::vector<double> const &initial_temperatures);
 
   /**
    * Setup the DoFHandler, the AffineConstraints, and the
@@ -85,7 +86,7 @@ private:
   /**
    * Associated MaterialProperty.
    */
-  MaterialProperty<dim, MemorySpaceType> &_material_properties;
+  MaterialProperty<dim, p_order, MemorySpaceType> &_material_properties;
   /**
    * Associated FECollection.
    */
@@ -105,7 +106,7 @@ private:
   /**
    * Pointer to the MechanicalOperator
    */
-  std::unique_ptr<MechanicalOperator<dim, MemorySpaceType>>
+  std::unique_ptr<MechanicalOperator<dim, p_order, MemorySpaceType>>
       _mechanical_operator;
   /**
    * Whether to include a gravitional body force in the calculation.
@@ -134,23 +135,23 @@ private:
   std::vector<std::vector<dealii::SymmetricTensor<2, dim>>> _back_stress;
 };
 
-template <int dim, typename MemorySpaceType>
+template <int dim, int p_order, typename MemorySpaceType>
 inline dealii::DoFHandler<dim> &
-MechanicalPhysics<dim, MemorySpaceType>::get_dof_handler()
+MechanicalPhysics<dim, p_order, MemorySpaceType>::get_dof_handler()
 {
   return _dof_handler;
 }
 
-template <int dim, typename MemorySpaceType>
+template <int dim, int p_order, typename MemorySpaceType>
 inline dealii::AffineConstraints<double> &
-MechanicalPhysics<dim, MemorySpaceType>::get_affine_constraints()
+MechanicalPhysics<dim, p_order, MemorySpaceType>::get_affine_constraints()
 {
   return _affine_constraints;
 }
 
-template <int dim, typename MemorySpaceType>
+template <int dim, int p_order, typename MemorySpaceType>
 inline std::vector<std::vector<dealii::SymmetricTensor<2, dim>>> &
-MechanicalPhysics<dim, MemorySpaceType>::get_stress_tensor()
+MechanicalPhysics<dim, p_order, MemorySpaceType>::get_stress_tensor()
 {
   return _stress;
 }

--- a/source/ThermalOperator.cc
+++ b/source/ThermalOperator.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 - 2022, the adamantine authors.
+/* Copyright (c) 2016 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -22,10 +22,10 @@
 namespace adamantine
 {
 
-template <int dim, int fe_degree, typename MemorySpaceType>
-ThermalOperator<dim, fe_degree, MemorySpaceType>::ThermalOperator(
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::ThermalOperator(
     MPI_Comm const &communicator, BoundaryType boundary_type,
-    MaterialProperty<dim, MemorySpaceType> &material_properties,
+    MaterialProperty<dim, p_order, MemorySpaceType> &material_properties,
     std::vector<std::shared_ptr<HeatSource<dim>>> const &heat_sources)
     : _communicator(communicator), _boundary_type(boundary_type),
       _material_properties(material_properties), _heat_sources(heat_sources),
@@ -43,8 +43,8 @@ ThermalOperator<dim, fe_degree, MemorySpaceType>::ThermalOperator(
       dealii::update_values | dealii::update_JxW_values;
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
-void ThermalOperator<dim, fe_degree, MemorySpaceType>::reinit(
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+void ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::reinit(
     dealii::DoFHandler<dim> const &dof_handler,
     dealii::AffineConstraints<double> const &affine_constraints,
     dealii::hp::QCollection<1> const &q_collection)
@@ -66,8 +66,8 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::reinit(
     }
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
-void ThermalOperator<dim, fe_degree, MemorySpaceType>::cell_local_mass(
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+void ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::cell_local_mass(
     dealii::MatrixFree<dim, double> const &data,
     dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
     dealii::LA::distributed::Vector<double, MemorySpaceType> const &src,
@@ -100,8 +100,8 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::cell_local_mass(
   }
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
-void ThermalOperator<dim, fe_degree, MemorySpaceType>::
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+void ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::
     compute_inverse_mass_matrix(
         dealii::DoFHandler<dim> const &dof_handler,
         dealii::AffineConstraints<double> const &affine_constraints)
@@ -146,16 +146,16 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::
   }
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
-void ThermalOperator<dim, fe_degree, MemorySpaceType>::clear()
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+void ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::clear()
 {
   _cell_it_to_mf_cell_map.clear();
   _matrix_free.clear();
   _inverse_mass_matrix->reinit(0);
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
-void ThermalOperator<dim, fe_degree, MemorySpaceType>::vmult(
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+void ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::vmult(
     dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
     dealii::LA::distributed::Vector<double, MemorySpaceType> const &src) const
 {
@@ -163,8 +163,8 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::vmult(
   vmult_add(dst, src);
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
-void ThermalOperator<dim, fe_degree, MemorySpaceType>::Tvmult(
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+void ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::Tvmult(
     dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
     dealii::LA::distributed::Vector<double, MemorySpaceType> const &src) const
 {
@@ -172,8 +172,8 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::Tvmult(
   Tvmult_add(dst, src);
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
-void ThermalOperator<dim, fe_degree, MemorySpaceType>::vmult_add(
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+void ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::vmult_add(
     dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
     dealii::LA::distributed::Vector<double, MemorySpaceType> const &src) const
 {
@@ -208,8 +208,8 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::vmult_add(
     dst.local_element(dof) += scaling * src.local_element(dof);
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
-void ThermalOperator<dim, fe_degree, MemorySpaceType>::Tvmult_add(
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+void ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::Tvmult_add(
     dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
     dealii::LA::distributed::Vector<double, MemorySpaceType> const &src) const
 {
@@ -217,12 +217,12 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::Tvmult_add(
   vmult_add(dst, src);
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
-void ThermalOperator<dim, fe_degree, MemorySpaceType>::update_state_ratios(
-    unsigned int cell, unsigned int q,
-    dealii::VectorizedArray<double> temperature,
-    std::array<dealii::VectorizedArray<double>, g_n_material_states>
-        &state_ratios) const
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+void ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::
+    update_state_ratios(unsigned int cell, unsigned int q,
+                        dealii::VectorizedArray<double> temperature,
+                        std::array<dealii::VectorizedArray<double>,
+                                   g_n_material_states> &state_ratios) const
 {
   unsigned int constexpr liquid =
       static_cast<unsigned int>(MaterialState::liquid);
@@ -270,12 +270,13 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::update_state_ratios(
   _powder_ratio(cell, q) = state_ratios[powder];
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
-void ThermalOperator<dim, fe_degree, MemorySpaceType>::update_face_state_ratios(
-    unsigned int face, unsigned int q,
-    dealii::VectorizedArray<double> temperature,
-    std::array<dealii::VectorizedArray<double>, g_n_material_states>
-        &face_state_ratios) const
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+void ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::
+    update_face_state_ratios(
+        unsigned int face, unsigned int q,
+        dealii::VectorizedArray<double> temperature,
+        std::array<dealii::VectorizedArray<double>, g_n_material_states>
+            &face_state_ratios) const
 {
   unsigned int constexpr liquid =
       static_cast<unsigned int>(MaterialState::liquid);
@@ -323,9 +324,9 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::update_face_state_ratios(
   _face_powder_ratio(face, q) = face_state_ratios[powder];
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
 dealii::VectorizedArray<double>
-ThermalOperator<dim, fe_degree, MemorySpaceType>::get_inv_rho_cp(
+ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::get_inv_rho_cp(
     std::array<dealii::types::material_id,
                dealii::VectorizedArray<double>::size()> const &material_id,
     std::array<dealii::VectorizedArray<double>, g_n_material_states> const
@@ -373,12 +374,13 @@ ThermalOperator<dim, fe_degree, MemorySpaceType>::get_inv_rho_cp(
   return 1.0 / (density * specific_heat);
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
-void ThermalOperator<dim, fe_degree, MemorySpaceType>::cell_local_apply(
-    dealii::MatrixFree<dim, double> const &data,
-    dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
-    dealii::LA::distributed::Vector<double, MemorySpaceType> const &src,
-    std::pair<unsigned int, unsigned int> const &cell_range) const
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+void ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::
+    cell_local_apply(
+        dealii::MatrixFree<dim, double> const &data,
+        dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
+        dealii::LA::distributed::Vector<double, MemorySpaceType> const &src,
+        std::pair<unsigned int, unsigned int> const &cell_range) const
 {
   // Get the subrange of cells associated with the fe index 0
   std::pair<unsigned int, unsigned int> cell_subrange =
@@ -395,7 +397,7 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::cell_local_apply(
   // It's really worth to compute it once and pass it when we compute a
   // material property.
   dealii::AlignedVector<dealii::VectorizedArray<double>> temperature_powers(
-      _material_properties.polynomial_order + 1);
+      p_order + 1);
 
   // Loop over the "cells". Note that we don't really work on a cell but on a
   // set of quadrature point.
@@ -415,7 +417,7 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::cell_local_apply(
     {
       auto temperature = fe_eval.get_value(q);
       // Precompute the powers of temperature.
-      for (unsigned int i = 0; i <= _material_properties.polynomial_order; ++i)
+      for (unsigned int i = 0; i <= p_order; ++i)
       {
         // FIXME Need to cast i to double due to a limitation in deal.II 9.5
         temperature_powers[i] = std::pow(temperature, static_cast<double>(i));
@@ -513,12 +515,13 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::cell_local_apply(
   }
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
-void ThermalOperator<dim, fe_degree, MemorySpaceType>::face_local_apply(
-    dealii::MatrixFree<dim, double> const &data,
-    dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
-    dealii::LA::distributed::Vector<double, MemorySpaceType> const &src,
-    std::pair<unsigned int, unsigned int> const &face_range) const
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+void ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::
+    face_local_apply(
+        dealii::MatrixFree<dim, double> const &data,
+        dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
+        dealii::LA::distributed::Vector<double, MemorySpaceType> const &src,
+        std::pair<unsigned int, unsigned int> const &face_range) const
 {
   // Get the fe_indices of the cells that share faces in face_range;
   auto const adjacent_cells_fe_index = data.get_face_range_category(face_range);
@@ -561,7 +564,7 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::face_local_apply(
   // It's really worth to compute it once and pass it when we compute a
   // material property.
   dealii::AlignedVector<dealii::VectorizedArray<double>> temperature_powers(
-      _material_properties.polynomial_order + 1);
+      p_order + 1);
 
   // Loop over the faces
   for (unsigned int face = face_range.first; face < face_range.second; ++face)
@@ -578,7 +581,7 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::face_local_apply(
     {
       auto temperature = fe_face_eval.get_value(q);
       // Precompute the powers of temperature.
-      for (unsigned int i = 0; i <= _material_properties.polynomial_order; ++i)
+      for (unsigned int i = 0; i <= p_order; ++i)
       {
         // FIXME Need to cast i to double due to a limitation in deal.II 9.5
         temperature_powers[i] = std::pow(temperature, static_cast<double>(i));
@@ -635,8 +638,8 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::face_local_apply(
   }
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
-void ThermalOperator<dim, fe_degree,
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+void ThermalOperator<dim, p_order, fe_degree,
                      MemorySpaceType>::get_state_from_material_properties()
 {
   unsigned int const n_cells = _matrix_free.n_cell_batches();
@@ -736,8 +739,8 @@ void ThermalOperator<dim, fe_degree,
   }
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
-void ThermalOperator<dim, fe_degree,
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+void ThermalOperator<dim, p_order, fe_degree,
                      MemorySpaceType>::set_state_to_material_properties()
 {
   _material_properties.set_state(_liquid_ratio, _powder_ratio,
@@ -745,8 +748,8 @@ void ThermalOperator<dim, fe_degree,
                                  _matrix_free.get_dof_handler());
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
-void ThermalOperator<dim, fe_degree, MemorySpaceType>::
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+void ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::
     set_material_deposition_orientation(
         std::vector<double> const &deposition_cos,
         std::vector<double> const &deposition_sin)
@@ -790,4 +793,4 @@ void ThermalOperator<dim, fe_degree, MemorySpaceType>::
 
 } // namespace adamantine
 
-INSTANTIATE_DIM_FEDEGREE_HOST(TUPLE(ThermalOperator))
+INSTANTIATE_DIM_PORDER_FEDEGREE_HOST(TUPLE(ThermalOperator))

--- a/source/ThermalOperator.hh
+++ b/source/ThermalOperator.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 - 2023, the adamantine authors.
+/* Copyright (c) 2016 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -22,13 +22,13 @@ namespace adamantine
  * This class is the operator associated with the heat equation, i.e., vmult
  * performs \f$ dst = -\nabla k \nabla src \f$.
  */
-template <int dim, int fe_degree, typename MemorySpaceType>
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
 class ThermalOperator final : public ThermalOperatorBase<dim, MemorySpaceType>
 {
 public:
   ThermalOperator(
       MPI_Comm const &communicator, BoundaryType boundary_type,
-      MaterialProperty<dim, MemorySpaceType> &material_properties,
+      MaterialProperty<dim, p_order, MemorySpaceType> &material_properties,
       std::vector<std::shared_ptr<HeatSource<dim>>> const &heat_sources);
 
   /**
@@ -189,7 +189,7 @@ private:
   /**
    * Material properties associated with the domain.
    */
-  MaterialProperty<dim, MemorySpaceType> &_material_properties;
+  MaterialProperty<dim, p_order, MemorySpaceType> &_material_properties;
   /**
    * Vector of heat sources.
    */
@@ -254,55 +254,58 @@ private:
   dealii::Table<2, dealii::VectorizedArray<double>> _deposition_sin;
 };
 
-template <int dim, int fe_degree, typename MemorySpaceType>
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
 inline dealii::types::global_dof_index
-ThermalOperator<dim, fe_degree, MemorySpaceType>::m() const
+ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::m() const
 {
   return _matrix_free.get_vector_partitioner()->size();
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
 inline dealii::types::global_dof_index
-ThermalOperator<dim, fe_degree, MemorySpaceType>::n() const
+ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::n() const
 {
   return _matrix_free.get_vector_partitioner()->size();
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
 inline std::shared_ptr<dealii::LA::distributed::Vector<double, MemorySpaceType>>
-ThermalOperator<dim, fe_degree, MemorySpaceType>::get_inverse_mass_matrix()
-    const
+ThermalOperator<dim, p_order, fe_degree,
+                MemorySpaceType>::get_inverse_mass_matrix() const
 {
   return _inverse_mass_matrix;
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
 inline dealii::MatrixFree<dim, double> const &
-ThermalOperator<dim, fe_degree, MemorySpaceType>::get_matrix_free() const
+ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::get_matrix_free()
+    const
 {
   return _matrix_free;
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
-inline void ThermalOperator<dim, fe_degree, MemorySpaceType>::jacobian_vmult(
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+inline void
+ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::jacobian_vmult(
     dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
     dealii::LA::distributed::Vector<double, MemorySpaceType> const &src) const
 {
   vmult(dst, src);
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
-inline void
-ThermalOperator<dim, fe_degree, MemorySpaceType>::initialize_dof_vector(
-    dealii::LA::distributed::Vector<double, MemorySpaceType> &vector) const
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+inline void ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::
+    initialize_dof_vector(
+        dealii::LA::distributed::Vector<double, MemorySpaceType> &vector) const
 {
   _matrix_free.initialize_dof_vector(vector);
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
 inline void
-ThermalOperator<dim, fe_degree, MemorySpaceType>::set_time_and_source_height(
-    double t, double height)
+ThermalOperator<dim, p_order, fe_degree,
+                MemorySpaceType>::set_time_and_source_height(double t,
+                                                             double height)
 {
   _current_source_height = height;
   for (auto &beam : _heat_sources)

--- a/source/ThermalOperatorDevice.hh
+++ b/source/ThermalOperatorDevice.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 - 2023, the adamantine authors.
+/* Copyright (c) 2016 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -16,14 +16,14 @@
 
 namespace adamantine
 {
-template <int dim, int fe_degree, typename MemorySpaceType>
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
 class ThermalOperatorDevice final
     : public ThermalOperatorBase<dim, MemorySpaceType>
 {
 public:
   ThermalOperatorDevice(
       MPI_Comm const &communicator, BoundaryType boundary_type,
-      MaterialProperty<dim, MemorySpaceType> &material_properties);
+      MaterialProperty<dim, p_order, MemorySpaceType> &material_properties);
 
   void reinit(dealii::DoFHandler<dim> const &dof_handler,
               dealii::AffineConstraints<double> const &affine_constraints,
@@ -121,7 +121,7 @@ private:
   /**
    * Material properties associated with the domain.
    */
-  MaterialProperty<dim, MemorySpaceType> &_material_properties;
+  MaterialProperty<dim, p_order, MemorySpaceType> &_material_properties;
   dealii::CUDAWrappers::MatrixFree<dim, double> _matrix_free;
   Kokkos::View<double *, kokkos_default> _liquid_ratio;
   Kokkos::View<double *, kokkos_default> _powder_ratio;
@@ -138,48 +138,49 @@ private:
       _inv_rho_cp_cells;
 };
 
-template <int dim, int fe_degree, typename MemorySpaceType>
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
 inline dealii::types::global_dof_index
-ThermalOperatorDevice<dim, fe_degree, MemorySpaceType>::m() const
+ThermalOperatorDevice<dim, p_order, fe_degree, MemorySpaceType>::m() const
 {
   return _m;
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
 inline dealii::types::global_dof_index
-ThermalOperatorDevice<dim, fe_degree, MemorySpaceType>::n() const
+ThermalOperatorDevice<dim, p_order, fe_degree, MemorySpaceType>::n() const
 {
   // Operator must be square
   return _m;
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
 inline std::shared_ptr<dealii::LA::distributed::Vector<double, MemorySpaceType>>
-ThermalOperatorDevice<dim, fe_degree,
+ThermalOperatorDevice<dim, p_order, fe_degree,
                       MemorySpaceType>::get_inverse_mass_matrix() const
 {
   return _inverse_mass_matrix;
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
 inline dealii::CUDAWrappers::MatrixFree<dim, double> const &
-ThermalOperatorDevice<dim, fe_degree, MemorySpaceType>::get_matrix_free() const
+ThermalOperatorDevice<dim, p_order, fe_degree,
+                      MemorySpaceType>::get_matrix_free() const
 {
   return _matrix_free;
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
 inline void
-ThermalOperatorDevice<dim, fe_degree, MemorySpaceType>::jacobian_vmult(
+ThermalOperatorDevice<dim, p_order, fe_degree, MemorySpaceType>::jacobian_vmult(
     dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
     dealii::LA::distributed::Vector<double, MemorySpaceType> const &src) const
 {
   vmult(dst, src);
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType>
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
 inline double
-ThermalOperatorDevice<dim, fe_degree, MemorySpaceType>::get_inv_rho_cp(
+ThermalOperatorDevice<dim, p_order, fe_degree, MemorySpaceType>::get_inv_rho_cp(
     typename dealii::DoFHandler<dim>::cell_iterator const &cell,
     unsigned int) const
 {

--- a/source/ThermalPhysics.cc
+++ b/source/ThermalPhysics.cc
@@ -8,51 +8,5 @@
 #include <ThermalPhysics.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_FEDEGREE_QUAD_HOST(TUPLE(ThermalPhysics))
-
-namespace adamantine
-{
-template class ThermalPhysics<2, 1, dealii::MemorySpace::Default,
-                              dealii::QGauss<1>>;
-template class ThermalPhysics<2, 2, dealii::MemorySpace::Default,
-                              dealii::QGauss<1>>;
-template class ThermalPhysics<2, 3, dealii::MemorySpace::Default,
-                              dealii::QGauss<1>>;
-template class ThermalPhysics<2, 4, dealii::MemorySpace::Default,
-                              dealii::QGauss<1>>;
-template class ThermalPhysics<2, 5, dealii::MemorySpace::Default,
-                              dealii::QGauss<1>>;
-
-template class ThermalPhysics<3, 1, dealii::MemorySpace::Default,
-                              dealii::QGauss<1>>;
-template class ThermalPhysics<3, 2, dealii::MemorySpace::Default,
-                              dealii::QGauss<1>>;
-template class ThermalPhysics<3, 3, dealii::MemorySpace::Default,
-                              dealii::QGauss<1>>;
-template class ThermalPhysics<3, 4, dealii::MemorySpace::Default,
-                              dealii::QGauss<1>>;
-template class ThermalPhysics<3, 5, dealii::MemorySpace::Default,
-                              dealii::QGauss<1>>;
-
-template class ThermalPhysics<2, 1, dealii::MemorySpace::Default,
-                              dealii::QGaussLobatto<1>>;
-template class ThermalPhysics<2, 2, dealii::MemorySpace::Default,
-                              dealii::QGaussLobatto<1>>;
-template class ThermalPhysics<2, 3, dealii::MemorySpace::Default,
-                              dealii::QGaussLobatto<1>>;
-template class ThermalPhysics<2, 4, dealii::MemorySpace::Default,
-                              dealii::QGaussLobatto<1>>;
-template class ThermalPhysics<2, 5, dealii::MemorySpace::Default,
-                              dealii::QGaussLobatto<1>>;
-
-template class ThermalPhysics<3, 1, dealii::MemorySpace::Default,
-                              dealii::QGaussLobatto<1>>;
-template class ThermalPhysics<3, 2, dealii::MemorySpace::Default,
-                              dealii::QGaussLobatto<1>>;
-template class ThermalPhysics<3, 3, dealii::MemorySpace::Default,
-                              dealii::QGaussLobatto<1>>;
-template class ThermalPhysics<3, 4, dealii::MemorySpace::Default,
-                              dealii::QGaussLobatto<1>>;
-template class ThermalPhysics<3, 5, dealii::MemorySpace::Default,
-                              dealii::QGaussLobatto<1>>;
-} // namespace adamantine
+INSTANTIATE_DIM_PORDER_FEDEGREE_QUAD_HOST(TUPLE(ThermalPhysics))
+INSTANTIATE_DIM_PORDER_FEDEGREE_QUAD_DEVICE(TUPLE(ThermalPhysics))

--- a/source/ThermalPhysics.hh
+++ b/source/ThermalPhysics.hh
@@ -29,7 +29,7 @@ namespace adamantine
  * This class takes care of building the linear operator and the
  * right-hand-side. Also used to evolve the system in time.
  */
-template <int dim, int fe_degree, typename MemorySpaceType,
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType,
           typename QuadratureType>
 class ThermalPhysics : public ThermalPhysicsInterface<dim, MemorySpaceType>
 {
@@ -37,10 +37,10 @@ public:
   /**
    * Constructor.
    */
-  ThermalPhysics(MPI_Comm const &communicator,
-                 boost::property_tree::ptree const &database,
-                 Geometry<dim> &geometry,
-                 MaterialProperty<dim, MemorySpaceType> &material_properties);
+  ThermalPhysics(
+      MPI_Comm const &communicator, boost::property_tree::ptree const &database,
+      Geometry<dim> &geometry,
+      MaterialProperty<dim, p_order, MemorySpaceType> &material_properties);
 
   void setup() override;
 
@@ -224,7 +224,7 @@ private:
   /**
    * Associated material properties.
    */
-  MaterialProperty<dim, MemorySpaceType> &_material_properties;
+  MaterialProperty<dim, p_order, MemorySpaceType> &_material_properties;
   /**
    * Vector of heat sources.
    */
@@ -243,27 +243,28 @@ private:
   std::unique_ptr<dealii::TimeStepping::RungeKutta<LA_Vector>> _time_stepping;
 };
 
-template <int dim, int fe_degree, typename MemorySpaceType,
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType,
           typename QuadratureType>
-inline double ThermalPhysics<dim, fe_degree, MemorySpaceType,
+inline double ThermalPhysics<dim, p_order, fe_degree, MemorySpaceType,
                              QuadratureType>::get_delta_t_guess() const
 {
   return _delta_t_guess;
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType,
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType,
           typename QuadratureType>
 inline void
-ThermalPhysics<dim, fe_degree, MemorySpaceType,
+ThermalPhysics<dim, p_order, fe_degree, MemorySpaceType,
                QuadratureType>::update_material_deposition_orientation()
 {
   _thermal_operator->set_material_deposition_orientation(_deposition_cos,
                                                          _deposition_sin);
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType,
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType,
           typename QuadratureType>
-inline void ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::
+inline void
+ThermalPhysics<dim, p_order, fe_degree, MemorySpaceType, QuadratureType>::
     set_material_deposition_orientation(
         std::vector<double> const &deposition_cos,
         std::vector<double> const &deposition_sin)
@@ -273,89 +274,89 @@ inline void ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::
   update_material_deposition_orientation();
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType,
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType,
           typename QuadratureType>
 inline double
-ThermalPhysics<dim, fe_degree, MemorySpaceType,
+ThermalPhysics<dim, p_order, fe_degree, MemorySpaceType,
                QuadratureType>::get_deposition_cos(unsigned int const i) const
 {
   return _deposition_cos[i];
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType,
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType,
           typename QuadratureType>
 inline double
-ThermalPhysics<dim, fe_degree, MemorySpaceType,
+ThermalPhysics<dim, p_order, fe_degree, MemorySpaceType,
                QuadratureType>::get_deposition_sin(unsigned int const i) const
 {
   return _deposition_sin[i];
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType,
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType,
           typename QuadratureType>
 inline std::vector<bool>
-ThermalPhysics<dim, fe_degree, MemorySpaceType,
+ThermalPhysics<dim, p_order, fe_degree, MemorySpaceType,
                QuadratureType>::get_has_melted_vector() const
 {
   return _has_melted;
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType,
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType,
           typename QuadratureType>
-inline void ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::
+inline void
+ThermalPhysics<dim, p_order, fe_degree, MemorySpaceType, QuadratureType>::
     set_has_melted_vector(std::vector<bool> const &has_melted)
 {
   _has_melted = has_melted;
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType,
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType,
           typename QuadratureType>
 inline bool
-ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::get_has_melted(
-    unsigned int const i) const
+ThermalPhysics<dim, p_order, fe_degree, MemorySpaceType,
+               QuadratureType>::get_has_melted(unsigned int const i) const
 {
   return _has_melted[i];
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType,
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType,
           typename QuadratureType>
 inline dealii::DoFHandler<dim> &
-ThermalPhysics<dim, fe_degree, MemorySpaceType,
+ThermalPhysics<dim, p_order, fe_degree, MemorySpaceType,
                QuadratureType>::get_dof_handler()
 {
   return _dof_handler;
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType,
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType,
           typename QuadratureType>
 inline dealii::AffineConstraints<double> &
-ThermalPhysics<dim, fe_degree, MemorySpaceType,
+ThermalPhysics<dim, p_order, fe_degree, MemorySpaceType,
                QuadratureType>::get_affine_constraints()
 {
   return _affine_constraints;
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType,
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType,
           typename QuadratureType>
 inline std::vector<std::shared_ptr<HeatSource<dim>>> &
-ThermalPhysics<dim, fe_degree, MemorySpaceType,
+ThermalPhysics<dim, p_order, fe_degree, MemorySpaceType,
                QuadratureType>::get_heat_sources()
 {
   return _heat_sources;
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType,
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType,
           typename QuadratureType>
-inline unsigned int
-ThermalPhysics<dim, fe_degree, MemorySpaceType, QuadratureType>::get_fe_degree()
-    const
+inline unsigned int ThermalPhysics<dim, p_order, fe_degree, MemorySpaceType,
+                                   QuadratureType>::get_fe_degree() const
 {
   return fe_degree;
 }
 
-template <int dim, int fe_degree, typename MemorySpaceType,
+template <int dim, int p_order, int fe_degree, typename MemorySpaceType,
           typename QuadratureType>
-inline double ThermalPhysics<dim, fe_degree, MemorySpaceType,
+inline double ThermalPhysics<dim, p_order, fe_degree, MemorySpaceType,
                              QuadratureType>::get_current_source_height() const
 {
   return _current_source_height;

--- a/source/ThermalPhysicsInterface.hh
+++ b/source/ThermalPhysicsInterface.hh
@@ -8,7 +8,6 @@
 #ifndef THERMAL_PHYSICS_INTERFACE_HH
 #define THERMAL_PHYSICS_INTERFACE_HH
 
-#include <MaterialProperty.hh>
 #include <types.hh>
 
 #include <deal.II/dofs/dof_handler.h>

--- a/source/instantiation.hh
+++ b/source/instantiation.hh
@@ -21,33 +21,79 @@
 #define INST_DIM_HOST(z, dim, class_name) template class adamantine::class_name<dim, dealii::MemorySpace::Host>;
 #define INSTANTIATE_DIM_HOST(class_name) BOOST_PP_REPEAT_FROM_TO(2, 4, INST_DIM_HOST, class_name)
 
-#define TUPLE_N (0, 0, 0)
+#define TUPLE_N (0, 0, 0, 0)
 #define TUPLE(class_name) BOOST_PP_TUPLE_REPLACE(TUPLE_N, 0, class_name)
 
 // Instantiation of the class for:
 //   - dim = 2 and 3
-//   - fe_degree = 1 to 5
-#define M_FE_DEGREE(z, fe_degree, TUPLE_1) \
+//   - p_order = 0 to 4
+#define M_P_ORDER_HOST_1(z, p_order, TUPLE_1) \
   template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_1)<BOOST_PP_TUPLE_ELEM(1, TUPLE_1),\
-  fe_degree, dealii::MemorySpace::Host>;
-#define M_DIM(z, dim, TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(1, 6, M_FE_DEGREE, BOOST_PP_TUPLE_REPLACE(TUPLE_0, 1, dim))
-#define INSTANTIATE_DIM_FEDEGREE_HOST(TUPLE_0) BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM, TUPLE_0)
+  p_order, dealii::MemorySpace::Host>;
+#define M_DIM_HOST_1(z, dim, TUPLE_0) \
+  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_HOST_1, BOOST_PP_TUPLE_REPLACE(TUPLE_0, 1, dim))
+#define INSTANTIATE_DIM_PORDER_HOST(TUPLE_0) BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_HOST_1, TUPLE_0)
+
+#define M_P_ORDER_DEVICE(z, p_order, TUPLE_1) \
+  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_1)<BOOST_PP_TUPLE_ELEM(1, TUPLE_1),\
+  p_order, dealii::MemorySpace::Default>;
+#define M_DIM_DEVICE_1(z, dim, TUPLE_0) \
+  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_DEVICE, BOOST_PP_TUPLE_REPLACE(TUPLE_0, 1, dim))
+#define INSTANTIATE_DIM_PORDER_DEVICE(TUPLE_0) BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_DEVICE_1, TUPLE_0)
 
 // Instantiation of the class for:
 //   - dim = 2 and 3
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+#define M_FE_DEGREE_HOST_2(z, fe_degree, TUPLE_1) \
+  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_1)<BOOST_PP_TUPLE_ELEM(1, TUPLE_1),\
+  BOOST_PP_TUPLE_ELEM(2, TUPLE_1), fe_degree, dealii::MemorySpace::Host>;
+#define M_P_ORDER_HOST_2(z, p_order, TUPLE_1) \
+  BOOST_PP_REPEAT_FROM_TO(1, 6, M_FE_DEGREE_HOST_2, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 2, p_order))
+#define M_DIM_HOST_2(z, dim, TUPLE_0) \
+  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_HOST_2, BOOST_PP_TUPLE_REPLACE(TUPLE_0, 1, dim))
+#define INSTANTIATE_DIM_PORDER_FEDEGREE_HOST(TUPLE_0) BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_HOST_2, TUPLE_0)
+
+#define M_FE_DEGREE_DEVICE_2(z, fe_degree, TUPLE_1) \
+  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_1)<BOOST_PP_TUPLE_ELEM(1, TUPLE_1),\
+  BOOST_PP_TUPLE_ELEM(2, TUPLE_1), fe_degree, dealii::MemorySpace::Default>;
+#define M_P_ORDER_DEVICE_2(z, p_order, TUPLE_1) \
+  BOOST_PP_REPEAT_FROM_TO(1, 6, M_FE_DEGREE_DEVICE_2, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 2, p_order))
+#define M_DIM_DEVICE_2(z, dim, TUPLE_0) \
+  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_DEVICE_2, BOOST_PP_TUPLE_REPLACE(TUPLE_0, 1, dim))
+#define INSTANTIATE_DIM_PORDER_FEDEGREE_DEVICE(TUPLE_0) BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_DEVICE_2, TUPLE_0)
+
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - p_order = 0 to 4
 //   - fe_degree = 1 to 5
 //   - QuadratureType = dealii::QGauss<1> and dealii::QGaussLobatto<1>
 #define QUADRATURE_TYPE (dealii::QGauss<1>)(dealii::QGaussLobatto<1>)
 
-#define MA_QUADRATURE_TYPE(z, TUPLE_2, quadrature)\
-  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_2)<BOOST_PP_TUPLE_ELEM(1, TUPLE_2),\
-BOOST_PP_TUPLE_ELEM(2, TUPLE_2), dealii::MemorySpace::Host, quadrature>;
-#define MA_FE_DEGREE(z, fe_degree, TUPLE_1) \
-  BOOST_PP_SEQ_FOR_EACH(MA_QUADRATURE_TYPE, \
-      BOOST_PP_TUPLE_REPLACE(TUPLE_1, 2, fe_degree), QUADRATURE_TYPE)
-#define MA_DIM(z, dim, TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(1, 6, MA_FE_DEGREE, BOOST_PP_TUPLE_REPLACE(TUPLE_0, 1, dim))
-#define INSTANTIATE_DIM_FEDEGREE_QUAD_HOST(TUPLE_0) BOOST_PP_REPEAT_FROM_TO(2, 4, MA_DIM, TUPLE_0)
+#define M_QUADRATURE_TYPE_HOST_3(z, TUPLE_3, quadrature)\
+  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_3)<BOOST_PP_TUPLE_ELEM(1, TUPLE_3),\
+BOOST_PP_TUPLE_ELEM(2, TUPLE_3), BOOST_PP_TUPLE_ELEM(3, TUPLE_3), dealii::MemorySpace::Host,\
+quadrature>;
+#define M_FE_DEGREE_HOST_3(z, fe_degree, TUPLE_2) \
+  BOOST_PP_SEQ_FOR_EACH(M_QUADRATURE_TYPE_HOST_3, \
+      BOOST_PP_TUPLE_REPLACE(TUPLE_2, 3, fe_degree), QUADRATURE_TYPE)
+#define M_P_ORDER_HOST_3(z, p_order, TUPLE_1) \
+  BOOST_PP_REPEAT_FROM_TO(1, 6, M_FE_DEGREE_HOST_3, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 2, p_order))
+#define M_DIM_HOST_3(z, dim, TUPLE_0) \
+  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_HOST_3, BOOST_PP_TUPLE_REPLACE(TUPLE_0, 1, dim))
+#define INSTANTIATE_DIM_PORDER_FEDEGREE_QUAD_HOST(TUPLE_0) BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_HOST_3, TUPLE_0)
+
+#define M_QUADRATURE_TYPE_DEVICE_3(z, TUPLE_3, quadrature)\
+  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_3)<BOOST_PP_TUPLE_ELEM(1, TUPLE_3),\
+BOOST_PP_TUPLE_ELEM(2, TUPLE_3), BOOST_PP_TUPLE_ELEM(3, TUPLE_3), dealii::MemorySpace::Default,\
+quadrature>;
+#define M_FE_DEGREE_DEVICE_3(z, fe_degree, TUPLE_2) \
+  BOOST_PP_SEQ_FOR_EACH(M_QUADRATURE_TYPE_DEVICE_3, \
+      BOOST_PP_TUPLE_REPLACE(TUPLE_2, 3, fe_degree), QUADRATURE_TYPE)
+#define M_P_ORDER_DEVICE_3(z, p_order, TUPLE_1) \
+  BOOST_PP_REPEAT_FROM_TO(1, 6, M_FE_DEGREE_DEVICE_3, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 2, p_order))
+#define M_DIM_DEVICE_3(z, dim, TUPLE_0) \
+  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_DEVICE_3, BOOST_PP_TUPLE_REPLACE(TUPLE_0, 1, dim))
+#define INSTANTIATE_DIM_PORDER_FEDEGREE_QUAD_DEVICE(TUPLE_0) BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_DEVICE_3, TUPLE_0)
 
 // clang-format on

--- a/tests/test_implicit_operator.cc
+++ b/tests/test_implicit_operator.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2017 - 2021, the adamantine authors.
+/* Copyright (c) 2017 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE(implicit_operator)
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 10.);
-  adamantine::MaterialProperty<2, dealii::MemorySpace::Host> mat_properties(
+  adamantine::MaterialProperty<2, 0, dealii::MemorySpace::Host> mat_properties(
       communicator, geometry.get_triangulation(), mat_prop_database);
 
   boost::property_tree::ptree beam_database;
@@ -83,11 +83,10 @@ BOOST_AUTO_TEST_CASE(implicit_operator)
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
 
   // Initialize the ThermalOperator
-  std::shared_ptr<adamantine::ThermalOperator<2, 2, dealii::MemorySpace::Host>>
-      thermal_operator = std::make_shared<
-          adamantine::ThermalOperator<2, 2, dealii::MemorySpace::Host>>(
-          communicator, adamantine::BoundaryType::adiabatic, mat_properties,
-          heat_sources);
+  auto thermal_operator = std::make_shared<
+      adamantine::ThermalOperator<2, 0, 2, dealii::MemorySpace::Host>>(
+      communicator, adamantine::BoundaryType::adiabatic, mat_properties,
+      heat_sources);
   std::vector<double> deposition_cos(
       geometry.get_triangulation().n_locally_owned_active_cells(), 1.);
   std::vector<double> deposition_sin(

--- a/tests/test_integration_2d.cc
+++ b/tests/test_integration_2d.cc
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(integration_2D, *utf::tolerance(0.1))
   boost::property_tree::info_parser::read_info(filename, database);
 
   auto [temperature, displacement] =
-      run<2, dealii::MemorySpace::Host>(communicator, database, timers);
+      run<2, 4, dealii::MemorySpace::Host>(communicator, database, timers);
 
   std::ifstream gold_file("integration_2d_gold.txt");
   for (unsigned int i = 0; i < temperature.locally_owned_size(); ++i)
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(integration_2D_ensemble, *utf::tolerance(0.1))
   boost::property_tree::ptree database;
   boost::property_tree::info_parser::read_info(filename, database);
 
-  auto result_ensemble = run_ensemble<2, dealii::MemorySpace::Host>(
+  auto result_ensemble = run_ensemble<2, 3, dealii::MemorySpace::Host>(
       communicator, database, timers);
 
   for (auto &result_member : result_ensemble)

--- a/tests/test_integration_2d_device.cc
+++ b/tests/test_integration_2d_device.cc
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(intregation_2D_device, *utf::tolerance(0.1))
   boost::property_tree::info_parser::read_info(filename, database);
 
   auto [temperature, displacement] =
-      run<2, dealii::MemorySpace::Default>(communicator, database, timers);
+      run<2, 4, dealii::MemorySpace::Default>(communicator, database, timers);
 
   std::ifstream gold_file("integration_2d_gold.txt");
   for (unsigned int i = 0; i < temperature.locally_owned_size(); ++i)

--- a/tests/test_integration_3d.cc
+++ b/tests/test_integration_3d.cc
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(integration_3D, *utf::tolerance(0.1))
   boost::property_tree::info_parser::read_info(filename, database);
 
   auto [temperature, displacement] =
-      run<3, dealii::MemorySpace::Host>(communicator, database, timers);
+      run<3, 4, dealii::MemorySpace::Host>(communicator, database, timers);
 
   int num_ranks = 0;
   MPI_Comm_size(communicator, &num_ranks);
@@ -115,11 +115,11 @@ BOOST_AUTO_TEST_CASE(integration_3D_checkpoint_restart)
   database.put("checkpoint.overwrite_files", true);
   database.put("checkpoint.time_steps_between_checkpoint", 80);
   auto [temperature_1, displacement_1] =
-      run<3, dealii::MemorySpace::Host>(communicator, database, timers);
+      run<3, 4, dealii::MemorySpace::Host>(communicator, database, timers);
   // Restart of the simulation
   database.put("restart.filename_prefix", checkpoint_filename);
   auto [temperature_2, displacement_2] =
-      run<3, dealii::MemorySpace::Host>(communicator, database, timers);
+      run<3, 4, dealii::MemorySpace::Host>(communicator, database, timers);
 
   // Compare the temperatures. When using more than one processor, the
   // partitioning is different and so the distribution of the dofs are

--- a/tests/test_integration_3d_amr.cc
+++ b/tests/test_integration_3d_amr.cc
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(integration_3D_amr, *utf::tolerance(0.1))
   boost::property_tree::info_parser::read_info(filename, database);
 
   auto [temperature, displacement] =
-      run<3, dealii::MemorySpace::Host>(communicator, database, timers);
+      run<3, 4, dealii::MemorySpace::Host>(communicator, database, timers);
 
   double min_val = std::numeric_limits<double>::max();
   double max_val = std::numeric_limits<double>::min();

--- a/tests/test_integration_3d_amr_device.cc
+++ b/tests/test_integration_3d_amr_device.cc
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(integration_3D_amr_device, *utf::tolerance(0.1))
   boost::property_tree::info_parser::read_info(filename, database);
 
   auto [temperature, displacement] =
-      run<3, dealii::MemorySpace::Default>(communicator, database, timers);
+      run<3, 4, dealii::MemorySpace::Default>(communicator, database, timers);
 
   double min_val = std::numeric_limits<double>::max();
   double max_val = std::numeric_limits<double>::min();

--- a/tests/test_integration_3d_device.cc
+++ b/tests/test_integration_3d_device.cc
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(integration_3D_device, *utf::tolerance(0.1))
   boost::property_tree::info_parser::read_info(filename, database);
 
   auto [temperature, displacement] =
-      run<3, dealii::MemorySpace::Default>(communicator, database, timers);
+      run<3, 3, dealii::MemorySpace::Default>(communicator, database, timers);
 
   std::ifstream gold_file("integration_3d_gold.txt");
   for (unsigned int i = 0; i < temperature.locally_owned_size(); ++i)
@@ -64,11 +64,11 @@ BOOST_AUTO_TEST_CASE(integration_3D_checkpoint_restart_device)
   database.put("checkpoint.overwrite_files", true);
   database.put("checkpoint.time_steps_between_checkpoint", 80);
   auto [temperature_1, displacement_1] =
-      run<3, dealii::MemorySpace::Host>(communicator, database, timers);
+      run<3, 3, dealii::MemorySpace::Host>(communicator, database, timers);
   // Restart of the simulation
   database.put("restart.filename_prefix", checkpoint_filename);
   auto [temperature_2, displacement_2] =
-      run<3, dealii::MemorySpace::Host>(communicator, database, timers);
+      run<3, 3, dealii::MemorySpace::Host>(communicator, database, timers);
 
   // Compare the temperatures. When using more than one processor, the
   // partitioning is different and so the distribution of the dofs are

--- a/tests/test_integration_da.cc
+++ b/tests/test_integration_da.cc
@@ -31,8 +31,8 @@ double integration_da(MPI_Comm communicator, bool l2_norm)
   boost::property_tree::info_parser::read_info(filename, database);
 
   // Run the simulation
-  auto result = run_ensemble<3, dealii::MemorySpace::Host>(communicator,
-                                                           database, timers);
+  auto result = run_ensemble<3, 1, dealii::MemorySpace::Host>(communicator,
+                                                              database, timers);
 
   if (l2_norm)
   {
@@ -100,8 +100,8 @@ double integration_da_point_cloud_add_mat(MPI_Comm communicator, bool l2_norm)
   boost::property_tree::info_parser::read_info(filename, database);
 
   // Run the simulation
-  auto result = run_ensemble<3, dealii::MemorySpace::Host>(communicator,
-                                                           database, timers);
+  auto result = run_ensemble<3, 1, dealii::MemorySpace::Host>(communicator,
+                                                              database, timers);
 
   if (l2_norm)
   {
@@ -182,8 +182,8 @@ double integration_da_ray_add_mat(MPI_Comm communicator, bool l2_norm)
   database.put("experiment.format", "ray");
 
   // Run the simulation
-  auto result = run_ensemble<3, dealii::MemorySpace::Host>(communicator,
-                                                           database, timers);
+  auto result = run_ensemble<3, 1, dealii::MemorySpace::Host>(communicator,
+                                                              database, timers);
 
   if (l2_norm)
   {

--- a/tests/test_integration_da_augmented.cc
+++ b/tests/test_integration_da_augmented.cc
@@ -35,8 +35,8 @@ BOOST_AUTO_TEST_CASE(integration_3D_data_assimilation_augmented,
   boost::property_tree::info_parser::read_info(filename, database);
 
   // Run the simulation
-  auto result = run_ensemble<3, dealii::MemorySpace::Host>(communicator,
-                                                           database, timers);
+  auto result = run_ensemble<3, 3, dealii::MemorySpace::Host>(communicator,
+                                                              database, timers);
 
   // Three ensemble members expected
   unsigned int local_result_size = result.size();

--- a/tests/test_integration_thermoelastic.cc
+++ b/tests/test_integration_thermoelastic.cc
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(integration_thermoelastic, *utf::tolerance(1.0e-5))
   database.put("materials.material_0.solid.thermal_expansion_coef", 17.2e-3);
 
   auto [temperature, displacement] =
-      run<3, dealii::MemorySpace::Host>(communicator, database, timers);
+      run<3, 3, dealii::MemorySpace::Host>(communicator, database, timers);
 
   // For now doing a simple regression test. Without a dof handler, it's hard to
   // do something more meaningful with the vector.
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(integration_thermoelastic_add_material,
   database.put("materials.material_0.solid.thermal_expansion_coef", 17.2e-3);
 
   auto [temperature, displacement] =
-      run<3, dealii::MemorySpace::Host>(communicator, database, timers);
+      run<3, 2, dealii::MemorySpace::Host>(communicator, database, timers);
 
   // For now doing a simple regression test. Without a dof handler, it's hard to
   // do something more meaningful with the vector.

--- a/tests/test_material_deposition.cc
+++ b/tests/test_material_deposition.cc
@@ -273,7 +273,7 @@ BOOST_AUTO_TEST_CASE(material_deposition)
   // Build MaterialProperty
   boost::property_tree::ptree material_property_database =
       database.get_child("materials");
-  adamantine::MaterialProperty<dim, dealii::MemorySpace::Host>
+  adamantine::MaterialProperty<dim, 1, dealii::MemorySpace::Host>
       material_properties(communicator, geometry.get_triangulation(),
                           material_property_database);
 
@@ -285,7 +285,7 @@ BOOST_AUTO_TEST_CASE(material_deposition)
   database.put("boundary.type", "adiabatic");
 
   // Build ThermalPhysics
-  adamantine::ThermalPhysics<dim, dim, dealii::MemorySpace::Host,
+  adamantine::ThermalPhysics<dim, 1, dim, dealii::MemorySpace::Host,
                              dealii::QGauss<1>>
       thermal_physics(communicator, database, geometry, material_properties);
   thermal_physics.setup();

--- a/tests/test_material_property.hh
+++ b/tests/test_material_property.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, the adamantine authors.
+/* Copyright (c) 2021 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -51,7 +51,7 @@ void material_property()
   database.put("material_0.liquidus", "100");
   database.put("material_0.solid.lame_first_parameter", 2.);
   database.put("material_0.solid.lame_second_parameter", 3.);
-  adamantine::MaterialProperty<2, MemorySpaceType> mat_prop(
+  adamantine::MaterialProperty<2, 2, MemorySpaceType> mat_prop(
       communicator, triangulation, database);
   // Evaluate the material property at the given temperature
   dealii::FE_Q<2> fe(4);
@@ -128,7 +128,7 @@ void ratios()
   database.put("material_0.solidus", "50");
   database.put("material_0.liquidus", "100");
   database.put("material_0.latent_heat", "1000");
-  adamantine::MaterialProperty<2, MemorySpaceType> mat_prop(
+  adamantine::MaterialProperty<2, 0, MemorySpaceType> mat_prop(
       communicator, triangulation, database);
   dealii::LinearAlgebra::distributed::Vector<double, MemorySpaceType>
       temperature(dof_handler.locally_owned_dofs(), communicator);
@@ -301,7 +301,7 @@ void material_property_table()
                "0., 10.; 10., 100.; 18., 200.");
   database.put("material_1.powder.thermal_conductivity_z",
                "0., 10.; 10., 100.; 18., 200.");
-  adamantine::MaterialProperty<2, MemorySpaceType> mat_prop(
+  adamantine::MaterialProperty<2, 0, MemorySpaceType> mat_prop(
       communicator, triangulation, database);
   // Evaluate the material property at the given temperature
   dealii::FE_Q<2> fe(4);
@@ -412,7 +412,7 @@ void material_property_polynomials()
   database.put("material_1.powder.density", "15., 2., 3.");
   database.put("material_1.powder.thermal_conductivity_x", " 10., 18., 200.");
   database.put("material_1.powder.thermal_conductivity_z", " 10., 18., 200.");
-  adamantine::MaterialProperty<2, MemorySpaceType> mat_prop(
+  adamantine::MaterialProperty<2, 4, MemorySpaceType> mat_prop(
       communicator, triangulation, database);
   // Evaluate the material property at the given temperature
   dealii::FE_Q<2> fe(4);

--- a/tests/test_mechanical_operator.cc
+++ b/tests/test_mechanical_operator.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023, the adamantine authors.
+/* Copyright (c) 2022 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(elastostatic, *utf::tolerance(1e-12))
   double const lame_second = 3.;
   material_database.put("material_0.solid.lame_first_parameter", lame_first);
   material_database.put("material_0.solid.lame_second_parameter", lame_second);
-  adamantine::MaterialProperty<dim, dealii::MemorySpace::Host>
+  adamantine::MaterialProperty<dim, 4, dealii::MemorySpace::Host>
       material_properties(communicator, triangulation, material_database);
   // Create the DoFHandler
   dealii::hp::FECollection<dim> fe_collection;
@@ -100,11 +100,11 @@ BOOST_AUTO_TEST_CASE(elastostatic, *utf::tolerance(1e-12))
 
   std::vector<double> empty_vector;
 
-  adamantine::MechanicalOperator<dim, dealii::MemorySpace::Host>
+  adamantine::MechanicalOperator<dim, 4, dealii::MemorySpace::Host>
       mechanical_operator(communicator, material_properties, empty_vector);
   std::vector<std::shared_ptr<adamantine::BodyForce<dim>>> body_forces;
   auto gravity_force = std::make_shared<
-      adamantine::GravityForce<dim, dealii::MemorySpace::Host>>(
+      adamantine::GravityForce<dim, 4, dealii::MemorySpace::Host>>(
       material_properties);
   body_forces.push_back(gravity_force);
   mechanical_operator.reinit(dof_handler, affine_constraints, q_collection,
@@ -261,7 +261,7 @@ BOOST_AUTO_TEST_CASE(thermoelastic, *utf::tolerance(1e-12))
   double const lame_second = 3.;
   material_database.put("material_0.solid.lame_first_parameter", lame_first);
   material_database.put("material_0.solid.lame_second_parameter", lame_second);
-  adamantine::MaterialProperty<dim, dealii::MemorySpace::Host>
+  adamantine::MaterialProperty<dim, 4, dealii::MemorySpace::Host>
       material_properties(communicator, triangulation, material_database);
   // Create the thermal DoFHandler
   dealii::hp::FECollection<dim> thermal_fe_collection;
@@ -298,7 +298,7 @@ BOOST_AUTO_TEST_CASE(thermoelastic, *utf::tolerance(1e-12))
   temperature = 1.;
   // Create the MechanicalOperator
   std::vector<double> reference_temperatures = {0.0, 0.0};
-  adamantine::MechanicalOperator<dim, dealii::MemorySpace::Host>
+  adamantine::MechanicalOperator<dim, 4, dealii::MemorySpace::Host>
       mechanical_operator(communicator, material_properties,
                           reference_temperatures);
   std::vector<bool> has_melted(triangulation.n_active_cells(), false);
@@ -306,7 +306,7 @@ BOOST_AUTO_TEST_CASE(thermoelastic, *utf::tolerance(1e-12))
                                          has_melted);
   std::vector<std::shared_ptr<adamantine::BodyForce<dim>>> body_forces;
   auto gravity_force = std::make_shared<
-      adamantine::GravityForce<dim, dealii::MemorySpace::Host>>(
+      adamantine::GravityForce<dim, 4, dealii::MemorySpace::Host>>(
       material_properties);
   body_forces.push_back(gravity_force);
   mechanical_operator.reinit(mechanical_dof_handler,

--- a/tests/test_mechanical_physics.cc
+++ b/tests/test_mechanical_physics.cc
@@ -223,18 +223,18 @@ BOOST_AUTO_TEST_CASE(elastostatic)
   material_database.put("material_0.solid.density", 1.);
   material_database.put("material_0.solid.lame_first_parameter", 2.);
   material_database.put("material_0.solid.lame_second_parameter", 3.);
-  adamantine::MaterialProperty<3, dealii::MemorySpace::Host>
+  adamantine::MaterialProperty<3, 4, dealii::MemorySpace::Host>
       material_properties(communicator, triangulation, material_database);
   // Build MechanicalPhysics
   unsigned int const fe_degree = 1;
   std::vector<double> empty_vector;
-  adamantine::MechanicalPhysics<3, dealii::MemorySpace::Host>
+  adamantine::MechanicalPhysics<3, 4, dealii::MemorySpace::Host>
       mechanical_physics(communicator, fe_degree, geometry, material_properties,
                          empty_vector);
   std::vector<std::shared_ptr<adamantine::BodyForce<3>>> body_forces;
-  auto gravity_force =
-      std::make_shared<adamantine::GravityForce<3, dealii::MemorySpace::Host>>(
-          material_properties);
+  auto gravity_force = std::make_shared<
+      adamantine::GravityForce<3, 4, dealii::MemorySpace::Host>>(
+      material_properties);
   body_forces.push_back(gravity_force);
   mechanical_physics.setup_dofs(body_forces);
   auto solution = mechanical_physics.solve();
@@ -290,18 +290,18 @@ BOOST_AUTO_TEST_CASE(fe_nothing)
   material_database.put("material_0.solid.density", 1.);
   material_database.put("material_0.solid.lame_first_parameter", 2.);
   material_database.put("material_0.solid.lame_second_parameter", 3.);
-  adamantine::MaterialProperty<3, dealii::MemorySpace::Host>
+  adamantine::MaterialProperty<3, 2, dealii::MemorySpace::Host>
       material_properties(communicator, triangulation, material_database);
   // Build MechanicalPhysics
   unsigned int const fe_degree = 1;
   std::vector<double> empty_vector;
-  adamantine::MechanicalPhysics<3, dealii::MemorySpace::Host>
+  adamantine::MechanicalPhysics<3, 2, dealii::MemorySpace::Host>
       mechanical_physics(communicator, fe_degree, geometry, material_properties,
                          empty_vector);
   std::vector<std::shared_ptr<adamantine::BodyForce<3>>> body_forces;
-  auto gravity_force =
-      std::make_shared<adamantine::GravityForce<3, dealii::MemorySpace::Host>>(
-          material_properties);
+  auto gravity_force = std::make_shared<
+      adamantine::GravityForce<3, 2, dealii::MemorySpace::Host>>(
+      material_properties);
   body_forces.push_back(gravity_force);
   mechanical_physics.setup_dofs(body_forces);
   auto solution = mechanical_physics.solve();
@@ -418,7 +418,7 @@ run_eshelby(std::vector<dealii::Point<dim>> pts, unsigned int refinement_cycles)
 
   double const alpha = 0.01;
   material_database.put("material_0.solid.thermal_expansion_coef", alpha);
-  adamantine::MaterialProperty<dim, dealii::MemorySpace::Host>
+  adamantine::MaterialProperty<dim, 3, dealii::MemorySpace::Host>
       material_properties(communicator, triangulation, material_database);
 
   // Build ThermalPhysics
@@ -441,7 +441,7 @@ run_eshelby(std::vector<dealii::Point<dim>> pts, unsigned int refinement_cycles)
                "scan_path_test_thermal_physics.txt");
   database.put("sources.beam_0.scan_path_file_format", "segment");
   database.put("boundary.type", "adiabatic");
-  adamantine::ThermalPhysics<dim, 1, dealii::MemorySpace::Host,
+  adamantine::ThermalPhysics<dim, 3, 1, dealii::MemorySpace::Host,
                              dealii::QGauss<1>>
       thermal_physics(communicator, database, geometry, material_properties);
   thermal_physics.setup();
@@ -455,7 +455,7 @@ run_eshelby(std::vector<dealii::Point<dim>> pts, unsigned int refinement_cycles)
   // Build MechanicalPhysics
   unsigned int const fe_degree = 1;
   std::vector<double> initial_temperature = {2.0};
-  adamantine::MechanicalPhysics<3, dealii::MemorySpace::Host>
+  adamantine::MechanicalPhysics<3, 3, dealii::MemorySpace::Host>
       mechanical_physics(communicator, fe_degree, geometry, material_properties,
                          initial_temperature);
 
@@ -556,18 +556,18 @@ BOOST_AUTO_TEST_CASE(elastoplastic)
   material_database.put("material_0.solid.plastic_modulus", 1.5);
   material_database.put("material_0.solid.isotropic_hardening", 0.5);
   material_database.put("material_0.solid.elastic_limit", 0.1);
-  adamantine::MaterialProperty<3, dealii::MemorySpace::Host>
+  adamantine::MaterialProperty<3, 4, dealii::MemorySpace::Host>
       material_properties(communicator, triangulation, material_database);
   // Build MechanicalPhysics
   unsigned int const fe_degree = 1;
   std::vector<double> empty_vector;
-  adamantine::MechanicalPhysics<3, dealii::MemorySpace::Host>
+  adamantine::MechanicalPhysics<3, 4, dealii::MemorySpace::Host>
       mechanical_physics(communicator, fe_degree, geometry, material_properties,
                          empty_vector);
   std::vector<std::shared_ptr<adamantine::BodyForce<3>>> body_forces;
-  auto gravity_force =
-      std::make_shared<adamantine::GravityForce<3, dealii::MemorySpace::Host>>(
-          material_properties);
+  auto gravity_force = std::make_shared<
+      adamantine::GravityForce<3, 4, dealii ::MemorySpace::Host>>(
+      material_properties);
   body_forces.push_back(gravity_force);
   mechanical_physics.setup_dofs(body_forces);
   mechanical_physics.solve();

--- a/tests/test_post_processor.cc
+++ b/tests/test_post_processor.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 - 2023, the adamantine authors.
+/* Copyright (c) 2016 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(thermal_post_processor)
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 10.);
-  adamantine::MaterialProperty<2, dealii::MemorySpace::Host> mat_properties(
+  adamantine::MaterialProperty<2, 0, dealii::MemorySpace::Host> mat_properties(
       communicator, geometry.get_triangulation(), mat_prop_database);
 
   boost::property_tree::ptree beam_database;
@@ -81,9 +81,9 @@ BOOST_AUTO_TEST_CASE(thermal_post_processor)
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperator<2, 2, dealii::MemorySpace::Host> thermal_operator(
-      communicator, adamantine::BoundaryType::adiabatic, mat_properties,
-      heat_sources);
+  adamantine::ThermalOperator<2, 0, 2, dealii::MemorySpace::Host>
+      thermal_operator(communicator, adamantine::BoundaryType::adiabatic,
+                       mat_properties, heat_sources);
   std::vector<double> deposition_cos(
       geometry.get_triangulation().n_locally_owned_active_cells(), 1.);
   std::vector<double> deposition_sin(
@@ -186,12 +186,13 @@ BOOST_AUTO_TEST_CASE(mechanical_post_processor)
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 10.);
   mat_prop_database.put("material_0.solid.lame_first_parameter", 2.);
   mat_prop_database.put("material_0.solid.lame_second_parameter", 3.);
-  adamantine::MaterialProperty<dim, dealii::MemorySpace::Host> mat_properties(
-      communicator, geometry.get_triangulation(), mat_prop_database);
+  adamantine::MaterialProperty<dim, 0, dealii::MemorySpace::Host>
+      mat_properties(communicator, geometry.get_triangulation(),
+                     mat_prop_database);
 
   std::vector<double> empty_vector;
 
-  adamantine::MechanicalOperator<dim, dealii::MemorySpace::Host>
+  adamantine::MechanicalOperator<dim, 0, dealii::MemorySpace::Host>
       mechanical_operator(communicator, mat_properties, empty_vector);
   mechanical_operator.reinit(dof_handler, affine_constraints, q_collection);
 

--- a/tests/test_thermal_operator.cc
+++ b/tests/test_thermal_operator.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 - 2022, the adamantine authors.
+/* Copyright (c) 2016 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(thermal_operator, *utf::tolerance(1e-15))
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 10.);
-  adamantine::MaterialProperty<2, dealii::MemorySpace::Host> mat_properties(
+  adamantine::MaterialProperty<2, 1, dealii::MemorySpace::Host> mat_properties(
       communicator, geometry.get_triangulation(), mat_prop_database);
 
   // Create the heat sources
@@ -96,9 +96,9 @@ BOOST_AUTO_TEST_CASE(thermal_operator, *utf::tolerance(1e-15))
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperator<2, 2, dealii::MemorySpace::Host> thermal_operator(
-      communicator, adamantine::BoundaryType::adiabatic, mat_properties,
-      heat_sources);
+  adamantine::ThermalOperator<2, 1, 2, dealii::MemorySpace::Host>
+      thermal_operator(communicator, adamantine::BoundaryType::adiabatic,
+                       mat_properties, heat_sources);
   std::vector<double> deposition_cos(
       geometry.get_triangulation().n_locally_owned_active_cells(), 1.);
   std::vector<double> deposition_sin(
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(spmv, *utf::tolerance(1e-12))
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 1.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 1.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 1.);
-  adamantine::MaterialProperty<2, dealii::MemorySpace::Host> mat_properties(
+  adamantine::MaterialProperty<2, 2, dealii::MemorySpace::Host> mat_properties(
       communicator, geometry.get_triangulation(), mat_prop_database);
 
   // Create the heat sources
@@ -198,9 +198,9 @@ BOOST_AUTO_TEST_CASE(spmv, *utf::tolerance(1e-12))
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperator<2, 2, dealii::MemorySpace::Host> thermal_operator(
-      communicator, adamantine::BoundaryType::adiabatic, mat_properties,
-      heat_sources);
+  adamantine::ThermalOperator<2, 2, 2, dealii::MemorySpace::Host>
+      thermal_operator(communicator, adamantine::BoundaryType::adiabatic,
+                       mat_properties, heat_sources);
   std::vector<double> deposition_cos(
       geometry.get_triangulation().n_locally_owned_active_cells(), 1.);
   std::vector<double> deposition_sin(
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic, *utf::tolerance(1e-12))
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 0.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 1.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 0.);
-  adamantine::MaterialProperty<2, dealii::MemorySpace::Host> mat_properties(
+  adamantine::MaterialProperty<2, 2, dealii::MemorySpace::Host> mat_properties(
       communicator, geometry.get_triangulation(), mat_prop_database);
 
   // Create the heat sources
@@ -304,9 +304,9 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic, *utf::tolerance(1e-12))
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperator<2, 2, dealii::MemorySpace::Host> thermal_operator(
-      communicator, adamantine::BoundaryType::adiabatic, mat_properties,
-      heat_sources);
+  adamantine::ThermalOperator<2, 2, 2, dealii::MemorySpace::Host>
+      thermal_operator(communicator, adamantine::BoundaryType::adiabatic,
+                       mat_properties, heat_sources);
   std::vector<double> deposition_cos(
       geometry.get_triangulation().n_locally_owned_active_cells(), 1.);
   std::vector<double> deposition_sin(
@@ -433,16 +433,16 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic_angle, *utf::tolerance(1e-10))
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", th_cond_x);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_y", th_cond_y);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", th_cond_z);
-  adamantine::MaterialProperty<3, dealii::MemorySpace::Host> mat_properties(
+  adamantine::MaterialProperty<3, 1, dealii::MemorySpace::Host> mat_properties(
       communicator, geometry.get_triangulation(), mat_prop_database);
 
   // Create the heat sources
   std::vector<std::shared_ptr<adamantine::HeatSource<3>>> heat_sources;
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperator<3, 2, dealii::MemorySpace::Host> thermal_operator(
-      communicator, adamantine::BoundaryType::adiabatic, mat_properties,
-      heat_sources);
+  adamantine::ThermalOperator<3, 1, 2, dealii::MemorySpace::Host>
+      thermal_operator(communicator, adamantine::BoundaryType::adiabatic,
+                       mat_properties, heat_sources);
   double constexpr deposition_angle = M_PI / 6.;
   std::vector<double> deposition_cos(
       geometry.get_triangulation().n_locally_owned_active_cells(),
@@ -588,7 +588,7 @@ BOOST_AUTO_TEST_CASE(spmv_rad, *utf::tolerance(1e-12))
   mat_prop_database.put("material_0.liquid.convection_heat_transfer_coef", 1.);
   mat_prop_database.put("material_0.radiation_temperature_infty", 0.0);
   mat_prop_database.put("material_0.convection_temperature_infty", 0.0);
-  adamantine::MaterialProperty<2, dealii::MemorySpace::Host> mat_properties(
+  adamantine::MaterialProperty<2, 1, dealii::MemorySpace::Host> mat_properties(
       communicator, geometry.get_triangulation(), mat_prop_database);
 
   // Create the heat sources
@@ -605,9 +605,9 @@ BOOST_AUTO_TEST_CASE(spmv_rad, *utf::tolerance(1e-12))
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperator<2, 2, dealii::MemorySpace::Host> thermal_operator(
-      communicator, adamantine::BoundaryType::radiative, mat_properties,
-      heat_sources);
+  adamantine::ThermalOperator<2, 1, 2, dealii::MemorySpace::Host>
+      thermal_operator(communicator, adamantine::BoundaryType::radiative,
+                       mat_properties, heat_sources);
   std::vector<double> deposition_cos(
       geometry.get_triangulation().n_locally_owned_active_cells(), 1.);
   std::vector<double> deposition_sin(
@@ -769,7 +769,7 @@ BOOST_AUTO_TEST_CASE(spmv_conv, *utf::tolerance(1e-12))
   mat_prop_database.put("material_0.liquid.convection_heat_transfer_coef", 1.);
   mat_prop_database.put("material_0.radiation_temperature_infty", 0.0);
   mat_prop_database.put("material_0.convection_temperature_infty", 0.0);
-  adamantine::MaterialProperty<2, dealii::MemorySpace::Host> mat_properties(
+  adamantine::MaterialProperty<2, 1, dealii::MemorySpace::Host> mat_properties(
       communicator, geometry.get_triangulation(), mat_prop_database);
 
   // Create the heat sources
@@ -786,9 +786,9 @@ BOOST_AUTO_TEST_CASE(spmv_conv, *utf::tolerance(1e-12))
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperator<2, 2, dealii::MemorySpace::Host> thermal_operator(
-      communicator, adamantine::BoundaryType::convective, mat_properties,
-      heat_sources);
+  adamantine::ThermalOperator<2, 1, 2, dealii::MemorySpace::Host>
+      thermal_operator(communicator, adamantine::BoundaryType::convective,
+                       mat_properties, heat_sources);
   std::vector<double> deposition_cos(
       geometry.get_triangulation().n_locally_owned_active_cells(), 1.);
   std::vector<double> deposition_sin(

--- a/tests/test_thermal_operator_device.cc
+++ b/tests/test_thermal_operator_device.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 - 2022, the adamantine authors.
+/* Copyright (c) 2016 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -69,11 +69,12 @@ BOOST_AUTO_TEST_CASE(thermal_operator_dev, *utf::tolerance(1e-10))
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 10.);
-  adamantine::MaterialProperty<2, dealii::MemorySpace::Default> mat_properties(
-      communicator, geometry.get_triangulation(), mat_prop_database);
+  adamantine::MaterialProperty<2, 0, dealii::MemorySpace::Default>
+      mat_properties(communicator, geometry.get_triangulation(),
+                     mat_prop_database);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperatorDevice<2, 2, dealii::MemorySpace::Default>
+  adamantine::ThermalOperatorDevice<2, 0, 2, dealii::MemorySpace::Default>
       thermal_operator_dev(communicator, adamantine::BoundaryType::adiabatic,
                            mat_properties);
   thermal_operator_dev.compute_inverse_mass_matrix(dof_handler,
@@ -157,11 +158,12 @@ BOOST_AUTO_TEST_CASE(spmv, *utf::tolerance(1e-12))
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 1.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 1.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 1.);
-  adamantine::MaterialProperty<2, dealii::MemorySpace::Default> mat_properties(
-      communicator, geometry.get_triangulation(), mat_prop_database);
+  adamantine::MaterialProperty<2, 3, dealii::MemorySpace::Default>
+      mat_properties(communicator, geometry.get_triangulation(),
+                     mat_prop_database);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperatorDevice<2, 2, dealii::MemorySpace::Default>
+  adamantine::ThermalOperatorDevice<2, 3, 2, dealii::MemorySpace::Default>
       thermal_operator_dev(communicator, adamantine::BoundaryType::adiabatic,
                            mat_properties);
   thermal_operator_dev.compute_inverse_mass_matrix(dof_handler,
@@ -258,11 +260,12 @@ BOOST_AUTO_TEST_CASE(mf_spmv, *utf::tolerance(1.5e-12))
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 0.266);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 0.266);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 0.266);
-  adamantine::MaterialProperty<2, dealii::MemorySpace::Host>
+  adamantine::MaterialProperty<2, 4, dealii::MemorySpace::Host>
       mat_properties_host(communicator, geometry.get_triangulation(),
                           mat_prop_database);
-  adamantine::MaterialProperty<2, dealii::MemorySpace::Default> mat_properties(
-      communicator, geometry.get_triangulation(), mat_prop_database);
+  adamantine::MaterialProperty<2, 4, dealii::MemorySpace::Default>
+      mat_properties(communicator, geometry.get_triangulation(),
+                     mat_prop_database);
 
   // Create the heat sources
   boost::property_tree::ptree beam_database;
@@ -278,7 +281,7 @@ BOOST_AUTO_TEST_CASE(mf_spmv, *utf::tolerance(1.5e-12))
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperatorDevice<2, 2, dealii::MemorySpace::Default>
+  adamantine::ThermalOperatorDevice<2, 4, 2, dealii::MemorySpace::Default>
       thermal_operator_dev(communicator, adamantine::BoundaryType::adiabatic,
                            mat_properties);
   thermal_operator_dev.compute_inverse_mass_matrix(dof_handler,
@@ -293,7 +296,7 @@ BOOST_AUTO_TEST_CASE(mf_spmv, *utf::tolerance(1.5e-12))
   thermal_operator_dev.get_state_from_material_properties();
   BOOST_TEST(thermal_operator_dev.m() == thermal_operator_dev.n());
 
-  adamantine::ThermalOperator<2, 2, dealii::MemorySpace::Host>
+  adamantine::ThermalOperator<2, 4, 2, dealii::MemorySpace::Host>
       thermal_operator_host(communicator, adamantine::BoundaryType::adiabatic,
                             mat_properties_host, heat_sources);
   thermal_operator_host.compute_inverse_mass_matrix(dof_handler,
@@ -389,11 +392,12 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic_angle, *utf::tolerance(1e-10))
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", th_cond_x);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_y", th_cond_y);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", th_cond_z);
-  adamantine::MaterialProperty<3, dealii::MemorySpace::Default> mat_properties(
-      communicator, geometry.get_triangulation(), mat_prop_database);
+  adamantine::MaterialProperty<3, 3, dealii::MemorySpace::Default>
+      mat_properties(communicator, geometry.get_triangulation(),
+                     mat_prop_database);
 
   // Initialize the ThermalOperatorDevice
-  adamantine::ThermalOperatorDevice<3, 2, dealii::MemorySpace::Default>
+  adamantine::ThermalOperatorDevice<3, 3, 2, dealii::MemorySpace::Default>
       thermal_operator_dev(communicator, adamantine::BoundaryType::adiabatic,
                            mat_properties);
   double constexpr deposition_angle = M_PI / 6.;

--- a/tests/test_thermal_physics.hh
+++ b/tests/test_thermal_physics.hh
@@ -109,7 +109,7 @@ void thermal_2d(boost::property_tree::ptree &database, double time_step)
   material_property_database.put("material_0.liquid.thermal_conductivity_z",
                                  1.);
   // Build MaterialProperty
-  adamantine::MaterialProperty<2, MemorySpaceType> material_properties(
+  adamantine::MaterialProperty<2, 2, MemorySpaceType> material_properties(
       communicator, geometry.get_triangulation(), material_property_database);
   // Source database
   database.put("sources.n_beams", 1);
@@ -125,8 +125,8 @@ void thermal_2d(boost::property_tree::ptree &database, double time_step)
   database.put("boundary.type", "adiabatic");
 
   // Build ThermalPhysics
-  adamantine::ThermalPhysics<2, 2, MemorySpaceType, dealii::QGauss<1>> physics(
-      communicator, database, geometry, material_properties);
+  adamantine::ThermalPhysics<2, 2, 2, MemorySpaceType, dealii::QGauss<1>>
+      physics(communicator, database, geometry, material_properties);
   physics.setup();
   dealii::LA::distributed::Vector<double, MemorySpaceType> solution;
   physics.initialize_dof_vector(0., solution);
@@ -182,7 +182,7 @@ void thermal_2d_manufactured_solution()
   material_property_database.put("material_0.liquid.thermal_conductivity_z",
                                  1.);
   // Build MaterialProperty
-  adamantine::MaterialProperty<2, MemorySpaceType> material_properties(
+  adamantine::MaterialProperty<2, 1, MemorySpaceType> material_properties(
       communicator, geometry.get_triangulation(), material_property_database);
 
   boost::property_tree::ptree database;
@@ -203,8 +203,8 @@ void thermal_2d_manufactured_solution()
   // Time-stepping database
   database.put("time_stepping.method", "rk_fourth_order");
   // Build ThermalPhysics
-  adamantine::ThermalPhysics<2, 2, MemorySpaceType, dealii::QGauss<1>> physics(
-      communicator, database, geometry, material_properties);
+  adamantine::ThermalPhysics<2, 1, 2, MemorySpaceType, dealii::QGauss<1>>
+      physics(communicator, database, geometry, material_properties);
   physics.setup();
   dealii::LA::distributed::Vector<double, MemorySpaceType> solution;
   physics.initialize_dof_vector(0., solution);
@@ -245,15 +245,15 @@ void initial_temperature()
 
   // Build MaterialProperty
   auto material_property_database = basic_material_properies_database();
-  adamantine::MaterialProperty<2, MemorySpaceType> material_properties(
+  adamantine::MaterialProperty<2, 4, MemorySpaceType> material_properties(
       communicator, geometry.get_triangulation(), material_property_database);
 
   // Other generic input parameters
   auto database = basic_input_database();
 
   // Build ThermalPhysics
-  adamantine::ThermalPhysics<2, 2, MemorySpaceType, dealii::QGauss<1>> physics(
-      communicator, database, geometry, material_properties);
+  adamantine::ThermalPhysics<2, 4, 2, MemorySpaceType, dealii::QGauss<1>>
+      physics(communicator, database, geometry, material_properties);
   physics.setup();
   dealii::LA::distributed::Vector<double, MemorySpaceType> solution;
   physics.initialize_dof_vector(1000., solution);
@@ -296,7 +296,7 @@ void energy_conservation()
   material_property_database.put("material_0.liquid.thermal_conductivity_z",
                                  2.);
   // Build MaterialProperty
-  adamantine::MaterialProperty<2, MemorySpaceType> material_properties(
+  adamantine::MaterialProperty<2, 0, MemorySpaceType> material_properties(
       communicator, geometry.get_triangulation(), material_property_database);
   boost::property_tree::ptree database;
   // Source database
@@ -314,8 +314,8 @@ void energy_conservation()
   // Boundary database
   database.put("boundary.type", "adiabatic");
   // Build ThermalPhysics
-  adamantine::ThermalPhysics<2, 2, MemorySpaceType, dealii::QGauss<1>> physics(
-      communicator, database, geometry, material_properties);
+  adamantine::ThermalPhysics<2, 0, 2, MemorySpaceType, dealii::QGauss<1>>
+      physics(communicator, database, geometry, material_properties);
   physics.setup();
   dealii::LA::distributed::Vector<double, MemorySpaceType> solution;
   double constexpr initial_temperature = 10;
@@ -415,7 +415,7 @@ void radiation_bcs()
   material_property_database.put("material_0.convection_temperature_infty",
                                  0.0);
   // Build MaterialProperty
-  adamantine::MaterialProperty<2, MemorySpaceType> material_properties(
+  adamantine::MaterialProperty<2, 1, MemorySpaceType> material_properties(
       communicator, geometry.get_triangulation(), material_property_database);
   boost::property_tree::ptree database;
   // Source database
@@ -425,7 +425,8 @@ void radiation_bcs()
   // Boundary database
   database.put("boundary.type", "radiative");
   // Build ThermalPhysics
-  adamantine::ThermalPhysics<2, 2, dealii::MemorySpace::Host, dealii::QGauss<1>>
+  adamantine::ThermalPhysics<2, 1, 2, dealii::MemorySpace::Host,
+                             dealii::QGauss<1>>
       physics(communicator, database, geometry, material_properties);
   physics.setup();
   dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> solution;
@@ -517,7 +518,7 @@ void convection_bcs()
   material_property_database.put("material_0.convection_temperature_infty",
                                  20.0);
   // Build MaterialProperty
-  adamantine::MaterialProperty<2, MemorySpaceType> material_properties(
+  adamantine::MaterialProperty<2, 0, MemorySpaceType> material_properties(
       communicator, geometry.get_triangulation(), material_property_database);
   boost::property_tree::ptree database;
   // Source database
@@ -527,7 +528,8 @@ void convection_bcs()
   // Boundary database
   database.put("boundary.type", "convective");
   // Build ThermalPhysics
-  adamantine::ThermalPhysics<2, 2, dealii::MemorySpace::Host, dealii::QGauss<1>>
+  adamantine::ThermalPhysics<2, 0, 2, dealii::MemorySpace::Host,
+                             dealii::QGauss<1>>
       physics(communicator, database, geometry, material_properties);
   physics.setup();
   dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> solution;
@@ -583,15 +585,15 @@ void reference_temperature()
 
   // Build MaterialProperty
   auto material_property_database = basic_material_properies_database();
-  adamantine::MaterialProperty<2, MemorySpaceType> material_properties(
+  adamantine::MaterialProperty<2, 4, MemorySpaceType> material_properties(
       communicator, geometry.get_triangulation(), material_property_database);
 
   // Other generic input parameters
   auto database = basic_input_database();
 
   // Build ThermalPhysics
-  adamantine::ThermalPhysics<2, 2, MemorySpaceType, dealii::QGauss<1>> physics(
-      communicator, database, geometry, material_properties);
+  adamantine::ThermalPhysics<2, 4, 2, MemorySpaceType, dealii::QGauss<1>>
+      physics(communicator, database, geometry, material_properties);
   physics.setup();
   dealii::LA::distributed::Vector<double, MemorySpaceType> solution;
   physics.initialize_dof_vector(1000., solution);


### PR DESCRIPTION
Currently when using a polynomial description of the material properties, we assume that we have a polynomial of order four. This is often not the case and we end up wasting a lot of flops. This PR makes the polynomial order a template parameter. The correct order is computed at runtime by doing a first read of the material parameters before calling `MaterialProperties`. The new template parameter `p_order` propagates everywhere because we need to template `MaterialProperties` and almost every class owns a reference to `MaterialProperties`.