### PR TITLE
Fix a bug in update_face_state_ratios

### DIFF
--- a/source/ThermalOperator.templates.hh
+++ b/source/ThermalOperator.templates.hh
@@ -351,7 +351,7 @@ void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
   unsigned int constexpr solid =
       static_cast<unsigned int>(MaterialStates::State::solid);
 
-  if constexpr (std::is_same_v<MaterialStates, SolidLiquid>)
+  if constexpr (std::is_same_v<MaterialStates, Solid>)
   {
     // We just nee to fill state_ratios with 1.
     for (unsigned int n = 0; n < face_state_ratios[solid].size(); ++n)


### PR DESCRIPTION
I found the issue with the convective and radiative boundary conditions. There was a bug in `update_face_state_ratios`. We would go through the `Solid` state branch when we had `SolidLiquid` states. Because of that the liquid face state ratio was not initialized and we would get wrong material properties. I am going to rework some of our tests so we can catch that kind of issue next time. 