### PR TITLE
Avoid compiler warnings

### DIFF
--- a/application/adamantine.cc
+++ b/application/adamantine.cc
@@ -106,7 +106,7 @@ get_p_order_and_n_material_states(boost::property_tree::ptree &database)
 
   // Sanity check
   adamantine::ASSERT_THROW(
-      p_order >= 0 && p_order < 5,
+      p_order < 5,
       "Error when computing the polynomial order of the material properties");
   adamantine::ASSERT_THROW(
       n_material_states > 0 && n_material_states < 4,

--- a/source/MaterialProperty.hh
+++ b/source/MaterialProperty.hh
@@ -57,13 +57,6 @@ public:
       boost::property_tree::ptree const &database);
 
   /**
-   * Copy constructor. It should only be called by KOKKOS_CLASS_LAMBDA. The
-   * copy constructor does not copy all the member variables of the class.
-   */
-  MaterialProperty(MaterialProperty<dim, p_order, MaterialStates,
-                                    MemorySpaceType> const &other);
-
-  /**
    * Return true if the material properties are given in table format.
    * Return false if they are given in polynomial format.
    */

--- a/source/types.hh
+++ b/source/types.hh
@@ -8,6 +8,8 @@
 #ifndef TYPES_HH
 #define TYPES_HH
 
+#include <Kokkos_NumericTraits.hpp>
+
 #include <array>
 #include <string>
 
@@ -163,18 +165,19 @@ struct axis;
 template <>
 struct axis<2>
 {
-  static int constexpr x = 0;
-  static int constexpr y = -1;
-  static int constexpr z = 1;
+  static unsigned int constexpr x = 0;
+  static unsigned int constexpr y =
+      Kokkos::Experimental::finite_max_v<unsigned int>;
+  static unsigned int constexpr z = 1;
 };
 
 // dim == 3 specialization
 template <>
 struct axis<3>
 {
-  static int constexpr x = 0;
-  static int constexpr y = 1;
-  static int constexpr z = 2;
+  static unsigned int constexpr x = 0;
+  static unsigned int constexpr y = 1;
+  static unsigned int constexpr z = 2;
 };
 
 /**


### PR DESCRIPTION
While working on #282, I noticed that there are more warnings which this pull request fixes. I wasn't sure if we wanted to enforce this with `-Werror` or similar.