### PR TITLE
Remove embedded time stepping methods and Kelly estimator AMR

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,22 +162,10 @@ The following options are available:
   * beam\_X.diameter: diameter of the beam in meters (default value: 2e-3)
 * time\_stepping (required):
   * method: name of the method to use for the time integration: forward\_euler,
-  rk\_third\_order, rk\_fourth\_order, heun\_euler, bogacki\_shampine, dopri,
-  fehlberg, cash\_karp, backward\_euler, implicit\_midpoint, crank\_nicolson, or
-  sdirk2 (required)
+  rk\_third\_order, rk\_fourth\_order, backward\_euler, implicit\_midpoint, 
+  crank\_nicolson, or sdirk2 (required)
   * duration: duration of the simulation in seconds (required)
   * time\_step: length of the time steps used for the simulation in seconds (required)
-  * for embedded methods:
-    * coarsening\_parameter: coarsening of the time step when the error is small
-    enough (default value: 1.2)
-    * refining\_parameter: refining of the time step when the error is too large
-    (default value: 0.8)
-    * min\_time\_step: minimal time step (default value: 1e-14)
-    * max\_time\_step: maximal time step (default value: 1e100)
-    * refining\_tolerance: if the error is above the threshold, the time step is
-    refined (default value: 1e-8)
-    * coarsening\_tolerance: if the error is under the threshold, the time step
-    is coarsen (default value: 1e-12)
   * for implicit method:
     * max\_iteration: mamximum number of the iterations of the linear solver
     (default value: 1000)

--- a/README.md
+++ b/README.md
@@ -138,14 +138,9 @@ The following options are available:
   fields being written to the output files (default value: 1)
   * additional\_output\_refinement: additional levels of refinement for the output (default: 0)
 * refinement (required):
-  * n\_heat\_refinements: number of coarsening/refinement to execute (default value: 2)
-  * heat\_cell\_ratio: this is the ratio (n new cells)/(n old cells) after heat
-  refinement (default value: 1)
-  * n\_beam\_refinements: number of times the cells on the paths of the beams
-  are refined (default value: 2)
+  * n\_refinements: number of times the cells on the paths of the beams are refined (default value: 2)
   * beam\_cutoff: the cutoff value of the heat source terms above which beam-based refinement occurs (default value: 1e-15)
-  * coarsen\_after\_beam: whether to coarsen cells where the beam has already passed (may conflict with heat refinement, default value: false)
-  * max\_level: maximum number of times a cell can be refined
+  * coarsen\_after\_beam: whether to coarsen cells where the beam has already passed (default value: false)
   * time\_steps\_between\_refinement: number of time steps after which the
   refinement process is performed (default value: 2)
 * sources (required):

--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -973,8 +973,10 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
     if ((time + time_step) > duration)
       time_step = duration - time;
 
-    // Refine the mesh after time_steps_refinement time steps.
-    if (((n_time_step % time_steps_refinement) == 0) && use_thermal_physics)
+    // Refine the mesh the first time we get in the loop and after
+    // time_steps_refinement time steps.
+    if (((n_time_step == 1) || ((n_time_step % time_steps_refinement) == 0)) &&
+        use_thermal_physics)
     {
       timers[adamantine::refine].start();
       double next_refinement_time = time + time_steps_refinement * time_step;
@@ -983,8 +985,11 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
                   time_steps_refinement, refinement_database);
       timers[adamantine::refine].stop();
       if ((rank == 0) && (verbose_output == true))
-        std::cout << "n_dofs: " << thermal_physics->get_dof_handler().n_dofs()
+      {
+        std::cout << "n_time_step: " << n_time_step << " time: " << time
+                  << " n_dofs: " << thermal_physics->get_dof_handler().n_dofs()
                   << std::endl;
+      }
     }
 
     // Add material if necessary.
@@ -1033,8 +1038,8 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
       if ((rank == 0) && (verbose_output == true) &&
           (activation_end - activation_start > 0) && use_thermal_physics)
       {
-        std::cout << "n_dofs: " << thermal_physics->get_dof_handler().n_dofs()
-                  << std::endl;
+        std::cout << "n_dofs after cell activation: "
+                  << thermal_physics->get_dof_handler().n_dofs() << std::endl;
       }
     }
     timers[adamantine::add_material_activate].stop();
