### PR TITLE
Increase flexibility in creating meshes and loading meshes

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,14 @@ The following options are available:
     vtu, exodus, or default, i.e., use the file suffix to try to determine the
     mesh format (required)
     * mesh\_scale\_factor: Apply a uniform scaling factor to the mesh (e.g. if the mesh is defined in mm or inches instead of m), (default value: 1)
-    * set\_material\_id\_to\_0: Clear the material IDs defined in the mesh and sets them all to zero: true or false (default value: false)
+    * reset\_material\_id: Clear the material IDs defined in the mesh and set them all to zero so all material properties are given by the `material\_0` input block: true or false (default value: false)
   * if import\_mesh is false:
     * length: the length of the domain in meters (required)
     * height: the height of the domain in meters (required)
     * width: the width of the domain in meters (only in 3D)
-    * length_origin: the reference location in the length direction (default value: 0)
-    * height_origin: the reference location in the height direction (default value: 0)
-    * width_origin: the reference location in the width direction (only in 3D) (default value: 0)
+    * length\_origin: the reference location in the length direction (default value: 0)
+    * height\_origin: the reference location in the height direction (default value: 0)
+    * width\_origin: the reference location in the width direction (only in 3D) (default value: 0)
     * length\_divisions: number of cell layers in length (default value: 10)
     * height\_divisions: number of cell layers in the height (default value: 10)
     * width\_divisions: number of cell layers in width (only in 3D) (default value: 10)

--- a/README.md
+++ b/README.md
@@ -105,10 +105,15 @@ The following options are available:
     * mesh\_format: abaqus, assimp, unv, ucd, dbmesh, gmsh, tecplot, xda, vtk,
     vtu, exodus, or default, i.e., use the file suffix to try to determine the
     mesh format (required)
+    * mesh\_scale\_factor: Apply a uniform scaling factor to the mesh (e.g. if the mesh is defined in mm or inches instead of m), (default value: 1)
+    * set\_material\_id\_to\_0: Clear the material IDs defined in the mesh and sets them all to zero: true or false (default value: false)
   * if import\_mesh is false:
     * length: the length of the domain in meters (required)
     * height: the height of the domain in meters (required)
     * width: the width of the domain in meters (only in 3D)
+    * length_origin: the reference location in the length direction (default value: 0)
+    * height_origin: the reference location in the height direction (default value: 0)
+    * width_origin: the reference location in the width direction (only in 3D) (default value: 0)
     * length\_divisions: number of cell layers in length (default value: 10)
     * height\_divisions: number of cell layers in the height (default value: 10)
     * width\_divisions: number of cell layers in width (only in 3D) (default value: 10)

