### PR TITLE
Sets adamantine as bin executable in Dockerfile

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -26,3 +26,6 @@ RUN cd /home && git clone https://github.com/adamantine-sim/adamantine && \
       -DADAMANTINE_ENABLE_CALIPER=ON \
     ../ && \
     make && mv bin ../ && cd ../ && rm -r build
+
+# Make adamantine available as executable anywhere in container
+RUN ln -s /home/adamantine/bin/adamantine /bin/adamantine


### PR DESCRIPTION
Work includes:
  - adding a soft link in the Dockerfile for the adamantine executable so that you can just type `adamantine` anywhere in the container to run (instead of requiring to know the path `/home/adamantine/bin/adamantine` as it is currently)

This is mainly to help user experience for those that use the container + other container images that extend from this one (my current use case)

To test:
  - Checkout branch
  - Run `docker build -t adamantine-image -f ./ci/Dockerfile .` to build the container image
  - Run `docker run adamantine-image adamantine` to test executable is available from default directory
  - Run `docker run adamantine-image -w /change/to/path /bin/bash -c "pwd && adamantine"` to show adamantine is available even in a new directory