@@ -1700,8 +1705,9 @@ run_ensemble(MPI_Comm const &global_communicator,
       time_step = duration - time;
 
     // ----- Refine the mesh if necessary -----
-    // Refine the mesh after time_steps_refinement time steps.
-    if ((n_time_step % time_steps_refinement) == 0)
+    // Refine the mesh the first time we get in the loop and after
+    // time_steps_refinement time steps.
+    if ((n_time_step == 1) || ((n_time_step % time_steps_refinement) == 0))
     {
       timers[adamantine::refine].start();
       double const next_refinement_time =
@@ -1719,9 +1725,12 @@ run_ensemble(MPI_Comm const &global_communicator,
 
       timers[adamantine::refine].stop();
       if ((global_rank == 0) && (verbose_output == true))
-        std::cout << "n_dofs: "
+      {
+        std::cout << "n_time_step: " << n_time_step << " time: " << time
+                  << " n_dofs: "
                   << thermal_physics_ensemble[0]->get_dof_handler().n_dofs()
                   << std::endl;
+      }
     }
 
     // We use an epsilon to get the "expected" behavior when the deposition
@@ -1767,9 +1776,11 @@ run_ensemble(MPI_Comm const &global_communicator,
 
       if ((global_rank == 0) && (verbose_output == true) &&
           (activation_end - activation_start > 0))
-        std::cout << "n_dofs: "
+      {
+        std::cout << "n_dofs after cell activation: "
                   << thermal_physics_ensemble[0]->get_dof_handler().n_dofs()
                   << std::endl;
+      }
     }
     timers[adamantine::add_material_activate].stop();
 

--- a/application/input.info
+++ b/application/input.info
@@ -22,11 +22,8 @@ boundary
 
 refinement
 {
-  n_heat_refinements 0 ; Number of coarsening/refinement executed (uses Kelly's
-                       ; error estimator)
-  n_beam_refinements 2 ; Number of time the cells on the paths of the beams are
-                       ; refined
-  max_level          2 ; Maximum number of time a cell can be refined
+  n_refinements 2 ; Number of time the cells on the paths of the beams are
+                  ; refined
 }
 
 materials

--- a/application/input.info
+++ b/application/input.info
@@ -89,10 +89,9 @@ sources
 
 time_stepping
 {
-  method backward_euler ; Possibilities: backward_euler, implicit_midpoint,
-                        ; crank_nicolson, sdirk2, forward_euler, rk_third_order,
-                        ; rk_fourth_order, bogacki_shampine, dopri,
-                        ; fehlberg, cash_karp
+  method forward_euler ; Possibilities: backward_euler, implicit_midpoint,
+                       ; crank_nicolson, sdirk2, forward_euler, rk_third_order,
+                       ; rk_fourth_order
   duration 1e-9 ; [s]
   time_step 5e-11 ; [s]
 }

--- a/source/ThermalPhysics.hh
+++ b/source/ThermalPhysics.hh
@@ -73,8 +73,6 @@ public:
       dealii::LA::distributed::Vector<double, MemorySpaceType> &solution,
       std::vector<Timer> &timers) override;
 
-  double get_delta_t_guess() const override;
-
   void
   initialize_dof_vector(double const value,
                         dealii::LA::distributed::Vector<double, MemorySpaceType>
@@ -147,10 +145,6 @@ private:
                                    std::vector<Timer> &timers) const;
 
   /**
-   * This flag is true if the time stepping method is embedded.
-   */
-  bool _embedded_method = false;
-  /**
    * This flag is true if the time stepping method is implicit.
    */
   bool _implicit_method = false;
@@ -167,10 +161,6 @@ private:
    * Maximum number of temporary vectors when inverting the ImplicitOperator.
    */
   unsigned int _max_n_tmp_vectors;
-  /**
-   * Guess of the next time step.
-   */
-  double _delta_t_guess;
   /**
    * Tolerance to inverte the ImplicitOperator.
    */
@@ -244,15 +234,6 @@ private:
    */
   std::unique_ptr<dealii::TimeStepping::RungeKutta<LA_Vector>> _time_stepping;
 };
