### PR TITLE
Fix missing explicit instantiations

### DIFF
--- a/source/experimental_data_utils.cc
+++ b/source/experimental_data_utils.cc
@@ -229,4 +229,10 @@ get_expt_to_dof_mapping(PointsValues<2> const &points_values,
 template std::pair<std::vector<int>, std::vector<int>>
 get_expt_to_dof_mapping(PointsValues<3> const &points_values,
                         dealii::DoFHandler<3> const &dof_handler);
+template std::pair<std::vector<dealii::types::global_dof_index>,
+                   std::vector<dealii::Point<2>>>
+get_dof_to_support_mapping(dealii::DoFHandler<2> const &dof_handler);
+template std::pair<std::vector<dealii::types::global_dof_index>,
+                   std::vector<dealii::Point<3>>>
+get_dof_to_support_mapping(dealii::DoFHandler<3> const &dof_handler);
 } // namespace adamantine

--- a/source/material_deposition.cc
+++ b/source/material_deposition.cc
@@ -382,4 +382,28 @@ template std::vector<
 get_elements_to_activate(
     dealii::DoFHandler<3> const &dof_handler,
     std::vector<dealii::BoundingBox<3>> const &material_deposition_boxes);
+
+template std::tuple<std::vector<dealii::BoundingBox<2, double>>,
+                    std::vector<double>, std::vector<double>,
+                    std::vector<double>>
+merge_deposition_paths(
+    std::vector<std::tuple<std::vector<dealii::BoundingBox<2, double>>,
+                           std::vector<double>, std::vector<double>,
+                           std::vector<double>>> const &deposition_paths);
+template std::tuple<std::vector<dealii::BoundingBox<3, double>>,
+                    std::vector<double>, std::vector<double>,
+                    std::vector<double>>
+merge_deposition_paths(
+    std::vector<std::tuple<std::vector<dealii::BoundingBox<3, double>>,
+                           std::vector<double>, std::vector<double>,
+                           std::vector<double>>> const &deposition_paths);
+
+template std::tuple<std::vector<dealii::BoundingBox<2>>, std::vector<double>,
+                    std::vector<double>, std::vector<double>>
+deposition_along_scan_path(boost::property_tree::ptree const &geometry_database,
+                           ScanPath const &scan_path);
+template std::tuple<std::vector<dealii::BoundingBox<3>>, std::vector<double>,
+                    std::vector<double>, std::vector<double>>
+deposition_along_scan_path(boost::property_tree::ptree const &geometry_database,
+                           ScanPath const &scan_path);
 } // namespace adamantine


### PR DESCRIPTION
Trying to compile with `clang++`, I am running into a bunch of missing explicit instantiations that this pull request fixes.