### PR TITLE
Add support to using more than one MPI rank per ensemble member

### DIFF
--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -1286,10 +1286,6 @@ void split_global_communicator(MPI_Comm global_communicator,
       static_cast<double>(global_ensemble_size);
   if (avg_n_procs_per_member > 1)
   {
-    // FIXME This branch does not work currently
-    adamantine::ASSERT_THROW(false, "Number of MPI ranks should be less than "
-                                    "the number of ensemble members");
-
     local_ensemble_size = 1;
     // We need all the members to use the same partitioning otherwise the dofs
     // may be number differently which is problematic for the data assimulation.

--- a/ci/jenkins_config
+++ b/ci/jenkins_config
@@ -22,7 +22,7 @@ pipeline {
             docker {
               image "rombur/adamantine-stack:no_gpu-latest"
                 alwaysPull true
-                label 'docker || nvidia-docker || rocm-docker'
+                label 'nvidia-docker || rocm-docker'
             }
           }
           steps {
@@ -38,7 +38,7 @@ pipeline {
                   -D DEAL_II_DIR=${DEAL_II_DIR} \
                   ..
                 '''
-                sh 'make -j3'
+                sh 'make -j8'
                 sh 'ctest --no-compress-output -R test_ -T Test'
               }
           }

--- a/source/RayTracing.cc
+++ b/source/RayTracing.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023, the adamantine authors.
+/* Copyright (c) 2023 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -170,8 +170,6 @@ unsigned int RayTracing::read_next_frame()
 
 PointsValues<3> RayTracing::get_points_values()
 {
-  PointsValues<dim> points_values;
-
   // Perform the ray tracing to get the cells that are intersected by rays
 
   // Create the bounding boxes associated to the locally owned cells with FE
@@ -217,133 +215,150 @@ PointsValues<3> RayTracing::get_points_values()
     }
   }
 
-  // If there are no intersections with the mesh leave early
-  if (n_intersections == 0)
-    return points_values;
-
-  points_values.points.reserve(n_intersections);
-  points_values.values.reserve(n_intersections);
-  auto constexpr reference_cell = dealii::ReferenceCells::get_hypercube<dim>();
-  double constexpr tol = 1e-10;
-  for (unsigned int i = 0; i < n_rays; ++i)
+  std::vector<dealii::Point<dim>> points;
+  std::vector<double> values;
+  if (n_intersections != 0)
   {
-    for (int j = offset[i]; j < offset[i + 1]; ++j)
+    points.reserve(n_intersections);
+    values.reserve(n_intersections);
+    auto constexpr reference_cell =
+        dealii::ReferenceCells::get_hypercube<dim>();
+    double constexpr tol = 1e-10;
+    for (unsigned int i = 0; i < n_rays; ++i)
     {
-      if (indices_ranks[j].second == my_rank)
+      for (int j = offset[i]; j < offset[i + 1]; ++j)
       {
-        double distance = std::numeric_limits<double>::max();
-        dealii::Point<dim> intersection;
-        auto const &cell = cell_iterators[indices_ranks[j].first];
-        // We know that the ray intersects the bounding box but we don't know
-        // where it intersects the cells. We need to check the intersection of
-        // the ray with each face of the cell.
-        for (unsigned int f = 0; f < reference_cell.n_faces(); ++f)
+        if (indices_ranks[j].second == my_rank)
         {
-          // First we check if the ray is parallel to the face. If this is the
-          // case, either the ray misses the face or the ray hits the edge of
-          // the face. In that last case, the ray is also orthogonal to
-          // another face and it is safe to discard all rays parallel to a
-          // face.
-          auto const point_0 = cell->face(f)->vertex(0);
-          auto const point_1 = cell->face(f)->vertex(1);
-          auto const point_2 = cell->face(f)->vertex(2);
-          dealii::Tensor<1, dim> edge_01({point_1[0] - point_0[0],
-                                          point_1[1] - point_0[1],
-                                          point_1[2] - point_0[2]});
-          dealii::Tensor<1, dim> edge_02({point_2[0] - point_0[0],
-                                          point_2[1] - point_0[1],
-                                          point_2[2] - point_0[2]});
-          auto const &ray_direction = _rays_current_frame[i].direction;
-          dealii::Tensor<2, dim> matrix(
-              {{-ray_direction[0], -ray_direction[1], -ray_direction[2]},
-               {edge_01[0], edge_01[1], edge_01[2]},
-               {edge_02[0], edge_02[1], edge_02[2]}});
-          double const det = dealii::determinant(matrix);
-          double face_area = 0.;
-          for (int e = 0; e < dim; ++e)
-            for (int k = 0; k < dim; ++k)
-              face_area += std::abs(edge_01[e] * edge_02[k]);
-          // If determinant is close to zero, the ray is parallel to the face
-          // and we go to the next face.
-          if (std::abs(det) < tol * face_area)
-            continue;
-          // Compute the distance along the ray direction between the origin
-          // of the ray and the intersection point.
-          auto const cross_product = dealii::cross_product_3d(edge_01, edge_02);
-          auto const &ray_origin = _rays_current_frame[i].origin;
-          dealii::Tensor<1, dim> p0_ray({ray_origin[0] - point_0[0],
-                                         ray_origin[1] - point_0[1],
-                                         ray_origin[2] - point_0[2]});
-          double d = cross_product * p0_ray / det;
-          // If d is less than 0, this means that the ray intersects the plane
-          // of the face but not the face itself. We can exit early.
-          if (d < 0)
-            continue;
-          // We can finally compute the intersection point. It is possible
-          // that a ray intersects multiple faces. For instance if the mesh is
-          // a cube the ray will get into the cube from one face and it will
-          // get out of the cube by the opposite face. The correct
-          // intersection point is the one with the smallest distance.
-          if (d < distance)
+          double distance = std::numeric_limits<double>::max();
+          dealii::Point<dim> intersection;
+          auto const &cell = cell_iterators[indices_ranks[j].first];
+          // We know that the ray intersects the bounding box but we don't know
+          // where it intersects the cells. We need to check the intersection of
+          // the ray with each face of the cell.
+          for (unsigned int f = 0; f < reference_cell.n_faces(); ++f)
           {
-            // The point intersects the plane of the face but maybe not the
-            // face itself. Check that the point is on the face. NOTE: We
-            // assume that the face is an axis-aligned rectangle.
-            dealii::Point<dim> face_intersection =
-                ray_origin + d * ray_direction;
-            std::vector<double> min(dim, std::numeric_limits<double>::max());
-            std::vector<double> max(dim, std::numeric_limits<double>::lowest());
-            for (unsigned int coord = 0; coord < dim; ++coord)
+            // First we check if the ray is parallel to the face. If this is the
+            // case, either the ray misses the face or the ray hits the edge of
+            // the face. In that last case, the ray is also orthogonal to
+            // another face and it is safe to discard all rays parallel to a
+            // face.
+            auto const point_0 = cell->face(f)->vertex(0);
+            auto const point_1 = cell->face(f)->vertex(1);
+            auto const point_2 = cell->face(f)->vertex(2);
+            dealii::Tensor<1, dim> edge_01({point_1[0] - point_0[0],
+                                            point_1[1] - point_0[1],
+                                            point_1[2] - point_0[2]});
+            dealii::Tensor<1, dim> edge_02({point_2[0] - point_0[0],
+                                            point_2[1] - point_0[1],
+                                            point_2[2] - point_0[2]});
+            auto const &ray_direction = _rays_current_frame[i].direction;
+            dealii::Tensor<2, dim> matrix(
+                {{-ray_direction[0], -ray_direction[1], -ray_direction[2]},
+                 {edge_01[0], edge_01[1], edge_01[2]},
+                 {edge_02[0], edge_02[1], edge_02[2]}});
+            double const det = dealii::determinant(matrix);
+            double face_area = 0.;
+            for (int e = 0; e < dim; ++e)
+              for (int k = 0; k < dim; ++k)
+                face_area += std::abs(edge_01[e] * edge_02[k]);
+            // If determinant is close to zero, the ray is parallel to the face
+            // and we go to the next face.
+            if (std::abs(det) < tol * face_area)
+              continue;
+            // Compute the distance along the ray direction between the origin
+            // of the ray and the intersection point.
+            auto const cross_product =
+                dealii::cross_product_3d(edge_01, edge_02);
+            auto const &ray_origin = _rays_current_frame[i].origin;
+            dealii::Tensor<1, dim> p0_ray({ray_origin[0] - point_0[0],
+                                           ray_origin[1] - point_0[1],
+                                           ray_origin[2] - point_0[2]});
+            double d = cross_product * p0_ray / det;
+            // If d is less than 0, this means that the ray intersects the plane
+            // of the face but not the face itself. We can exit early.
+            if (d < 0)
+              continue;
+            // We can finally compute the intersection point. It is possible
+            // that a ray intersects multiple faces. For instance if the mesh is
+            // a cube the ray will get into the cube from one face and it will
+            // get out of the cube by the opposite face. The correct
+            // intersection point is the one with the smallest distance.
+            if (d < distance)
             {
-              if (point_0[coord] < min[coord])
-                min[coord] = point_0[coord];
-              if (point_0[coord] > max[coord])
-                max[coord] = point_0[coord];
-
-              if (point_1[coord] < min[coord])
-                min[coord] = point_1[coord];
-              if (point_1[coord] > max[coord])
-                max[coord] = point_1[coord];
-
-              if (point_2[coord] < min[coord])
-                min[coord] = point_2[coord];
-              if (point_2[coord] > max[coord])
-                max[coord] = point_2[coord];
-            }
-
-            bool on_the_face = true;
-            double const effective_edge = std::sqrt(face_area);
-            for (int coord = 0; coord < dim; ++coord)
-            {
-              if ((face_intersection[coord] <
-                   (min[coord] - tol * effective_edge)) ||
-                  (face_intersection[coord] >
-                   (max[coord] + tol * effective_edge)))
+              // The point intersects the plane of the face but maybe not the
+              // face itself. Check that the point is on the face. NOTE: We
+              // assume that the face is an axis-aligned rectangle.
+              dealii::Point<dim> face_intersection =
+                  ray_origin + d * ray_direction;
+              std::vector<double> min(dim, std::numeric_limits<double>::max());
+              std::vector<double> max(dim,
+                                      std::numeric_limits<double>::lowest());
+              for (unsigned int coord = 0; coord < dim; ++coord)
               {
-                on_the_face = false;
-                break;
+                if (point_0[coord] < min[coord])
+                  min[coord] = point_0[coord];
+                if (point_0[coord] > max[coord])
+                  max[coord] = point_0[coord];
+
+                if (point_1[coord] < min[coord])
+                  min[coord] = point_1[coord];
+                if (point_1[coord] > max[coord])
+                  max[coord] = point_1[coord];
+
+                if (point_2[coord] < min[coord])
+                  min[coord] = point_2[coord];
+                if (point_2[coord] > max[coord])
+                  max[coord] = point_2[coord];
+              }
+
+              bool on_the_face = true;
+              double const effective_edge = std::sqrt(face_area);
+              for (int coord = 0; coord < dim; ++coord)
+              {
+                if ((face_intersection[coord] <
+                     (min[coord] - tol * effective_edge)) ||
+                    (face_intersection[coord] >
+                     (max[coord] + tol * effective_edge)))
+                {
+                  on_the_face = false;
+                  break;
+                }
+              }
+
+              if (on_the_face)
+              {
+                distance = d;
+                intersection = face_intersection;
               }
             }
-
-            if (on_the_face)
-            {
-              distance = d;
-              intersection = face_intersection;
-            }
           }
-        }
-        if (distance < std::numeric_limits<double>::max())
-        {
-          points_values.points.push_back(intersection);
-          points_values.values.push_back(_values_current_frame[i]);
+          if (distance < std::numeric_limits<double>::max())
+          {
+            points.push_back(intersection);
+            values.push_back(_values_current_frame[i]);
+          }
         }
       }
     }
+    // We know that there are at most n_intersections between the rays and the
+    // mesh
+    ASSERT(points.size() <= n_intersections,
+           "Error when computing the intersection of rays with the mesh.");
   }
-  // We know that there are at most n_intersections between the rays and the
-  // mesh
-  ASSERT(points_values.points.size() <= n_intersections,
-         "Error when computing the intersection of rays with the mesh.");
+
+  // We need all the processors to know the intersection points of the rays with
+  // the mesh and the values at these points.
+  PointsValues<dim> points_values;
+  auto all_points = dealii::Utilities::MPI::all_gather(communicator, points);
+  auto all_values = dealii::Utilities::MPI::all_gather(communicator, values);
+  for (unsigned int i = 0; i < all_points.size(); ++i)
+  {
+    points_values.points.insert(points_values.points.end(),
+                                all_points[i].begin(), all_points[i].end());
+    points_values.values.insert(points_values.values.end(),
+                                all_values[i].begin(), all_values[i].end());
+  }
 
   return points_values;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,12 +37,15 @@ list(APPEND
      test_integration_3d
      test_integration_3d_amr
      test_integration_3d_amr_device
-     test_integration_da
      test_integration_da_augmented
      test_material_deposition
      test_thermal_physics
      test_ensemble_management
     )
+
+# test_integration_da is a special test that we need to test with more
+# processors than the others
+adamantine_ADD_BOOST_TEST(test_integration_da 1 2 3 6)
 
 foreach(TEST_NAME ${UNIT_TESTS})
   adamantine_ADD_BOOST_TEST(${TEST_NAME})


### PR DESCRIPTION
This PR enables us to use multiple processors per ensemble member. This only works if the all the ensemble members use the same number of processors. This ensures that the mesh is partitioned the same way for all the ensemble members which simplifies some operations. We could remove this condition in the future.

The changes in the code are pretty small if you hide the whitespace changes. Most of the bugs were related to some data not being distributed to all the processors.