-
-template <int dim, int p_order, int fe_degree, typename MaterialStates,
-          typename MemorySpaceType, typename QuadratureType>
-inline double
-ThermalPhysics<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
-               QuadratureType>::get_delta_t_guess() const
-{
-  return _delta_t_guess;
-}
 
 template <int dim, int p_order, int fe_degree, typename MaterialStates,
           typename MemorySpaceType, typename QuadratureType>

--- a/source/ThermalPhysics.templates.hh
+++ b/source/ThermalPhysics.templates.hh
@@ -411,41 +411,6 @@ ThermalPhysics<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
     _time_stepping =
         std::make_unique<dealii::TimeStepping::ExplicitRungeKutta<LA_Vector>>(
             dealii::TimeStepping::RK_CLASSIC_FOURTH_ORDER);
-  else if (method.compare("heun_euler") == 0)
-  {
-    _time_stepping = std::make_unique<
-        dealii::TimeStepping::EmbeddedExplicitRungeKutta<LA_Vector>>(
-        dealii::TimeStepping::HEUN_EULER);
-    _embedded_method = true;
-  }
-  else if (method.compare("bogacki_shampine") == 0)
-  {
-    _time_stepping = std::make_unique<
-        dealii::TimeStepping::EmbeddedExplicitRungeKutta<LA_Vector>>(
-        dealii::TimeStepping::BOGACKI_SHAMPINE);
-    _embedded_method = true;
-  }
-  else if (method.compare("dopri") == 0)
-  {
-    _time_stepping = std::make_unique<
-        dealii::TimeStepping::EmbeddedExplicitRungeKutta<LA_Vector>>(
-        dealii::TimeStepping::DOPRI);
-    _embedded_method = true;
-  }
-  else if (method.compare("fehlberg") == 0)
-  {
-    _time_stepping = std::make_unique<
-        dealii::TimeStepping::EmbeddedExplicitRungeKutta<LA_Vector>>(
-        dealii::TimeStepping::FEHLBERG);
-    _embedded_method = true;
-  }
-  else if (method.compare("cash_karp") == 0)
-  {
-    _time_stepping = std::make_unique<
-        dealii::TimeStepping::EmbeddedExplicitRungeKutta<LA_Vector>>(
-        dealii::TimeStepping::CASH_KARP);
-    _embedded_method = true;
-  }
   else if (method.compare("backward_euler") == 0)
   {
     _time_stepping =
@@ -473,31 +438,6 @@ ThermalPhysics<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
         std::make_unique<dealii::TimeStepping::ImplicitRungeKutta<LA_Vector>>(
             dealii::TimeStepping::SDIRK_TWO_STAGES);
     _implicit_method = true;
-  }
-
-  if (_embedded_method == true)
-  {
-    // PropertyTreeInput time_steppping.coarsening_parameter
-    double coarsen_param =
-        time_stepping_database.get("coarsening_parameter", 1.2);
-    // PropertyTreeInput time_steppping.refining_parameter
-    double refine_param = time_stepping_database.get("refining_parameter", 0.8);
-    // PropertyTreeInput time_stepping.min_time_step
-    double min_delta = time_stepping_database.get("min_time_step", 1e-14);
-    // PropertyTreeInput time_stepping.max_time_step
-    double max_delta = time_stepping_database.get("max_time_step", 1e100);
-    // PropertyTreeInput time_stepping.refining_tolerance
-    double refine_tol = time_stepping_database.get("refining_tolerance", 1e-8);
-    // PropertyTreeInput time_stepping.coarsening_tolerance
-    double coarsen_tol =
-        time_stepping_database.get("coarsening_tolerance", 1e-12);
-    dealii::TimeStepping::EmbeddedExplicitRungeKutta<LA_Vector> *embedded_rk =
-        static_cast<
-            dealii::TimeStepping::EmbeddedExplicitRungeKutta<LA_Vector> *>(
-            _time_stepping.get());
-    embedded_rk->set_time_adaptation_parameters(coarsen_param, refine_param,
-                                                min_delta, max_delta,
-                                                refine_tol, coarsen_tol);
   }
 
   // If the time stepping scheme is implicit, set the parameters for the solver
@@ -948,21 +888,7 @@ double ThermalPhysics<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
   double time = _time_stepping->evolve_one_time_step(eval, id_m_Jinv, t,
                                                      delta_t, solution);
 
