### PR TITLE
CI: Use -Werror in CPU build

### DIFF
--- a/ci/jenkins_config
+++ b/ci/jenkins_config
@@ -34,7 +34,7 @@ pipeline {
                   -D ADAMANTINE_ENABLE_TESTS=ON \
                   -DADAMANTINE_ENABLE_ADIAK=ON \
                   -DADAMANTINE_ENABLE_CALIPER=ON \
-                  -D CMAKE_CXX_FLAGS="-Wall -Wextra -pedantic" \
+                  -D CMAKE_CXX_FLAGS="-Wall -Wextra -pedantic -Werror" \
                   -D DEAL_II_DIR=${DEAL_II_DIR} \
                   ..
                 '''

--- a/source/MaterialProperty.templates.hh
+++ b/source/MaterialProperty.templates.hh
@@ -230,16 +230,7 @@ void MaterialProperty<dim, p_order, MaterialStates,
 #ifdef ADAMANTINE_DEBUG
   if constexpr (std::is_same_v<MemorySpaceType, dealii::MemorySpace::Host>)
   {
-    auto state = _state;
-    Kokkos::parallel_for(
-        "adamantine::set_state_nan",
-        Kokkos::MDRangePolicy<Kokkos::DefaultHostExecutionSpace,
-                              Kokkos::Rank<2>>(
-            {{0, 0}}, {{MaterialStates::n_material_states,
-                        static_cast<int>(_dofs_map.size())}}),
-        KOKKOS_LAMBDA(int i, int j) {
-          state(i, j) = std::numeric_limits<double>::signaling_NaN();
-        });
+    Kokkos::deep_copy(_state, std::numeric_limits<double>::signaling_NaN());
   }
 #endif
 }

--- a/source/utils.hh
+++ b/source/utils.hh
@@ -61,7 +61,7 @@ wait_for_file_to_update(std::string const &filename, std::string const &message,
       ++counter;
     }
   }
-  catch (std::filesystem::filesystem_error)
+  catch (std::filesystem::filesystem_error const &)
   {
     // No-op
   }


### PR DESCRIPTION
We are currently seeing
```
/var/jenkins/workspace/adamantine_PR-303/source/utils.hh:64:27: warning: catching polymorphic type 'class std::filesystem::__cxx11::filesystem_error' by value [-Wcatch-value=]
   64 |   catch (std::filesystem::filesystem_error)
      |                           ^~~~~~~~~~~~~~~~
```
in the CI.