### PR TITLE
Restart fixes for experimental data and ensembles

### DIFF
--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -1482,6 +1482,7 @@ run_ensemble(MPI_Comm const &global_communicator,
     // PropertyTreeInput checkpoint.time_steps_between_checkpoint
     time_steps_checkpoint =
         checkpoint_database.get<unsigned int>("time_steps_between_checkpoint");
+    // PropertyTreeInput checkpoint.filename_prefix
     checkpoint_filename =
         checkpoint_database.get<std::string>("filename_prefix");
     // PropertyTreeInput checkpoint.overwrite_files


### PR DESCRIPTION
This PR makes two small fixes involving restart:
- It removes the rank id from checkpoint filenames, this isn't needed and prevents loading the checkpoint at restart.
- It advances the experimental frame as necessary upon restart. Before this PR the code aborts when restarting after an experimental frame because it identifies an old, unassimilated frame.

I had to move the experiment block to after the restart block in initialization, this shows up in git as a somewhat convoluted change.