-  // If the method is embedded, get the next time step. Otherwise, just use the
-  // current time step.
-  if (_embedded_method == false)
-    _delta_t_guess = delta_t;
-  else
-  {
-    dealii::TimeStepping::EmbeddedExplicitRungeKutta<LA_Vector> *embedded_rk =
-        static_cast<
-            dealii::TimeStepping::EmbeddedExplicitRungeKutta<LA_Vector> *>(
-            _time_stepping.get());
-    _delta_t_guess = embedded_rk->get_status().delta_t_guess;
-  }
-
-  // Return the time at the end of the time step. This may be different than
-  // t+delta_t for embedded methods.
+  // Return the time at the end of the time step.
   return time;
 }
 

--- a/source/ThermalPhysicsInterface.hh
+++ b/source/ThermalPhysicsInterface.hh
@@ -84,11 +84,6 @@ public:
       std::vector<Timer> &timers) = 0;
 
   /**
-   * Return a guess of what should be the nex time step.
-   */
-  virtual double get_delta_t_guess() const = 0;
-
-  /**
    * Initialize the given vector with the given value.
    */
   virtual void

--- a/source/validate_input_database.cc
+++ b/source/validate_input_database.cc
@@ -361,25 +361,17 @@ void validate_input_database(boost::property_tree::ptree &database)
   // Tree: time_stepping
   std::string time_stepping_method =
       database.get<std::string>("time_stepping.method");
-  ASSERT_THROW(
-      boost::iequals(time_stepping_method, "forward_euler") ||
-          boost::iequals(time_stepping_method, "rk_third_order") ||
-          boost::iequals(time_stepping_method, "rk_fourth_order") ||
-          boost::iequals(time_stepping_method, "heun_euler") ||
-          boost::iequals(time_stepping_method, "bogacki_shampine") ||
-          boost::iequals(time_stepping_method, "dopri") ||
-          boost::iequals(time_stepping_method, "fehlberg") ||
-          boost::iequals(time_stepping_method, "cash_karp") ||
-          boost::iequals(time_stepping_method, "backward_euler") ||
-          boost::iequals(time_stepping_method, "implicit_midpoint") ||
-          boost::iequals(time_stepping_method, "crank_nicolson") ||
-          boost::iequals(time_stepping_method, "sdirk2"),
-      "Error: Time stepping method, '" + time_stepping_method +
-          "', is not recognized. Valid options are: 'forward_euler', "
-          "'rk_third_order', 'rk_fourth_order', 'heun_euler', "
-          "'bogacki_shampine', 'dopri', 'fehlberg', 'cash_karp', "
-          "'backward_euler', 'implicit_midpoint', 'crank_nicolson', and "
-          "'sdirk2'.");
+  ASSERT_THROW(boost::iequals(time_stepping_method, "forward_euler") ||
+                   boost::iequals(time_stepping_method, "rk_third_order") ||
+                   boost::iequals(time_stepping_method, "rk_fourth_order") ||
+                   boost::iequals(time_stepping_method, "backward_euler") ||
+                   boost::iequals(time_stepping_method, "implicit_midpoint") ||
+                   boost::iequals(time_stepping_method, "crank_nicolson") ||
+                   boost::iequals(time_stepping_method, "sdirk2"),
+               "Error: Time stepping method, '" + time_stepping_method +
+                   "', is not recognized. Valid options are: 'forward_euler', "
+                   "'rk_third_order', 'rk_fourth_order', 'backward_euler', "
+                   "'implicit_midpoint', 'crank_nicolson', and 'sdirk2'.");
 
   ASSERT_THROW(database.get<double>("time_stepping.duration") >= 0.0,
                "Error: Time stepping duration must be non-negative.");

--- a/tests/data/amr_test.info
+++ b/tests/data/amr_test.info
@@ -97,8 +97,7 @@ time_stepping
 {
   method forward_euler ; Possibilities: backward_euler, implicit_midpoint,
                         ; crank_nicolson, sdirk2, forward_euler, rk_third_order,
-                        ; rk_fourth_order, bogacki_shampine, dopri,
-                        ; fehlberg, cash_karp
+                        ; rk_fourth_order
   duration 25.0e-5 ; [s]
   time_step 1.0e-6 ; [s]
 }