--- a/source/Geometry.cc
+++ b/source/Geometry.cc
@@ -96,8 +96,8 @@ Geometry<dim>::Geometry(MPI_Comm const &communicator,
     dealii::GridTools::scale(mesh_scaling, _triangulation);
 
     // Set the mesh material id to 0 if specified in the input
-    // PropertyTreeInput geometry.set_material_id_to_0
-    auto reset_material_id = database.get("set_material_id_to_0", false);
+    // PropertyTreeInput geometry.reset_material_id
+    auto reset_material_id = database.get("reset_material_id", false);
     if (reset_material_id)
     {
       for (auto cell : _triangulation.active_cell_iterators())

--- a/source/Geometry.cc
+++ b/source/Geometry.cc
@@ -16,6 +16,7 @@
 #include <deal.II/grid/filtered_iterator.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_in.h>
+#include <deal.II/grid/grid_tools.h>
 
 namespace adamantine
 {
@@ -88,6 +89,22 @@ Geometry<dim>::Geometry(MPI_Comm const &communicator,
 
     grid_in.read(mesh_file, grid_in_format);
     _triangulation.copy_triangulation(serial_triangulation);
+
+    // Apply user-specified scaling to the mesh
+    // PropertyTreeInput geometry.mesh_scale_factor
+    auto mesh_scaling = database.get("mesh_scale_factor", 1.0);
+    dealii::GridTools::scale(mesh_scaling, _triangulation);
+
+    // Set the mesh material id to 0 if specified in the input
+    // PropertyTreeInput geometry.set_material_id_to_0
+    auto reset_material_id = database.get("set_material_id_to_0", false);
+    if (reset_material_id)
+    {
+      for (auto cell : _triangulation.active_cell_iterators())
+      {
+        cell->set_material_id(0);
+      }
+    }
   }
   else
   {
@@ -104,11 +121,21 @@ Geometry<dim>::Geometry(MPI_Comm const &communicator,
     dealii::Point<dim> p2;
     // PropertyTreeInput geometry.length
     p2[axis<dim>::x] = database.get<double>("length");
+    // PropertyTreeInput geometry.length_origin
+    p1[axis<dim>::x] = database.get("length_origin", 0.0);
     // PropertyTreeInput geometry.height
     p2[axis<dim>::z] = database.get<double>("height");
-    // PropertyTreeInput geometry.width
+    // PropertyTreeInput geometry.height_origin
+    p1[axis<dim>::z] = database.get("height_origin", 0.0);
     if (dim == 3)
+    {
+      // PropertyTreeInput geometry.width
       p2[axis<dim>::y] = database.get<double>("width");
+      // PropertyTreeInput geometry.width_origin
+      p1[axis<dim>::y] = database.get("width_origin", 0.0);
+    }
+
+    p2 = p2 + p1;
 
     // For now we assume that the geometry is very simple.
     dealii::GridGenerator::subdivided_hyper_rectangle(

--- a/source/validate_input_database.cc
+++ b/source/validate_input_database.cc
@@ -99,16 +99,6 @@ void validate_input_database(boost::property_tree::ptree &database)
   unsigned int dim = database.get<unsigned int>("geometry.dim");
   ASSERT_THROW((dim == 2) || (dim == 3), "Error: dim should be 2 or 3");
 
-  boost::optional<double> material_height_optional =
-      database.get_optional<double>("geometry.material_height");
-
-  if (material_height_optional)
-  {
-    double material_height = material_height_optional.get();
-    ASSERT_THROW(material_height >= 0.0,
-                 "Error: Material height must be non-negative.");
-  }
-
   bool use_powder = database.get("geometry.use_powder", false);
 
   if (use_powder)

--- a/tests/test_geometry.cc
+++ b/tests/test_geometry.cc
@@ -11,10 +11,13 @@
 #include <types.hh>
 
 #include <deal.II/grid/filtered_iterator.h>
+#include <deal.II/grid/grid_tools.h>
 
 #include <boost/property_tree/ptree.hpp>
 
 #include "main.cc"
+
+namespace utf = boost::unit_test;
 
 template <int dim>
 void check_material_id(
@@ -97,6 +100,39 @@ BOOST_AUTO_TEST_CASE(geometry_3D)
 
   dealii::types::boundary_id const top_boundary = 5;
   check_material_id(tria, top_boundary);
+}
+
+BOOST_AUTO_TEST_CASE(geometry_shifted_origin, *utf::tolerance(1e-12))
+{
+  MPI_Comm communicator = MPI_COMM_WORLD;
+  boost::property_tree::ptree database;
+  database.put("import_mesh", false);
+  database.put("length", 12);
+  database.put("length_divisions", 4);
+  database.put("height", 4);
+  database.put("height_divisions", 2);
+  database.put("width", 6);
+  database.put("width_divisions", 5);
+  database.put("material_height", 4);
+  database.put("use_powder", true);
+  database.put("powder_layer", 2);
+
+  database.put("length_origin", 2.);
+  database.put("height_origin", -1.);
+  database.put("width_origin", 3.);
+
+  adamantine::Geometry<3> geometry(communicator, database);
+  dealii::parallel::distributed::Triangulation<3> const &tria =
+      geometry.get_triangulation();
+
+  auto bounding_box = dealii::GridTools::compute_bounding_box(tria);
+
+  BOOST_TEST(bounding_box.get_boundary_points().first(0) == 2.);
+  BOOST_TEST(bounding_box.get_boundary_points().first(1) == 3.);
+  BOOST_TEST(bounding_box.get_boundary_points().first(2) == -1.);
+  BOOST_TEST(bounding_box.get_boundary_points().second(0) == 14.);
+  BOOST_TEST(bounding_box.get_boundary_points().second(1) == 9.);
+  BOOST_TEST(bounding_box.get_boundary_points().second(2) == 3.);
 }
 
 BOOST_AUTO_TEST_CASE(gmsh)


### PR DESCRIPTION
This is the first of two PRs to let us do the curved wall build for the Okuma. This one is focused on relaxing the assumption that the entire domain is in the +x, +y, +z octant. A common AM reference frame has the top of the substrate centered at (0, 0, 0).

Changes:
- Removes the check that the material height must be positive
- Allows the user to specify the origin for an adamantine-generated meshes
- Allows user-defined scaling of a read-in mesh
- Allows the material id of a read-in mesh be cleared and set to 0