### PR TITLE
Bump version to 1.0.9 on master

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 # TPL and adamantine
 include(SetupDealII)
 
-project(adamantine LANGUAGES CXX VERSION 0.1.0)
+project(adamantine LANGUAGES CXX VERSION 1.0.9)
 
 include(SetupTPLs)
 include(SetupAdamantine)


### PR DESCRIPTION
I've just created the branch for the `1.0`. Let's bump the version on master to `1.0.9` (this is inspired by what Kokkos does where the current development version is `4.3.99`)