--- a/tests/data/amr_test.info
+++ b/tests/data/amr_test.info
@@ -23,14 +23,10 @@ boundary
 
 refinement
 {
-  n_heat_refinements 0 ; Number of coarsening/refinement executed (uses Kelly's
-                       ; error estimator)
-  heat_cell_ratio    2.0 ;
-  n_beam_refinements 1 ; Number of time the cells on the paths of the beams are
-                       ; refined
-  max_level          1 ; Maximum number of time a cell can be refined
+  n_refinements 1 ; Number of time the cells on the paths of the beams are
+                  ; refined
   time_steps_between_refinement 200 ; number of time steps after which
-                                                 ; the refinement process is performed
+                                    ; the refinement process is performed
 }
 
 materials

--- a/tests/data/bare_plate_L_da.info
+++ b/tests/data/bare_plate_L_da.info
@@ -126,8 +126,7 @@ time_stepping
 {
   method forward_euler ; Possibilities: backward_euler, implicit_midpoint,
                         ; crank_nicolson, sdirk2, forward_euler, rk_third_order,
-                        ; rk_fourth_order, bogacki_shampine, dopri,
-                        ; fehlberg, cash_karp
+                        ; rk_fourth_order
   duration 5.0e-2 ; [s]
   time_step 1.0e-4 ; [s]
 }

--- a/tests/data/bare_plate_L_da.info
+++ b/tests/data/bare_plate_L_da.info
@@ -52,14 +52,10 @@ boundary
 
 refinement
 {
-  n_heat_refinements 0 ; Number of coarsening/refinement executed (uses Kelly's
-                       ; error estimator)
-  heat_cell_ratio    2.0 ;
-  n_beam_refinements 1 ; Number of time the cells on the paths of the beams are
-                       ; refined
-  max_level          1 ; Maximum number of time a cell can be refined
+  n_refinements 1 ; Number of time the cells on the paths of the beams are
+                  ; refined
   time_steps_between_refinement 250 ; number of time steps after which
-                                                 ; the refinement process is performed
+                                    ; the refinement process is performed
 }
 
 materials

--- a/tests/data/bare_plate_L_da_augmented.info
+++ b/tests/data/bare_plate_L_da_augmented.info
@@ -53,14 +53,10 @@ boundary
 
 refinement
 {
-  n_heat_refinements 0 ; Number of coarsening/refinement executed (uses Kelly's
-                       ; error estimator)
-  heat_cell_ratio    2.0 ;
-  n_beam_refinements 0 ; Number of time the cells on the paths of the beams are
-                       ; refined
-  max_level          0 ; Maximum number of time a cell can be refined
+  n_refinements 0 ; Number of time the cells on the paths of the beams are
+                  ; refined
   time_steps_between_refinement 2000000000 ; number of time steps after which
-                                                 ; the refinement process is performed
+                                           ; the refinement process is performed
 }
 
 materials

--- a/tests/data/bare_plate_L_da_augmented.info
+++ b/tests/data/bare_plate_L_da_augmented.info
@@ -127,8 +127,7 @@ time_stepping
 {
   method forward_euler ; Possibilities: backward_euler, implicit_midpoint,
                         ; crank_nicolson, sdirk2, forward_euler, rk_third_order,
-                        ; rk_fourth_order, bogacki_shampine, dopri,
-                        ; fehlberg, cash_karp
+                        ; rk_fourth_order
   duration 5.0e-2 ; [s]
   time_step 1.0e-4 ; [s]
 }

--- a/tests/data/bare_plate_L_ensemble.info
+++ b/tests/data/bare_plate_L_ensemble.info
@@ -104,8 +104,7 @@ time_stepping
 {
   method forward_euler ; Possibilities: backward_euler, implicit_midpoint,
                         ; crank_nicolson, sdirk2, forward_euler, rk_third_order,
-                        ; rk_fourth_order, bogacki_shampine, dopri,
-                        ; fehlberg, cash_karp
+                        ; rk_fourth_order
   duration 5.0e-2 ; [s]
   time_step 5.0e-5 ; [s]
 }

