### PR TITLE
Add changelog for release 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [1.0](https://github.com/adamantine-sim/adamantine/tree/release/1.0) (2024-10-01)
+
+Initial release.


### PR DESCRIPTION
We had the changelog in the release branch but I forgot to cherry-pick it for `master`