### PR TITLE
Fix uninitialized variables

### DIFF
--- a/source/ElectronBeamHeatSource.hh
+++ b/source/ElectronBeamHeatSource.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 - 2022, the adamantine authors.
+/* Copyright (c) 2020 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -9,6 +9,8 @@
 #define ELECTRON_BEAM_HEAT_SOURCE_HH
 
 #include <HeatSource.hh>
+
+#include <limits>
 
 namespace adamantine
 {
@@ -47,7 +49,7 @@ public:
 
 private:
   dealii::Point<3> _beam_center;
-  double _alpha;
+  double _alpha = std::numeric_limits<double>::signaling_NaN();
   double const _log_01 = std::log(0.1);
 };
 } // namespace adamantine

--- a/source/GoldakHeatSource.hh
+++ b/source/GoldakHeatSource.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 - 2022, the adamantine authors.
+/* Copyright (c) 2020 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -9,6 +9,8 @@
 #define GOLDAK_HEAT_SOURCE_HH
 
 #include <HeatSource.hh>
+
+#include <limits>
 
 namespace adamantine
 {
@@ -47,7 +49,7 @@ public:
 
 private:
   dealii::Point<3> _beam_center;
-  double _alpha;
+  double _alpha = std::numeric_limits<double>::signaling_NaN();
   double const _pi_over_3_to_1p5 = std::pow(dealii::numbers::PI / 3.0, 1.5);
 };
 } // namespace adamantine

--- a/source/ScanPath.hh
+++ b/source/ScanPath.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 - 2021, the adamantine authors.
+/* Copyright (c) 2016 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -17,6 +17,7 @@
 
 #include <iostream>
 #include <istream>
+#include <limits>
 #include <vector>
 
 namespace adamantine
@@ -41,9 +42,11 @@ enum class ScanPathSegmentType
  */
 struct ScanPathSegment
 {
-  double end_time;            // Unit: seconds
-  double power_modifier;      // Dimensionless
-  dealii::Point<3> end_point; // Unit: m
+  double end_time =
+      std::numeric_limits<double>::signaling_NaN(); // Unit: seconds
+  double power_modifier =
+      std::numeric_limits<double>::signaling_NaN(); // Dimensionless
+  dealii::Point<3> end_point;                       // Unit: m
 };
 
 /**

--- a/tests/test_implicit_operator.cc
+++ b/tests/test_implicit_operator.cc
@@ -77,13 +77,14 @@ BOOST_AUTO_TEST_CASE(implicit_operator)
   beam_database.put("depth", 0.1);
   beam_database.put("absorption_efficiency", 0.1);
   beam_database.put("diameter", 1.0);
-  beam_database.put("max_power", 10.);
+  beam_database.put("max_power", 0.);
   beam_database.put("scan_path_file", "scan_path.txt");
   beam_database.put("scan_path_file_format", "segment");
   std::vector<std::shared_ptr<adamantine::HeatSource<2>>> heat_sources;
   heat_sources.resize(1);
   heat_sources[0] =
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
+  heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
   auto thermal_operator = std::make_shared<

--- a/tests/test_thermal_operator.cc
+++ b/tests/test_thermal_operator.cc
@@ -91,13 +91,14 @@ BOOST_AUTO_TEST_CASE(thermal_operator, *utf::tolerance(1e-15))
   beam_database.put("depth", 0.1);
   beam_database.put("absorption_efficiency", 0.1);
   beam_database.put("diameter", 1.0);
-  beam_database.put("max_power", 10.);
+  beam_database.put("max_power", 0.);
   beam_database.put("scan_path_file", "scan_path.txt");
   beam_database.put("scan_path_file_format", "segment");
   std::vector<std::shared_ptr<adamantine::HeatSource<2>>> heat_sources;
   heat_sources.resize(1);
   heat_sources[0] =
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
+  heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
   adamantine::ThermalOperator<2, false, 1, 2, adamantine::SolidLiquidPowder,
@@ -196,13 +197,14 @@ BOOST_AUTO_TEST_CASE(spmv, *utf::tolerance(1e-12))
   beam_database.put("depth", 0.1);
   beam_database.put("absorption_efficiency", 0.1);
   beam_database.put("diameter", 1.0);
-  beam_database.put("max_power", 10.);
+  beam_database.put("max_power", 0.);
   beam_database.put("scan_path_file", "scan_path.txt");
   beam_database.put("scan_path_file_format", "segment");
   std::vector<std::shared_ptr<adamantine::HeatSource<2>>> heat_sources;
   heat_sources.resize(1);
   heat_sources[0] =
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
+  heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
   adamantine::ThermalOperator<2, false, 2, 2, adamantine::SolidLiquidPowder,
@@ -305,13 +307,14 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic, *utf::tolerance(1e-12))
   beam_database.put("depth", 0.1);
   beam_database.put("absorption_efficiency", 0.1);
   beam_database.put("diameter", 1.0);
-  beam_database.put("max_power", 10.);
+  beam_database.put("max_power", 0.);
   beam_database.put("scan_path_file", "scan_path.txt");
   beam_database.put("scan_path_file_format", "segment");
   std::vector<std::shared_ptr<adamantine::HeatSource<2>>> heat_sources;
   heat_sources.resize(1);
   heat_sources[0] =
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
+  heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
   adamantine::ThermalOperator<2, false, 2, 2, adamantine::SolidLiquidPowder,
@@ -612,13 +615,14 @@ BOOST_AUTO_TEST_CASE(spmv_rad, *utf::tolerance(1e-12))
   beam_database.put("depth", 0.1);
   beam_database.put("absorption_efficiency", 0.1);
   beam_database.put("diameter", 1.0);
-  beam_database.put("max_power", 10.);
+  beam_database.put("max_power", 0.);
   beam_database.put("scan_path_file", "scan_path.txt");
   beam_database.put("scan_path_file_format", "segment");
   std::vector<std::shared_ptr<adamantine::HeatSource<2>>> heat_sources;
   heat_sources.resize(1);
   heat_sources[0] =
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
+  heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
   adamantine::ThermalOperator<2, false, 1, 2, adamantine::SolidLiquidPowder,
@@ -796,13 +800,14 @@ BOOST_AUTO_TEST_CASE(spmv_conv, *utf::tolerance(1e-12))
   beam_database.put("depth", 0.1);
   beam_database.put("absorption_efficiency", 0.1);
   beam_database.put("diameter", 1.0);
-  beam_database.put("max_power", 10.);
+  beam_database.put("max_power", 0.);
   beam_database.put("scan_path_file", "scan_path.txt");
   beam_database.put("scan_path_file_format", "segment");
   std::vector<std::shared_ptr<adamantine::HeatSource<2>>> heat_sources;
   heat_sources.resize(1);
   heat_sources[0] =
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
+  heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
   adamantine::ThermalOperator<2, false, 1, 2, adamantine::SolidLiquidPowder,

--- a/tests/test_thermal_operator_device.cc
+++ b/tests/test_thermal_operator_device.cc
@@ -282,13 +282,14 @@ BOOST_AUTO_TEST_CASE(mf_spmv, *utf::tolerance(1.5e-12))
   beam_database.put("depth", 0.1);
   beam_database.put("absorption_efficiency", 0.1);
   beam_database.put("diameter", 1.0);
-  beam_database.put("max_power", 10.);
+  beam_database.put("max_power", 0.);
   beam_database.put("scan_path_file", "scan_path.txt");
   beam_database.put("scan_path_file_format", "segment");
   std::vector<std::shared_ptr<adamantine::HeatSource<2>>> heat_sources;
   heat_sources.resize(1);
   heat_sources[0] =
       std::make_shared<adamantine::GoldakHeatSource<2>>(beam_database);
+  heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
   adamantine::ThermalOperatorDevice<2, false, 4, 2,


### PR DESCRIPTION
I found the cause of the random failings in the CI. In some tests, we forgot to set the time at which the source should be evaluated. I have initialized member data in the sources to NaN which allowed me to find errors in `test_thermal_operator_device` and `test_implicit_operator` on top  of the known issue with `test_thermal_operator`.