--- a/tests/data/bare_plate_L_ensemble.info
+++ b/tests/data/bare_plate_L_ensemble.info
@@ -30,14 +30,10 @@ boundary
 
 refinement
 {
-  n_heat_refinements 0 ; Number of coarsening/refinement executed (uses Kelly's
-                       ; error estimator)
-  heat_cell_ratio    2.0 ;
-  n_beam_refinements 0 ; Number of time the cells on the paths of the beams are
-                       ; refined
-  max_level          0 ; Maximum number of time a cell can be refined
+  n_refinements 0 ; Number of time the cells on the paths of the beams are
+                  ; refined
   time_steps_between_refinement 2000000000 ; number of time steps after which
-                                                 ; the refinement process is performed
+                                           ; the refinement process is performed
 }
 
 materials

--- a/tests/data/demo_316_short.info
+++ b/tests/data/demo_316_short.info
@@ -112,8 +112,7 @@ time_stepping
 {
   method forward_euler ; Possibilities: backward_euler, implicit_midpoint,
                         ; crank_nicolson, sdirk2, forward_euler, rk_third_order,
-                        ; rk_fourth_order, bogacki_shampine, dopri,
-                        ; fehlberg, cash_karp
+                        ; rk_fourth_order
   duration 0.004 ; [s]
   time_step 0.6e-4 ; [s]
 }

--- a/tests/data/demo_316_short.info
+++ b/tests/data/demo_316_short.info
@@ -30,14 +30,10 @@ physics
 
 refinement
 {
-  n_heat_refinements 0 ; Number of coarsening/refinement executed (uses Kelly's
-                       ; error estimator)
-  heat_cell_ratio    2.0 ;
-  n_beam_refinements 0 ; Number of time the cells on the paths of the beams are
-                       ; refined
-  max_level          0 ; Maximum number of time a cell can be refined
+  n_refinements 0 ; Number of time the cells on the paths of the beams are
+                  ; refined
   time_steps_between_refinement 2000000000 ; number of time steps after which
-                                                 ; the refinement process is performed
+                                           ; the refinement process is performed
 }
 
 materials

--- a/tests/data/demo_316_short_anisotropic.info
+++ b/tests/data/demo_316_short_anisotropic.info
@@ -30,14 +30,10 @@ physics
 
 refinement
 {
-  n_heat_refinements 0 ; Number of coarsening/refinement executed (uses Kelly's
-                       ; error estimator)
-  heat_cell_ratio    2.0 ;
-  n_beam_refinements 0 ; Number of time the cells on the paths of the beams are
-                       ; refined
-  max_level          0 ; Maximum number of time a cell can be refined
+  n_refinements 0 ; Number of time the cells on the paths of the beams are
+                  ; refined
   time_steps_between_refinement 2000000000 ; number of time steps after which
-                                                 ; the refinement process is performed
+                                           ; the refinement process is performed
 }
 
 materials

--- a/tests/data/demo_316_short_anisotropic.info
+++ b/tests/data/demo_316_short_anisotropic.info
@@ -105,8 +105,7 @@ time_stepping
 {
   method forward_euler ; Possibilities: backward_euler, implicit_midpoint,
                         ; crank_nicolson, sdirk2, forward_euler, rk_third_order,
-                        ; rk_fourth_order, bogacki_shampine, dopri,
-                        ; fehlberg, cash_karp
+                        ; rk_fourth_order
   duration 0.001 ; [s]
   time_step 1e-5 ; [s]
 }

--- a/tests/data/integration_2d.info
+++ b/tests/data/integration_2d.info
@@ -84,8 +84,7 @@ time_stepping
 {
   method backward_euler ; Possibilities: backward_euler, implicit_midpoint,
                         ; crank_nicolson, sdirk2, forward_euler, rk_third_order,
-                        ; rk_fourth_order, bogacki_shampine, dopri,
-                        ; fehlberg, cash_karp
+                        ; rk_fourth_order
   duration 1e-9 ; [s]
   time_step 5e-11 ; [s]
 }

--- a/tests/data/integration_2d.info
+++ b/tests/data/integration_2d.info
@@ -16,11 +16,8 @@ physics
 
 refinement
 {
-  n_heat_refinements 0 ; Number of coarsening/refinement executed (uses Kelly's
-                       ; error estimator)
-  n_beam_refinements 2 ; Number of time the cells on the paths of the beams are
-                       ; refined
-  max_level          2 ; Maximum number of time a cell can be refined
+  n_refinements 2 ; Number of time the cells on the paths of the beams are
+                  ; refined
 }
 
 materials

