### PR TITLE
Make use_table a template parameter in hot loops

### DIFF
--- a/source/MaterialProperty.hh
+++ b/source/MaterialProperty.hh
@@ -14,6 +14,7 @@
 #include <deal.II/base/aligned_vector.h>
 #include <deal.II/base/memory_space.h>
 #include <deal.II/base/types.h>
+#include <deal.II/base/vectorization.h>
 #include <deal.II/distributed/tria.h>
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_handler.h>
@@ -142,7 +143,9 @@ public:
 
   /**
    * Compute a material property at a quadrature point for a mix of states.
+   * @Note This function is templated on @tparam because it is in a hot loop.
    */
+  template <bool use_table>
   dealii::VectorizedArray<double> compute_material_property(
       StateProperty state_property,
       dealii::types::material_id const *material_id,
@@ -153,12 +156,14 @@ public:
 
   /**
    * Compute a material property at a quadrature point for a mix of states.
+   * @Note This function is templated on @tparam because it is in a hot loop.
    */
-  KOKKOS_FUNCTION
-  double compute_material_property(StateProperty state_property,
-                                   dealii::types::material_id const material_id,
-                                   double const *state_ratios,
-                                   double temperature) const;
+  template <bool use_table>
+  KOKKOS_FUNCTION double
+  compute_material_property(StateProperty state_property,
+                            dealii::types::material_id const material_id,
+                            double const *state_ratios,
+                            double temperature) const;
 
   /**
    * Get the array of material state vectors. The order of the different state
@@ -399,6 +404,104 @@ inline dealii::DoFHandler<dim> const &
 MaterialProperty<dim, p_order, MemorySpaceType>::get_dof_handler() const
 {
   return _mp_dof_handler;
+}
+
+// We define the two compute_material_property in the header to simplify, the
+// instantiation. It also helps the compiler to inline the code.
+
+template <int dim, int p_order, typename MemorySpaceType>
+template <bool use_table>
+dealii::VectorizedArray<double>
+MaterialProperty<dim, p_order, MemorySpaceType>::compute_material_property(
+    StateProperty state_property, dealii::types::material_id const *material_id,
+    dealii::VectorizedArray<double> const *state_ratios,
+    dealii::VectorizedArray<double> const &temperature,
+    dealii::AlignedVector<dealii::VectorizedArray<double>> const
+        &temperature_powers) const
+{
+  dealii::VectorizedArray<double> value = 0.0;
+  unsigned int const property_index = static_cast<unsigned int>(state_property);
+
+  if constexpr (use_table)
+  {
+    for (unsigned int material_state = 0; material_state < g_n_material_states;
+         ++material_state)
+    {
+      for (unsigned int n = 0; n < dealii::VectorizedArray<double>::size(); ++n)
+      {
+        const dealii::types::material_id m_id = material_id[n];
+
+        value[n] += state_ratios[material_state][n] *
+                    compute_property_from_table(_state_property_tables, m_id,
+                                                material_state, property_index,
+                                                temperature[n]);
+      }
+    }
+  }
+  else
+  {
+    for (unsigned int material_state = 0; material_state < g_n_material_states;
+         ++material_state)
+    {
+      for (unsigned int n = 0; n < dealii::VectorizedArray<double>::size(); ++n)
+      {
+        dealii::types::material_id m_id = material_id[n];
+
+        for (unsigned int i = 0; i <= p_order; ++i)
+        {
+          value[n] += state_ratios[material_state][n] *
+                      _state_property_polynomials(m_id, material_state,
+                                                  property_index, i) *
+                      temperature_powers[i][n];
+        }
+      }
+    }
+  }
+
+  return value;
+}
+
+template <int dim, int p_order, typename MemorySpaceType>
+template <bool use_table>
+KOKKOS_FUNCTION double
+MaterialProperty<dim, p_order, MemorySpaceType>::compute_material_property(
+    StateProperty state_property, dealii::types::material_id const material_id,
+    double const *state_ratios, double temperature) const
+{
+  double value = 0.0;
+  unsigned int const property_index = static_cast<unsigned int>(state_property);
+
+  if constexpr (use_table)
+  {
+    for (unsigned int material_state = 0; material_state < g_n_material_states;
+         ++material_state)
+    {
+      const dealii::types::material_id m_id = material_id;
+
+      value += state_ratios[material_state] *
+               compute_property_from_table(_state_property_tables, m_id,
+                                           material_state, property_index,
+                                           temperature);
+    }
+  }
+  else
+  {
+    for (unsigned int material_state = 0; material_state < g_n_material_states;
+         ++material_state)
+    {
+      dealii::types::material_id m_id = material_id;
+
+      for (unsigned int i = 0; i <= p_order; ++i)
+      {
+        value += state_ratios[material_state] *
+                 _state_property_polynomials(m_id, material_state,
+                                             property_index, i) *
+                 std::pow(temperature, i);
+      }
+    }
+  }
+
+  return value;
 }
 } // namespace adamantine
 

--- a/source/ThermalOperator.hh
+++ b/source/ThermalOperator.hh
@@ -22,7 +22,8 @@ namespace adamantine
  * This class is the operator associated with the heat equation, i.e., vmult
  * performs \f$ dst = -\nabla k \nabla src \f$.
  */
-template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+template <int dim, bool use_table, int p_order, int fe_degree,
+          typename MemorySpaceType>
 class ThermalOperator final : public ThermalOperatorBase<dim, MemorySpaceType>
 {
 public:
@@ -254,56 +255,66 @@ private:
   dealii::Table<2, dealii::VectorizedArray<double>> _deposition_sin;
 };
 
-template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+template <int dim, bool use_table, int p_order, int fe_degree,
+          typename MemorySpaceType>
 inline dealii::types::global_dof_index
-ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::m() const
+ThermalOperator<dim, use_table, p_order, fe_degree, MemorySpaceType>::m() const
 {
   return _matrix_free.get_vector_partitioner()->size();
 }
 
-template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+template <int dim, bool use_table, int p_order, int fe_degree,
+          typename MemorySpaceType>
 inline dealii::types::global_dof_index
-ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::n() const
+ThermalOperator<dim, use_table, p_order, fe_degree, MemorySpaceType>::n() const
 {
   return _matrix_free.get_vector_partitioner()->size();
 }
 
-template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+template <int dim, bool use_table, int p_order, int fe_degree,
+          typename MemorySpaceType>
 inline std::shared_ptr<dealii::LA::distributed::Vector<double, MemorySpaceType>>
-ThermalOperator<dim, p_order, fe_degree,
+ThermalOperator<dim, use_table, p_order, fe_degree,
                 MemorySpaceType>::get_inverse_mass_matrix() const
 {
   return _inverse_mass_matrix;
 }
 
-template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+template <int dim, bool use_table, int p_order, int fe_degree,
+          typename MemorySpaceType>
 inline dealii::MatrixFree<dim, double> const &
-ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::get_matrix_free()
-    const
+ThermalOperator<dim, use_table, p_order, fe_degree,
+                MemorySpaceType>::get_matrix_free() const
 {
   return _matrix_free;
 }
 
-template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+template <int dim, bool use_table, int p_order, int fe_degree,
+          typename MemorySpaceType>
 inline void
-ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::jacobian_vmult(
-    dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
-    dealii::LA::distributed::Vector<double, MemorySpaceType> const &src) const
+ThermalOperator<dim, use_table, p_order, fe_degree, MemorySpaceType>::
+    jacobian_vmult(
+        dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
+        dealii::LA::distributed::Vector<double, MemorySpaceType> const &src)
+        const
 {
   vmult(dst, src);
 }
 
-template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
-inline void ThermalOperator<dim, p_order, fe_degree, MemorySpaceType>::
+template <int dim, bool use_table, int p_order, int fe_degree,
+          typename MemorySpaceType>
+inline void
+ThermalOperator<dim, use_table, p_order, fe_degree, MemorySpaceType>::
     initialize_dof_vector(
         dealii::LA::distributed::Vector<double, MemorySpaceType> &vector) const
 {
   _matrix_free.initialize_dof_vector(vector);
 }
 
-template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+template <int dim, bool use_table, int p_order, int fe_degree,
+          typename MemorySpaceType>
 inline void
-ThermalOperator<dim, p_order, fe_degree,
+ThermalOperator<dim, use_table, p_order, fe_degree,
                 MemorySpaceType>::set_time_and_source_height(double t,
                                                              double height)
 {

--- a/source/ThermalOperatorDevice.hh
+++ b/source/ThermalOperatorDevice.hh
@@ -16,7 +16,8 @@
 
 namespace adamantine
 {
-template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+template <int dim, bool use_table, int p_order, int fe_degree,
+          typename MemorySpaceType>
 class ThermalOperatorDevice final
     : public ThermalOperatorBase<dim, MemorySpaceType>
 {
@@ -138,51 +139,61 @@ private:
       _inv_rho_cp_cells;
 };
 
-template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+template <int dim, bool use_table, int p_order, int fe_degree,
+          typename MemorySpaceType>
 inline dealii::types::global_dof_index
-ThermalOperatorDevice<dim, p_order, fe_degree, MemorySpaceType>::m() const
+ThermalOperatorDevice<dim, use_table, p_order, fe_degree, MemorySpaceType>::m()
+    const
 {
   return _m;
 }
 
-template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+template <int dim, bool use_table, int p_order, int fe_degree,
+          typename MemorySpaceType>
 inline dealii::types::global_dof_index
-ThermalOperatorDevice<dim, p_order, fe_degree, MemorySpaceType>::n() const
+ThermalOperatorDevice<dim, use_table, p_order, fe_degree, MemorySpaceType>::n()
+    const
 {
   // Operator must be square
   return _m;
 }
 
-template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+template <int dim, bool use_table, int p_order, int fe_degree,
+          typename MemorySpaceType>
 inline std::shared_ptr<dealii::LA::distributed::Vector<double, MemorySpaceType>>
-ThermalOperatorDevice<dim, p_order, fe_degree,
+ThermalOperatorDevice<dim, use_table, p_order, fe_degree,
                       MemorySpaceType>::get_inverse_mass_matrix() const
 {
   return _inverse_mass_matrix;
 }
 
-template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+template <int dim, bool use_table, int p_order, int fe_degree,
+          typename MemorySpaceType>
 inline dealii::CUDAWrappers::MatrixFree<dim, double> const &
-ThermalOperatorDevice<dim, p_order, fe_degree,
+ThermalOperatorDevice<dim, use_table, p_order, fe_degree,
                       MemorySpaceType>::get_matrix_free() const
 {
   return _matrix_free;
 }
 
-template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+template <int dim, bool use_table, int p_order, int fe_degree,
+          typename MemorySpaceType>
 inline void
-ThermalOperatorDevice<dim, p_order, fe_degree, MemorySpaceType>::jacobian_vmult(
-    dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
-    dealii::LA::distributed::Vector<double, MemorySpaceType> const &src) const
+ThermalOperatorDevice<dim, use_table, p_order, fe_degree, MemorySpaceType>::
+    jacobian_vmult(
+        dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
+        dealii::LA::distributed::Vector<double, MemorySpaceType> const &src)
+        const
 {
   vmult(dst, src);
 }
 
-template <int dim, int p_order, int fe_degree, typename MemorySpaceType>
+template <int dim, bool use_table, int p_order, int fe_degree,
+          typename MemorySpaceType>
 inline double
-ThermalOperatorDevice<dim, p_order, fe_degree, MemorySpaceType>::get_inv_rho_cp(
-    typename dealii::DoFHandler<dim>::cell_iterator const &cell,
-    unsigned int) const
+ThermalOperatorDevice<dim, use_table, p_order, fe_degree, MemorySpaceType>::
+    get_inv_rho_cp(typename dealii::DoFHandler<dim>::cell_iterator const &cell,
+                   unsigned int) const
 {
   auto inv_rho_cp = _inv_rho_cp_cells.find(cell);
   ASSERT(inv_rho_cp != _inv_rho_cp_cells.end(), "Internal error");

--- a/source/instantiation.hh
+++ b/source/instantiation.hh
@@ -21,7 +21,7 @@
 #define INST_DIM_HOST(z, dim, class_name) template class adamantine::class_name<dim, dealii::MemorySpace::Host>;
 #define INSTANTIATE_DIM_HOST(class_name) BOOST_PP_REPEAT_FROM_TO(2, 4, INST_DIM_HOST, class_name)
 
-#define TUPLE_N (0, 0, 0, 0)
+#define TUPLE_N (0, 0, 0, 0, 0)
 #define TUPLE(class_name) BOOST_PP_TUPLE_REPLACE(TUPLE_N, 0, class_name)
 
 // Instantiation of the class for:
@@ -43,25 +43,34 @@
 
 // Instantiation of the class for:
 //   - dim = 2 and 3
+//   - use_table = true or false
 //   - p_order = 0 to 4
 //   - fe_degree = 1 to 5
-#define M_FE_DEGREE_HOST_2(z, fe_degree, TUPLE_1) \
-  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_1)<BOOST_PP_TUPLE_ELEM(1, TUPLE_1),\
-  BOOST_PP_TUPLE_ELEM(2, TUPLE_1), fe_degree, dealii::MemorySpace::Host>;
-#define M_P_ORDER_HOST_2(z, p_order, TUPLE_1) \
-  BOOST_PP_REPEAT_FROM_TO(1, 6, M_FE_DEGREE_HOST_2, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 2, p_order))
-#define M_DIM_HOST_2(z, dim, TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_HOST_2, BOOST_PP_TUPLE_REPLACE(TUPLE_0, 1, dim))
-#define INSTANTIATE_DIM_PORDER_FEDEGREE_HOST(TUPLE_0) BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_HOST_2, TUPLE_0)
+#define USE_TABLE (true)(false)
 
-#define M_FE_DEGREE_DEVICE_2(z, fe_degree, TUPLE_1) \
-  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_1)<BOOST_PP_TUPLE_ELEM(1, TUPLE_1),\
-  BOOST_PP_TUPLE_ELEM(2, TUPLE_1), fe_degree, dealii::MemorySpace::Default>;
-#define M_P_ORDER_DEVICE_2(z, p_order, TUPLE_1) \
-  BOOST_PP_REPEAT_FROM_TO(1, 6, M_FE_DEGREE_DEVICE_2, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 2, p_order))
-#define M_DIM_DEVICE_2(z, dim, TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_DEVICE_2, BOOST_PP_TUPLE_REPLACE(TUPLE_0, 1, dim))
-#define INSTANTIATE_DIM_PORDER_FEDEGREE_DEVICE(TUPLE_0) BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_DEVICE_2, TUPLE_0)
+#define M_FE_DEGREE_HOST_2(z, fe_degree, TUPLE_4) \
+  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_4)<BOOST_PP_TUPLE_ELEM(1, TUPLE_4),\
+  BOOST_PP_TUPLE_ELEM(2, TUPLE_4), BOOST_PP_TUPLE_ELEM(3, TUPLE_4), fe_degree,\
+  dealii::MemorySpace::Host>;
+#define M_P_ORDER_HOST_2(z, p_order, TUPLE_3) \
+  BOOST_PP_REPEAT_FROM_TO(1, 6, M_FE_DEGREE_HOST_2, BOOST_PP_TUPLE_REPLACE(TUPLE_3, 3, p_order))
+#define M_USE_TABLE_HOST_2(z, TUPLE_2, use_table) \
+  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_HOST_2, BOOST_PP_TUPLE_REPLACE(TUPLE_2, 2, use_table))
+#define M_DIM_HOST_2(z, dim, TUPLE_1) \
+  BOOST_PP_SEQ_FOR_EACH(M_USE_TABLE_HOST_2, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 1, dim), USE_TABLE)
+#define INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_HOST(TUPLE_0) BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_HOST_2, TUPLE_0)
+
+#define M_FE_DEGREE_DEVICE_2(z, fe_degree, TUPLE_4) \
+  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_4)<BOOST_PP_TUPLE_ELEM(1, TUPLE_4),\
+  BOOST_PP_TUPLE_ELEM(2, TUPLE_4), BOOST_PP_TUPLE_ELEM(3, TUPLE_4), fe_degree,\
+  dealii::MemorySpace::Default>;
+#define M_P_ORDER_DEVICE_2(z, p_order, TUPLE_3) \
+  BOOST_PP_REPEAT_FROM_TO(1, 6, M_FE_DEGREE_DEVICE_2, BOOST_PP_TUPLE_REPLACE(TUPLE_3, 3, p_order))
+#define M_USE_TABLE_DEVICE_2(z, TUPLE_2, use_table) \
+  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_DEVICE_2, BOOST_PP_TUPLE_REPLACE(TUPLE_2, 2, use_table))
+#define M_DIM_DEVICE_2(z, dim, TUPLE_1) \
+  BOOST_PP_SEQ_FOR_EACH(M_USE_TABLE_DEVICE_2, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 1, dim), USE_TABLE)
+#define INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_DEVICE(TUPLE_0) BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_DEVICE_2, TUPLE_0)
 
 // Instantiation of the class for:
 //   - dim = 2 and 3

