### PR TITLE
Cmake adjustments

### DIFF
--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -1,5 +1,14 @@
 # Create adamantine executable and link against the static library.
-add_executable(adamantine adamantine.cc)
+# Create adamantine executable and link against the static library.
+set(Adamantine_app_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/adamantine.hh
+)
+set(Adamantine_app_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/adamantine.cc
+)
+#add_executable(adamantine adamantine.cc)
+add_executable(adamantine ${Adamantine_app_SOURCES} ${Adamantine_app_HEADERS})
+
 set_target_properties(adamantine PROPERTIES
     CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -75,7 +75,7 @@ set(Adamantine_SOURCES
 # Because the Adamantine library is just used to simplify testing, we make it
 # static. Thus, once the application is created it can be moved around. The
 # other libraries can still be shared.
-add_library(Adamantine STATIC ${Adamantine_SOURCES})
+add_library(Adamantine STATIC ${Adamantine_SOURCES} ${Adamantine_HEADERS})
 
 DEAL_II_SETUP_TARGET(Adamantine)
 


### PR DESCRIPTION
IDE wasn't picking up the files for the Adamantine application or the headers. Linking them to the executable makes them show up. 