### PR TITLE
Add support for the on-the-fly update of the scan path

### DIFF
--- a/source/HeatSource.hh
+++ b/source/HeatSource.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 - 2021, the adamantine authors.
+/* Copyright (c) 2020 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -77,7 +77,7 @@ public:
   /**
    * Return the scan path for the heat source.
    */
-  virtual ScanPath const &get_scan_path() const;
+  virtual ScanPath &get_scan_path();
 
   /**
    * Compute the current height of the where the heat source meets the material
@@ -104,7 +104,7 @@ protected:
 };
 
 template <int dim>
-inline ScanPath const &HeatSource<dim>::get_scan_path() const
+inline ScanPath &HeatSource<dim>::get_scan_path()
 {
   return _scan_path;
 }

--- a/source/ScanPath.hh
+++ b/source/ScanPath.hh
@@ -11,13 +11,8 @@
 #include <deal.II/base/function.h>
 #include <deal.II/base/point.h>
 
-#include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/property_tree/ptree.hpp>
-
-#include <iostream>
-#include <istream>
 #include <limits>
+#include <string>
 #include <vector>
 
 namespace adamantine
@@ -78,41 +73,36 @@ public:
   ScanPath(std::string scan_path_file, std::string file_format);
 
   /**
-   * Calculates the location of the scan path at a given time for a single
+   * Calculate the location of the scan path at a given time for a single
    * coordinate.
    */
   dealii::Point<3> value(double const &time) const;
 
   /**
-   * Returns the power coefficient for the current segment
+   * Return the power coefficient for the current segment
    */
   double get_power_modifier(double const &time) const;
 
   /**
-   * Returns the scan path's list of segments
+   * Return the scan path's list of segments
    */
   std::vector<ScanPathSegment> get_segment_list() const;
 
+  /**
+   * Read the scan path file and update the list of segments.
+   */
+  void read_file();
+
 private:
-  /**
-   * The list of information about each segment in the scan path.
-   */
-  std::vector<ScanPathSegment> _segment_list;
-
-  /**
-   * The index of the current segment in the scan path.
-   */
-  mutable unsigned int _current_segment = 0;
-
   /**
    * Method to load a "segment" scan path file
    */
-  void load_segment_scan_path(std::string scan_path_file);
+  void load_segment_scan_path();
 
   /**
    * Method to load an "event series" scan path file
    */
-  void load_event_series_scan_path(std::string scan_path_file);
+  void load_event_series_scan_path();
 
   /**
    * Method to determine the current segment, its start point, and start time.
@@ -120,6 +110,23 @@ private:
   void update_current_segment_info(double time,
                                    dealii::Point<3> &segment_start_point,
                                    double &segment_start_time) const;
+
+  /**
+   * File name of the scan path
+   */
+  std::string _scan_path_file;
+  /**
+   * Format of the scan path file, either segment of event_series.
+   */
+  std::string _file_format;
+  /**
+   * The list of information about each segment in the scan path.
+   */
+  std::vector<ScanPathSegment> _segment_list;
+  /**
+   * The index of the current segment in the scan path.
+   */
+  mutable unsigned int _current_segment = 0;
 };
 } // namespace adamantine
 


### PR DESCRIPTION
@stvdwtt can you try this PR. With it you shouldn't need to restart adamantine to update the scan path.