### PR TITLE
Updates for deal.II master past 9.5

### DIFF
--- a/source/DataAssimilator.cc
+++ b/source/DataAssimilator.cc
@@ -54,7 +54,11 @@ DataAssimilator::DataAssimilator(MPI_Comm const &global_communicator,
     if (boost::optional<unsigned int> max_num_temp_vectors =
             database.get_optional<unsigned int>(
                 "solver.max_number_of_temp_vectors"))
+#if DEAL_II_VERSION_GTE(9, 6, 0)
+      _additional_data.max_basis_size = *max_num_temp_vectors - 2;
+#else
       _additional_data.max_n_tmp_vectors = *max_num_temp_vectors;
+#endif
 
     // PropertyTreeInput data_assimilation.solver.max_iterations
     if (boost::optional<unsigned int> max_iterations =

--- a/source/DataAssimilator.hh
+++ b/source/DataAssimilator.hh
@@ -14,7 +14,9 @@
 #include <deal.II/fe/mapping_q1_eulerian.h>
 #include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/la_parallel_block_vector.h>
+#if !DEAL_II_VERSION_GTE(9, 6, 0)
 #include <deal.II/lac/la_vector.h>
+#endif
 #include <deal.II/lac/solver_gmres.h>
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/trilinos_sparse_matrix.h>

--- a/source/MaterialProperty.hh
+++ b/source/MaterialProperty.hh
@@ -22,7 +22,9 @@
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/grid/filtered_iterator.h>
 #include <deal.II/lac/la_parallel_vector.h>
+#if !DEAL_II_VERSION_GTE(9, 6, 0)
 #include <deal.II/lac/la_vector.h>
+#endif
 
 #include <boost/property_tree/ptree.hpp>
 

--- a/tests/test_data_assimilator.cc
+++ b/tests/test_data_assimilator.cc
@@ -33,7 +33,11 @@ public:
     BOOST_TEST(da0._solver_control.tolerance() - 1.0e-10 == 0.,
                tt::tolerance(tol));
     BOOST_TEST(da0._solver_control.max_steps() == 100u);
+#if DEAL_II_VERSION_GTE(9, 6, 0)
+    BOOST_TEST(da0._additional_data.max_basis_size == 30u);
+#else
     BOOST_TEST(da0._additional_data.max_n_tmp_vectors == 30u);
+#endif
 
     // Now explicitly setting them
     database.put("solver.convergence_tolerance", 1.0e-6);
@@ -43,7 +47,11 @@ public:
     BOOST_TEST(da1._solver_control.tolerance() - 1.0e-6 == 0.,
                tt::tolerance(tol));
     BOOST_TEST(da1._solver_control.max_steps() == 25u);
+#if DEAL_II_VERSION_GTE(9, 6, 0)
+    BOOST_TEST(da1._additional_data.max_basis_size == 2u);
+#else
     BOOST_TEST(da1._additional_data.max_n_tmp_vectors == 4u);
+#endif
   };
 
   void test_calc_kalman_gain()


### PR DESCRIPTION
https://github.com/dealii/dealii/pull/16745 updated the SolverGMRES implementation and `deal.II/lac/la_vector.h` was removed in https://github.com/dealii/dealii/commit/d22e218017b8577437eb4fd36315dc6bf8653988.