--- a/tests/data/integration_2d_ensemble.info
+++ b/tests/data/integration_2d_ensemble.info
@@ -90,8 +90,7 @@ time_stepping
 {
   method backward_euler ; Possibilities: backward_euler, implicit_midpoint,
                         ; crank_nicolson, sdirk2, forward_euler, rk_third_order,
-                        ; rk_fourth_order, bogacki_shampine, dopri,
-                        ; fehlberg, cash_karp
+                        ; rk_fourth_order
   duration 1e-9 ; [s]
   time_step 5e-11 ; [s]
 }

--- a/tests/data/integration_2d_ensemble.info
+++ b/tests/data/integration_2d_ensemble.info
@@ -22,11 +22,8 @@ physics
 
 refinement
 {
-  n_heat_refinements 0 ; Number of coarsening/refinement executed (uses Kelly's
-                       ; error estimator)
-  n_beam_refinements 2 ; Number of time the cells on the paths of the beams are
-                       ; refined
-  max_level          2 ; Maximum number of time a cell can be refined
+  n_refinements 2 ; Number of time the cells on the paths of the beams are
+                  ; refined
 }
 
 materials

--- a/tests/data/integration_da_add_material.info
+++ b/tests/data/integration_da_add_material.info
@@ -62,14 +62,10 @@ boundary
 
 refinement
 {
-  n_heat_refinements 0 ; Number of coarsening/refinement executed (uses Kelly's
-                       ; error estimator)
-  heat_cell_ratio    2.0 ;
-  n_beam_refinements 0 ; Number of time the cells on the paths of the beams are
-                       ; refined
-  max_level          0 ; Maximum number of time a cell can be refined
+  n_refinements 0 ; Number of time the cells on the paths of the beams are
+                  ; refined
   time_steps_between_refinement 200000 ; number of time steps after which
-                                                 ; the refinement process is performed
+                                       ; the refinement process is performed
 }
 
 materials

--- a/tests/data/integration_da_add_material.info
+++ b/tests/data/integration_da_add_material.info
@@ -137,8 +137,7 @@ time_stepping
 {
   method forward_euler ; Possibilities: backward_euler, implicit_midpoint,
                         ; crank_nicolson, sdirk2, forward_euler, rk_third_order,
-                        ; rk_fourth_order, bogacki_shampine, dopri,
-                        ; fehlberg, cash_karp
+                        ; rk_fourth_order
   duration 2.0e-1 ; [s]
   time_step 2.0e-2 ; [s]
 }

--- a/tests/data/thermoelastic_bare_plate.info
+++ b/tests/data/thermoelastic_bare_plate.info
@@ -43,14 +43,10 @@ boundary
 
 refinement
 {
-  n_heat_refinements 0 ; Number of coarsening/refinement executed (uses Kelly's
-                       ; error estimator)
-  heat_cell_ratio    2.0 ;
-  n_beam_refinements 0 ; Number of time the cells on the paths of the beams are
-                       ; refined
-  max_level          0 ; Maximum number of time a cell can be refined
+  n_refinements 0 ; Number of time the cells on the paths of the beams are
+                  ; refined
   time_steps_between_refinement 100 ; number of time steps after which
-                                                 ; the refinement process is performed
+                                    ; the refinement process is performed
 }
 
 materials

--- a/tests/data/thermoelastic_bare_plate.info
+++ b/tests/data/thermoelastic_bare_plate.info
@@ -122,8 +122,7 @@ time_stepping
 {
   method forward_euler ; Possibilities: backward_euler, implicit_midpoint,
                         ; crank_nicolson, sdirk2, forward_euler, rk_third_order,
-                        ; rk_fourth_order, bogacki_shampine, dopri,
-                        ; fehlberg, cash_karp
+                        ; rk_fourth_order
   duration 4.0e0 ; [s]
   time_step 4.0e-3 ; [s]
 }


### PR DESCRIPTION
This is the last PR I would like to get merged before creating the release branch. This removes the embedded time stepping methods (aka the adaptive time step method) and the AMR based on the Kelly estimator. We are not using either of these capabilities and they are making the code and the input file more complicated. The embedded method methods are problematic for the GPU computations and the Kelly estimator AMR is not usable in practice because the number of cells cannot be kept stable. We may reintroduce these capabilities in the future but we need to do it in a more thoughtful way.