### PR TITLE
Improve support for scan path update

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ The following options are available:
   * method: name of the method to use for the time integration: forward\_euler,
   rk\_third\_order, rk\_fourth\_order, backward\_euler, implicit\_midpoint, 
   crank\_nicolson, or sdirk2 (required)
-  * duration: duration of the simulation in seconds (required)
+  * scan\_path\_for\_duration: if the flag is true, the duration of the simulation is determined by the duration of the scan path. In this case the scan path file needs to contain SCAN\_PATH\_END to terminate the simulation. If the flag is false, the duration of the simulation is determined by the duration input (default value: false)
+  * duration: duration of the simulation in seconds (required if scan\_path\_for\_duration is false)
   * time\_step: length of the time steps used for the simulation in seconds (required)
   * for implicit method:
     * max\_iteration: mamximum number of the iterations of the linear solver

--- a/source/ScanPath.hh
+++ b/source/ScanPath.hh
@@ -11,6 +11,7 @@
 #include <deal.II/base/function.h>
 #include <deal.II/base/point.h>
 
+#include <filesystem>
 #include <limits>
 #include <string>
 #include <vector>
@@ -93,6 +94,11 @@ public:
    */
   void read_file();
 
+  /**
+   * Return true if we reach the end of the scan path.
+   */
+  bool is_finished() const;
+
 private:
   /**
    * Method to load a "segment" scan path file
@@ -112,6 +118,10 @@ private:
                                    double &segment_start_time) const;
 
   /**
+   * Flag is true if we have reached the end of _scan_path_file.
+   */
+  bool _scan_path_end = false;
+  /**
    * File name of the scan path
    */
   std::string _scan_path_file;
@@ -119,6 +129,10 @@ private:
    * Format of the scan path file, either segment of event_series.
    */
   std::string _file_format;
+  /**
+   * Time the last time _scan_path_file was updated.
+   */
+  std::filesystem::file_time_type _last_write_time;
   /**
    * The list of information about each segment in the scan path.
    */

--- a/source/utils.hh
+++ b/source/utils.hh
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 - 2023, the adamantine authors.
+/* Copyright (c) 2016 - 2024, the adamantine authors.
  *
  * This file is subject to the Modified BSD License and may not be distributed
  * without copyright and license information. Please refer to the file LICENSE
@@ -36,6 +36,36 @@ inline void wait_for_file(std::string const &filename,
       std::cout << message << std::endl;
     ++counter;
   }
+}
+
+/**
+ * Wait for the file to be updated.
+ */
+inline void
+wait_for_file_to_update(std::string const &filename, std::string const &message,
+                        std::filesystem::file_time_type &last_write_time)
+{
+  unsigned int counter = 1;
+  // We check when the file was last written to know if he file was updated.
+  // When the file is being overwritten, the last_write_time() function throws
+  // an error. Since it's an "expected" behavior, we just catch the error keep
+  // working.
+  try
+  {
+    while (std::filesystem::last_write_time(filename) == last_write_time)
+    {
+      // Spin loop waiting for the file to be updated (message printed if
+      // counter overflows)
+      if (counter == 0)
+        std::cout << message << std::endl;
+      ++counter;
+    }
+  }
+  catch (std::filesystem::filesystem_error)
+  {
+    // No-op
+  }
+  last_write_time = std::filesystem::last_write_time(filename);
 }
 
 #define ASSERT(condition, message) assert((condition) && (message))

--- a/source/validate_input_database.cc
+++ b/source/validate_input_database.cc
@@ -373,8 +373,11 @@ void validate_input_database(boost::property_tree::ptree &database)
                    "'rk_third_order', 'rk_fourth_order', 'backward_euler', "
                    "'implicit_midpoint', 'crank_nicolson', and 'sdirk2'.");
 
-  ASSERT_THROW(database.get<double>("time_stepping.duration") >= 0.0,
-               "Error: Time stepping duration must be non-negative.");
+  if (database.get("time.scan_path_for_duration", false))
+  {
+    ASSERT_THROW(database.get<double>("time_stepping.duration") >= 0.0,
+                 "Error: Time stepping duration must be non-negative.");
+  }
 
   ASSERT_THROW(database.get<double>("time_stepping.time_step") >= 0.0,
                "Error: Time step must be non-negative.");


### PR DESCRIPTION
With this PR, we stop reading the scan path when we read `SCAN_PATH_END`. When using `segment scan path`, we need the number of segments to be at least equal to number of  segments + 1. Otherwise we won't read the `SCAN_PATH_END` line.

@stvdwtt can you check that it works as you expect.

Fixes #223  and #272 