--- a/tests/test_implicit_operator.cc
+++ b/tests/test_implicit_operator.cc
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(implicit_operator)
 
   // Initialize the ThermalOperator
   auto thermal_operator = std::make_shared<
-      adamantine::ThermalOperator<2, 0, 2, dealii::MemorySpace::Host>>(
+      adamantine::ThermalOperator<2, false, 0, 2, dealii::MemorySpace::Host>>(
       communicator, adamantine::BoundaryType::adiabatic, mat_properties,
       heat_sources);
   std::vector<double> deposition_cos(

--- a/tests/test_post_processor.cc
+++ b/tests/test_post_processor.cc
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(thermal_post_processor)
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperator<2, 0, 2, dealii::MemorySpace::Host>
+  adamantine::ThermalOperator<2, false, 0, 2, dealii::MemorySpace::Host>
       thermal_operator(communicator, adamantine::BoundaryType::adiabatic,
                        mat_properties, heat_sources);
   std::vector<double> deposition_cos(

--- a/tests/test_thermal_operator.cc
+++ b/tests/test_thermal_operator.cc
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(thermal_operator, *utf::tolerance(1e-15))
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperator<2, 1, 2, dealii::MemorySpace::Host>
+  adamantine::ThermalOperator<2, false, 1, 2, dealii::MemorySpace::Host>
       thermal_operator(communicator, adamantine::BoundaryType::adiabatic,
                        mat_properties, heat_sources);
   std::vector<double> deposition_cos(
@@ -198,7 +198,7 @@ BOOST_AUTO_TEST_CASE(spmv, *utf::tolerance(1e-12))
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperator<2, 2, 2, dealii::MemorySpace::Host>
+  adamantine::ThermalOperator<2, false, 2, 2, dealii::MemorySpace::Host>
       thermal_operator(communicator, adamantine::BoundaryType::adiabatic,
                        mat_properties, heat_sources);
   std::vector<double> deposition_cos(
@@ -304,7 +304,7 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic, *utf::tolerance(1e-12))
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperator<2, 2, 2, dealii::MemorySpace::Host>
+  adamantine::ThermalOperator<2, false, 2, 2, dealii::MemorySpace::Host>
       thermal_operator(communicator, adamantine::BoundaryType::adiabatic,
                        mat_properties, heat_sources);
   std::vector<double> deposition_cos(
@@ -440,7 +440,7 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic_angle, *utf::tolerance(1e-10))
   std::vector<std::shared_ptr<adamantine::HeatSource<3>>> heat_sources;
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperator<3, 1, 2, dealii::MemorySpace::Host>
+  adamantine::ThermalOperator<3, false, 1, 2, dealii::MemorySpace::Host>
       thermal_operator(communicator, adamantine::BoundaryType::adiabatic,
                        mat_properties, heat_sources);
   double constexpr deposition_angle = M_PI / 6.;
@@ -605,7 +605,7 @@ BOOST_AUTO_TEST_CASE(spmv_rad, *utf::tolerance(1e-12))
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperator<2, 1, 2, dealii::MemorySpace::Host>
+  adamantine::ThermalOperator<2, false, 1, 2, dealii::MemorySpace::Host>
       thermal_operator(communicator, adamantine::BoundaryType::radiative,
                        mat_properties, heat_sources);
   std::vector<double> deposition_cos(
@@ -786,7 +786,7 @@ BOOST_AUTO_TEST_CASE(spmv_conv, *utf::tolerance(1e-12))
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperator<2, 1, 2, dealii::MemorySpace::Host>
+  adamantine::ThermalOperator<2, false, 1, 2, dealii::MemorySpace::Host>
       thermal_operator(communicator, adamantine::BoundaryType::convective,
                        mat_properties, heat_sources);
   std::vector<double> deposition_cos(

--- a/tests/test_thermal_operator_device.cc
+++ b/tests/test_thermal_operator_device.cc
@@ -74,7 +74,8 @@ BOOST_AUTO_TEST_CASE(thermal_operator_dev, *utf::tolerance(1e-10))
                      mat_prop_database);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperatorDevice<2, 0, 2, dealii::MemorySpace::Default>
+  adamantine::ThermalOperatorDevice<2, false, 0, 2,
+                                    dealii::MemorySpace::Default>
       thermal_operator_dev(communicator, adamantine::BoundaryType::adiabatic,
                            mat_properties);
   thermal_operator_dev.compute_inverse_mass_matrix(dof_handler,
@@ -163,7 +164,8 @@ BOOST_AUTO_TEST_CASE(spmv, *utf::tolerance(1e-12))
                      mat_prop_database);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperatorDevice<2, 3, 2, dealii::MemorySpace::Default>
+  adamantine::ThermalOperatorDevice<2, false, 3, 2,
+                                    dealii::MemorySpace::Default>
       thermal_operator_dev(communicator, adamantine::BoundaryType::adiabatic,
                            mat_properties);
   thermal_operator_dev.compute_inverse_mass_matrix(dof_handler,
@@ -281,7 +283,8 @@ BOOST_AUTO_TEST_CASE(mf_spmv, *utf::tolerance(1.5e-12))
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperatorDevice<2, 4, 2, dealii::MemorySpace::Default>
+  adamantine::ThermalOperatorDevice<2, false, 4, 2,
+                                    dealii::MemorySpace::Default>
       thermal_operator_dev(communicator, adamantine::BoundaryType::adiabatic,
                            mat_properties);
   thermal_operator_dev.compute_inverse_mass_matrix(dof_handler,
@@ -296,7 +299,7 @@ BOOST_AUTO_TEST_CASE(mf_spmv, *utf::tolerance(1.5e-12))
   thermal_operator_dev.get_state_from_material_properties();
   BOOST_TEST(thermal_operator_dev.m() == thermal_operator_dev.n());
 
-  adamantine::ThermalOperator<2, 4, 2, dealii::MemorySpace::Host>
+  adamantine::ThermalOperator<2, false, 4, 2, dealii::MemorySpace::Host>
       thermal_operator_host(communicator, adamantine::BoundaryType::adiabatic,
                             mat_properties_host, heat_sources);
   thermal_operator_host.compute_inverse_mass_matrix(dof_handler,
@@ -397,7 +400,8 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic_angle, *utf::tolerance(1e-10))
                      mat_prop_database);
 
   // Initialize the ThermalOperatorDevice
-  adamantine::ThermalOperatorDevice<3, 3, 2, dealii::MemorySpace::Default>
+  adamantine::ThermalOperatorDevice<3, false, 3, 2,
+                                    dealii::MemorySpace::Default>
       thermal_operator_dev(communicator, adamantine::BoundaryType::adiabatic,
                            mat_properties);
   double constexpr deposition_angle = M_PI / 6.;


### PR DESCRIPTION
Use `if constexpr (use_table)` in `compute_material_property`. This gives us a noticeable speed up. I didn't template all of `MaterialProperty` on `use_table` because the other functions don't show up in the profiling and this keeps the code easier.