### PR TITLE
Fix Doxygen warnings

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -641,7 +641,7 @@ MAX_INITIALIZER_LINES  = 30
 # list will mention the files that were used to generate the documentation.
 # The default value is: YES.
 
-SHOW_USED_FILES        = YES
+SHOW_USED_FILES        = NO
 
 # Set the SHOW_FILES tag to NO to disable the generation of the Files page. This
 # will remove the Files entry from the Quick Index and from the Folder Tree View

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -230,12 +230,6 @@ TAB_SIZE               = 4
 
 ALIASES                =
 
-# This tag can be used to specify a number of word-keyword mappings (TCL only).
-# A mapping has the form "name=value". For example adding "class=itcl::class"
-# will allow you to use the command class in the itcl::class meaning.
-
-TCL_SUBST              =
-
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
 # instance, some of the names that are used will be different. The list of all
@@ -771,7 +765,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = @CMAKE_SOURCE_DIR@/README.md @CMAKE_SOURCE_DIR@/source @CMAKE_SOURCE_DIR@/application
+INPUT                  = @CMAKE_SOURCE_DIR@/doc/README.md @CMAKE_SOURCE_DIR@/source @CMAKE_SOURCE_DIR@/application
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1018,13 +1012,6 @@ VERBATIM_HEADERS       = YES
 # The default value is: YES.
 
 ALPHABETICAL_INDEX     = YES
-
-# The COLS_IN_ALPHA_INDEX tag can be used to specify the number of columns in
-# which the alphabetical index list will be split.
-# Minimum value: 1, maximum value: 20, default value: 5.
-# This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
-
-COLS_IN_ALPHA_INDEX    = 5
 
 # In case all classes in a project start with a common prefix, all classes will
 # be put under the same header in the alphabetical index. The IGNORE_PREFIX tag
@@ -2085,12 +2072,6 @@ EXTERNAL_GROUPS        = YES
 
 EXTERNAL_PAGES         = YES
 
-# The PERL_PATH should be the absolute path and name of the perl script
-# interpreter (i.e. the result of 'which perl').
-# The default file (with absolute path) is: /usr/bin/perl.
-
-PERL_PATH              = /usr/bin/perl
-
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
@@ -2103,15 +2084,6 @@ PERL_PATH              = /usr/bin/perl
 # The default value is: YES.
 
 CLASS_DIAGRAMS         = YES
-
-# You can define message sequence charts within doxygen comments using the \msc
-# command. Doxygen will then run the mscgen tool (see:
-# http://www.mcternan.me.uk/mscgen/)) to produce the chart and insert it in the
-# documentation. The MSCGEN_PATH tag allows you to specify the directory where
-# the mscgen tool resides. If left empty the tool is assumed to be found in the
-# default search path.
-
-MSCGEN_PATH            =
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,2 @@
+This is the documentation for adamantine developers. The user documentation can
+be found at https://adamantine-sim.github.io/adamantine

--- a/source/MaterialProperty.hh
+++ b/source/MaterialProperty.hh
@@ -138,7 +138,7 @@ public:
 
   /**
    * Compute a material property at a quadrature point for a mix of states.
-   * @Note This function is templated on @tparam because it is in a hot loop.
+   * @note This function is templated on @tparam because it is in a hot loop.
    */
   template <bool use_table>
   dealii::VectorizedArray<double> compute_material_property(
@@ -151,7 +151,7 @@ public:
 
   /**
    * Compute a material property at a quadrature point for a mix of states.
-   * @Note This function is templated on @tparam because it is in a hot loop.
+   * @note This function is templated on @tparam because it is in a hot loop.
    */
   template <bool use_table>
   KOKKOS_FUNCTION double

--- a/source/MechanicalOperator.hh
+++ b/source/MechanicalOperator.hh
@@ -89,7 +89,7 @@ public:
 private:
   /**
    * Assemble the matrix and the right-hand-side.
-   * @Note The 2D case does not represent any physical model but it is
+   * @note The 2D case does not represent any physical model but it is
    * convenient for testing.
    */
   void assemble_system(

--- a/source/ScanPath.hh
+++ b/source/ScanPath.hh
@@ -72,7 +72,7 @@ public:
    * \param[in] scan_path_file is the name of the text file containing the scan
    * path
    * \param[in] file_format is the format of the scan path file
-   * \param[in] optional units property tree
+   * \param[in] units_optional_database is the units property tree
    */
   ScanPath(std::string const &scan_path_file, std::string const &file_format,
            boost::optional<boost::property_tree::ptree const &> const

--- a/source/ThermalOperator.hh
+++ b/source/ThermalOperator.hh
@@ -111,7 +111,7 @@ public:
 private:
   /**
    * Update the ratios of the material state.
-   * @Note The input variables are not used when the only valid state is solid.
+   * @note The input variables are not used when the only valid state is solid.
    */
   void update_state_ratios(
       [[maybe_unused]] unsigned int cell, [[maybe_unused]] unsigned int q,
@@ -121,7 +121,7 @@ private:
 
   /**
    * Update the ratios of the material state at the face quadrature points.
-   * @Note The input variables are not used when the only valid state is solid.
+   * @note The input variables are not used when the only valid state is solid.
    */
   void update_face_state_ratios(
       [[maybe_unused]] unsigned int face, [[maybe_unused]] unsigned int q,

--- a/source/ensemble_management.hh
+++ b/source/ensemble_management.hh
@@ -16,7 +16,7 @@ namespace adamantine
 {
 /**
  * Return a vector of size @p length, with random values drawn following a
- * normal distribution of average @p mean and standard deviation @stddev. The
+ * normal distribution of average @p mean and standard deviation @p stddev. The
  * first @p n_rejected_draws are rejected. @p n_rejected_draws is used to
  * ensure that wether we use one MPI rank or ten, we use the same random
  * numbers. If we don't reject the first few draws, all the processors will use


### PR DESCRIPTION
This PR fixes Doxygen and stop printing full path of the directory where the Doxygen documentation was built.