### PR TITLE
Fixes HDF5 download site in ci/Dockerfile

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -132,7 +132,7 @@ RUN export P4EST_VERSION=2.3.3 && \
 ENV P4EST_DIR=${INSTALL_DIR}/p4est
 
 RUN export HDF5_VERSION=1.12.0 && \
-    export HDF5_URL=http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-${HDF5_VERSION}/src/hdf5-${HDF5_VERSION}.tar.bz2 && \
+    export HDF5_URL=https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-${HDF5_VERSION}/src/hdf5-${HDF5_VERSION}.tar.bz2 && \
     export HDF5_MD5=1fa68c4b11b6ef7a9d72ffa55995f898 && \
     export HDF5_ARCHIVE=${ARCHIVE_DIR}/hdf5.tar.bz2 && \
     export HDF5_SOURCE_DIR=${SOURCE_DIR}/hdf5 && \


### PR DESCRIPTION
It seems that the link for the HDF5 download site has change for the `ci/Dockerfile`

To check:
  - Clicking on https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-1.12.0/src/hdf5-1.12.0.tar.bz2 will redirect you to https://www.hdfgroup.org/download/hdf5-1-12-0-tar-bz2/
  - Clicking on https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-1.12.0/src/hdf5-1.12.0.tar.bz2 gets you the direct download needed in the Dockerfile

This work includes:
  - Switching the `HDF5_URL` environment variable URL prefix from `http://www.hdfgroup.org` to `https://support.hdfgroup.org` in `ci/Dockerfile`