### PR TITLE
Use ArborX to find which cells to refine when using AMR

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,6 @@ The following options are available:
   * additional\_output\_refinement: additional levels of refinement for the output (default: 0)
 * refinement (required):
   * n\_refinements: number of times the cells on the paths of the beams are refined (default value: 2)
-  * beam\_cutoff: the cutoff value of the heat source terms above which beam-based refinement occurs (default value: 1e-15)
   * coarsen\_after\_beam: whether to coarsen cells where the beam has already passed (default value: false)
   * time\_steps\_between\_refinement: number of time steps after which the
   refinement process is performed (default value: 2)

--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -543,6 +543,7 @@ compute_cells_to_refine(
   }
   dealii::ArborXWrappers::BVH bvh(cell_bounding_boxes);
 
+  double const bounding_box_scaling = 2.0;
   std::vector<dealii::BoundingBox<dim>> heat_source_bounding_boxes;
   for (unsigned int i = 0; i < n_time_steps; ++i)
   {
@@ -554,7 +555,8 @@ compute_cells_to_refine(
     for (auto &beam : heat_sources)
     {
       beam->update_time(current_time);
-      heat_source_bounding_boxes.push_back(beam->get_bounding_box());
+      heat_source_bounding_boxes.push_back(
+          beam->get_bounding_box(bounding_box_scaling));
     }
   }
 

--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -22,6 +22,7 @@
 #include <types.hh>
 #include <utils.hh>
 
+#include <deal.II/arborx/bvh.h>
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/symmetric_tensor.h>
@@ -527,45 +528,59 @@ compute_cells_to_refine(
     dealii::parallel::distributed::Triangulation<dim> &triangulation,
     double const time, double const next_refinement_time,
     unsigned int const n_time_steps,
-    std::vector<std::shared_ptr<adamantine::HeatSource<dim>>> &heat_sources,
-    double const current_source_height, double const refinement_beam_cutoff)
+    std::vector<std::shared_ptr<adamantine::HeatSource<dim>>> const
+        &heat_sources)
 {
-
   // Compute the position of the beams between time and next_refinement_time and
-  // refine the mesh where the source is greater than refinement_beam_cutoff.
-  // This cut-off is due to the fact that the source is gaussian and thus never
-  // strictly zero. If the beams intersect, some cells will appear twice in the
-  // vector. This is not a problem.
-  std::vector<typename dealii::parallel::distributed::Triangulation<
-      dim>::active_cell_iterator>
-      cells_to_refine;
+  // create a list of cells that will intersect the beam.
+
+  // Build the bounding boxes associated with the locally owned cells
+  std::vector<dealii::BoundingBox<dim>> cell_bounding_boxes;
+  for (auto const &cell : triangulation.active_cell_iterators() |
+                              dealii::IteratorFilters::LocallyOwnedCell())
+  {
+    cell_bounding_boxes.push_back(cell->bounding_box());
+  }
+  dealii::ArborXWrappers::BVH bvh(cell_bounding_boxes);
+
+  std::vector<dealii::BoundingBox<dim>> heat_source_bounding_boxes;
   for (unsigned int i = 0; i < n_time_steps; ++i)
   {
     double const current_time = time + static_cast<double>(i) /
                                            static_cast<double>(n_time_steps) *
                                            (next_refinement_time - time);
+
+    // Build the bounding boxes associated with the heat sources
     for (auto &beam : heat_sources)
     {
       beam->update_time(current_time);
-      for (auto cell : dealii::filter_iterators(
-               triangulation.active_cell_iterators(),
-               dealii::IteratorFilters::LocallyOwnedCell()))
-      {
-        // Check the value at the center of the cell faces. For most cases this
-        // should be sufficient, but if the beam is small compared to the
-        // coarsest mesh we may need to add other points to check (e.g.
-        // quadrature points, vertices).
-        for (unsigned int f = 0; f < cell->reference_cell().n_faces(); ++f)
-        {
-          if (beam->value(cell->face(f)->center(), current_source_height) >
-              refinement_beam_cutoff)
-          {
-            cells_to_refine.push_back(cell);
-            break;
-          }
-        }
-      }
+      heat_source_bounding_boxes.push_back(beam->get_bounding_box());
     }
+  }
+
+  // Perform the search with ArborX. Since we are only interested in locally
+  // owned cells, we use BVH.
+  dealii::ArborXWrappers::BoundingBoxIntersectPredicate bb_intersect(
+      heat_source_bounding_boxes);
+  auto [indices, offset] = bvh.query(bb_intersect);
+
+  // Put the indices into a set to get rid of the duplicates and to make it
+  // easier to check if the indices are found.
+  std::unordered_set<int> indices_to_refine;
+  indices_to_refine.insert(indices.begin(), indices.end());
+
+  std::vector<typename dealii::parallel::distributed::Triangulation<
+      dim>::active_cell_iterator>
+      cells_to_refine;
+  int cell_index = 0;
+  for (auto const &cell : triangulation.active_cell_iterators() |
+                              dealii::IteratorFilters::LocallyOwnedCell())
+  {
+    if (indices_to_refine.count(cell_index))
+    {
+      cells_to_refine.push_back(cell);
+    }
+    ++cell_index;
   }
 
   return cells_to_refine;
@@ -581,7 +596,8 @@ void refine_mesh(
     adamantine::MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType>
         &material_properties,
     dealii::LA::distributed::Vector<double, MemorySpaceType> &solution,
-    std::vector<std::shared_ptr<adamantine::HeatSource<dim>>> &heat_sources,
+    std::vector<std::shared_ptr<adamantine::HeatSource<dim>>> const
+        &heat_sources,
     double const time, double const next_refinement_time,
     unsigned int const time_steps_refinement,
     boost::property_tree::ptree const &refinement_database)
@@ -595,37 +611,16 @@ void refine_mesh(
           const_cast<dealii::Triangulation<dim> &>(
               dof_handler.get_triangulation()));
 
-  // Refine the mesh along the trajectory of the sources.
-  double current_source_height =
-      dynamic_cast<
-          adamantine::ThermalPhysics<dim, p_order, fe_degree, MaterialStates,
-                                     MemorySpaceType, dealii::QGauss<1>> *>(
-          thermal_physics.get())
-          ? dynamic_cast<adamantine::ThermalPhysics<
-                dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
-                dealii::QGauss<1>> *>(thermal_physics.get())
-                ->get_current_source_height()
-          : dynamic_cast<adamantine::ThermalPhysics<
-                dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
-                dealii::QGaussLobatto<1>> *>(thermal_physics.get())
-                ->get_current_source_height();
-
   // PropertyTreeInput refinement.n_refinements
   unsigned int const n_refinements =
       refinement_database.get("n_refinements", 2);
 
-  // PropertyTreeInput refinement.beam_cutoff
-  const double refinement_beam_cutoff =
-      refinement_database.get<double>("beam_cutoff", 1.0e-15);
-
   for (unsigned int i = 0; i < n_refinements; ++i)
   {
     // Compute the cells to be refined.
-    std::vector<typename dealii::parallel::distributed::Triangulation<
-        dim>::active_cell_iterator>
-        cells_to_refine = compute_cells_to_refine(
-            triangulation, time, next_refinement_time, time_steps_refinement,
-            heat_sources, current_source_height, refinement_beam_cutoff);
+    auto cells_to_refine =
+        compute_cells_to_refine(triangulation, time, next_refinement_time,
+                                time_steps_refinement, heat_sources);
 
     // PropertyTreeInput refinement.coarsen_after_beam
     const bool coarsen_after_beam =
@@ -672,7 +667,8 @@ void refine_mesh(
     adamantine::MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType>
         &material_properties,
     dealii::LA::distributed::Vector<double, MemorySpaceType> &solution,
-    std::vector<std::shared_ptr<adamantine::HeatSource<dim>>> &heat_sources,
+    std::vector<std::shared_ptr<adamantine::HeatSource<dim>>> const
+        &heat_sources,
     double const time, double const next_refinement_time,
     unsigned int const time_steps_refinement,
     boost::property_tree::ptree const &refinement_database)
@@ -1820,6 +1816,7 @@ run_ensemble(MPI_Comm const &global_communicator,
   // For now assume that all ensemble members share the same geometry (they
   // have independent adamantine::Geometry objects, but all are constructed
   // from identical parameters), base new additions on the 0th ensemble member
+  // since all the sources use the same scan path.
   auto [material_deposition_boxes, deposition_times, deposition_cos,
         deposition_sin] =
       adamantine::create_material_deposition_boxes<dim>(
@@ -1837,6 +1834,14 @@ run_ensemble(MPI_Comm const &global_communicator,
             material_deposition_boxes);
   }
   timers[adamantine::add_material_search].stop();
+
+  // ----- Compute bounding heat sources -----
+  // When using AMR, we refine the cells that the heat sources intersect. Since
+  // each ensemble members can have slightly different sources, we create a new
+  // set of heat sources that encompasses the member sources. We use these new
+  // sources when refining the mesh.
+  auto bounding_heat_sources = adamantine::get_bounding_heat_sources<dim>(
+      database_ensemble, global_communicator);
 
   // ----- Main time stepping loop -----
   if (global_rank == 0)
@@ -1871,7 +1876,7 @@ run_ensemble(MPI_Comm const &global_communicator,
         refine_mesh(thermal_physics_ensemble[member], dummy,
                     *material_properties_ensemble[member],
                     solution_augmented_ensemble[member].block(base_state),
-                    heat_sources_ensemble[member], time, next_refinement_time,
+                    bounding_heat_sources, time, next_refinement_time,
                     time_steps_refinement, refinement_database);
         solution_augmented_ensemble[member].collect_sizes();
       }

--- a/source/BeamHeatSourceProperties.hh
+++ b/source/BeamHeatSourceProperties.hh
@@ -59,8 +59,8 @@ public:
     // PropertyTreeInput sources.beam_X.absorption_efficiency
     absorption_efficiency = database.get<double>("absorption_efficiency");
     // PropertyTreeInput sources.beam_X.diameter
-    radius_squared = std::pow(
-        database.get<double>("diameter") * _dimension_scaling / 2.0, 2);
+    radius = database.get<double>("diameter") * _dimension_scaling / 2.0;
+    radius_squared = std::pow(radius, 2);
     // PropertyTreeInput sources.beam_X.max_power
     max_power = database.get<double>("max_power") * _power_scaling;
   }
@@ -74,7 +74,10 @@ public:
    * Energy conversion efficiency on the surface.
    */
   double absorption_efficiency = 0.;
-
+  /**
+   * Beam radius.
+   */
+  double radius = 0.;
   /**
    * Square of the beam radius.
    */

--- a/source/CubeHeatSource.cc
+++ b/source/CubeHeatSource.cc
@@ -35,7 +35,7 @@ CubeHeatSource<dim>::CubeHeatSource(
   _max_point[0] = source_database.get<double>("max_x") * dimension_scaling;
   _min_point[1] = source_database.get<double>("min_y") * dimension_scaling;
   _max_point[1] = source_database.get<double>("max_y") * dimension_scaling;
-  if (dim == 3)
+  if constexpr (dim == 3)
   {
     _min_point[2] = source_database.get<double>("min_z") * dimension_scaling;
     _max_point[2] = source_database.get<double>("max_z") * dimension_scaling;
@@ -75,6 +75,20 @@ template <int dim>
 double CubeHeatSource<dim>::get_current_height(double const /*time*/) const
 {
   return _max_point[axis<dim>::z];
+}
+
+template <int dim>
+dealii::BoundingBox<dim> CubeHeatSource<dim>::get_bounding_box() const
+{
+  if constexpr (dim == 2)
+  {
+    return {{{_min_point[0], _min_point[1]}, {_max_point[0], _max_point[1]}}};
+  }
+  else
+  {
+    return {{{_min_point[0], _min_point[1], _min_point[2]},
+             {_max_point[0], _max_point[1], _max_point[2]}}};
+  }
 }
 
 } // namespace adamantine

--- a/source/CubeHeatSource.cc
+++ b/source/CubeHeatSource.cc
@@ -78,7 +78,8 @@ double CubeHeatSource<dim>::get_current_height(double const /*time*/) const
 }
 
 template <int dim>
-dealii::BoundingBox<dim> CubeHeatSource<dim>::get_bounding_box() const
+dealii::BoundingBox<dim>
+CubeHeatSource<dim>::get_bounding_box(double const /*scaling_factor*/) const
 {
   if constexpr (dim == 2)
   {

--- a/source/CubeHeatSource.hh
+++ b/source/CubeHeatSource.hh
@@ -53,7 +53,8 @@ public:
    */
   double get_current_height(double const time) const final;
 
-  dealii::BoundingBox<dim> get_bounding_box() const final;
+  dealii::BoundingBox<dim>
+  get_bounding_box(double const scaling_factor) const final;
 
 private:
   bool _source_on = false;

--- a/source/CubeHeatSource.hh
+++ b/source/CubeHeatSource.hh
@@ -53,6 +53,8 @@ public:
    */
   double get_current_height(double const time) const final;
 
+  dealii::BoundingBox<dim> get_bounding_box() const final;
+
 private:
   bool _source_on = false;
   double _start_time;

--- a/source/ElectronBeamHeatSource.cc
+++ b/source/ElectronBeamHeatSource.cc
@@ -61,22 +61,23 @@ double ElectronBeamHeatSource<dim>::value(dealii::Point<dim> const &point,
 }
 
 template <int dim>
-dealii::BoundingBox<dim> ElectronBeamHeatSource<dim>::get_bounding_box() const
+dealii::BoundingBox<dim>
+ElectronBeamHeatSource<dim>::get_bounding_box(double const scaling_factor) const
 {
   if constexpr (dim == 2)
   {
-    return {{{_beam_center[axis<dim>::x] - this->_beam.radius,
-              _beam_center[axis<dim>::z] - this->_beam.depth},
-             {_beam_center[axis<dim>::x] + this->_beam.radius,
+    return {{{_beam_center[axis<dim>::x] - scaling_factor * this->_beam.radius,
+              _beam_center[axis<dim>::z] - scaling_factor * this->_beam.depth},
+             {_beam_center[axis<dim>::x] + scaling_factor * this->_beam.radius,
               _beam_center[axis<dim>::z]}}};
   }
   else
   {
-    return {{{_beam_center[axis<dim>::x] - this->_beam.radius,
-              _beam_center[axis<dim>::y] - this->_beam.radius,
-              _beam_center[axis<dim>::z] - this->_beam.depth},
-             {_beam_center[axis<dim>::x] + this->_beam.radius,
-              _beam_center[axis<dim>::y] + this->_beam.radius,
+    return {{{_beam_center[axis<dim>::x] - scaling_factor * this->_beam.radius,
+              _beam_center[axis<dim>::y] - scaling_factor * this->_beam.radius,
+              _beam_center[axis<dim>::z] - scaling_factor * this->_beam.depth},
+             {_beam_center[axis<dim>::x] + scaling_factor * this->_beam.radius,
+              _beam_center[axis<dim>::y] + scaling_factor * this->_beam.radius,
               _beam_center[axis<dim>::z]}}};
   }
 }

--- a/source/ElectronBeamHeatSource.cc
+++ b/source/ElectronBeamHeatSource.cc
@@ -45,7 +45,7 @@ double ElectronBeamHeatSource<dim>::value(dealii::Point<dim> const &point,
 
     double xpy_squared =
         std::pow(point[axis<dim>::x] - _beam_center[axis<dim>::x], 2);
-    if (dim == 3)
+    if constexpr (dim == 3)
     {
       xpy_squared +=
           std::pow(point[axis<dim>::y] - _beam_center[axis<dim>::y], 2);
@@ -57,6 +57,27 @@ double ElectronBeamHeatSource<dim>::value(dealii::Point<dim> const &point,
         distribution_z;
 
     return heat_source;
+  }
+}
+
+template <int dim>
+dealii::BoundingBox<dim> ElectronBeamHeatSource<dim>::get_bounding_box() const
+{
+  if constexpr (dim == 2)
+  {
+    return {{{_beam_center[axis<dim>::x] - this->_beam.radius,
+              _beam_center[axis<dim>::z] - this->_beam.depth},
+             {_beam_center[axis<dim>::x] + this->_beam.radius,
+              _beam_center[axis<dim>::z]}}};
+  }
+  else
+  {
+    return {{{_beam_center[axis<dim>::x] - this->_beam.radius,
+              _beam_center[axis<dim>::y] - this->_beam.radius,
+              _beam_center[axis<dim>::z] - this->_beam.depth},
+             {_beam_center[axis<dim>::x] + this->_beam.radius,
+              _beam_center[axis<dim>::y] + this->_beam.radius,
+              _beam_center[axis<dim>::z]}}};
   }
 }
 } // namespace adamantine

--- a/source/ElectronBeamHeatSource.hh
+++ b/source/ElectronBeamHeatSource.hh
@@ -50,7 +50,8 @@ public:
   double value(dealii::Point<dim> const &point,
                double const height) const final;
 
-  dealii::BoundingBox<dim> get_bounding_box() const final;
+  dealii::BoundingBox<dim>
+  get_bounding_box(double const scaling_factor) const final;
 
 private:
   dealii::Point<3> _beam_center;

--- a/source/ElectronBeamHeatSource.hh
+++ b/source/ElectronBeamHeatSource.hh
@@ -50,6 +50,8 @@ public:
   double value(dealii::Point<dim> const &point,
                double const height) const final;
 
+  dealii::BoundingBox<dim> get_bounding_box() const final;
+
 private:
   dealii::Point<3> _beam_center;
   double _alpha = std::numeric_limits<double>::signaling_NaN();

--- a/source/GoldakHeatSource.cc
+++ b/source/GoldakHeatSource.cc
@@ -57,22 +57,23 @@ double GoldakHeatSource<dim>::value(dealii::Point<dim> const &point,
 }
 
 template <int dim>
-dealii::BoundingBox<dim> GoldakHeatSource<dim>::get_bounding_box() const
+dealii::BoundingBox<dim>
+GoldakHeatSource<dim>::get_bounding_box(double const scaling_factor) const
 {
   if constexpr (dim == 2)
   {
-    return {{{_beam_center[axis<dim>::x] - this->_beam.radius,
-              _beam_center[axis<dim>::z] - this->_beam.depth},
-             {_beam_center[axis<dim>::x] + this->_beam.radius,
+    return {{{_beam_center[axis<dim>::x] - scaling_factor * this->_beam.radius,
+              _beam_center[axis<dim>::z] - scaling_factor * this->_beam.depth},
+             {_beam_center[axis<dim>::x] + scaling_factor * this->_beam.radius,
               _beam_center[axis<dim>::z]}}};
   }
   else
   {
-    return {{{_beam_center[axis<dim>::x] - this->_beam.radius,
-              _beam_center[axis<dim>::y] - this->_beam.radius,
-              _beam_center[axis<dim>::z] - this->_beam.depth},
-             {_beam_center[axis<dim>::x] + this->_beam.radius,
-              _beam_center[axis<dim>::y] + this->_beam.radius,
+    return {{{_beam_center[axis<dim>::x] - scaling_factor * this->_beam.radius,
+              _beam_center[axis<dim>::y] - scaling_factor * this->_beam.radius,
+              _beam_center[axis<dim>::z] - scaling_factor * this->_beam.depth},
+             {_beam_center[axis<dim>::x] + scaling_factor * this->_beam.radius,
+              _beam_center[axis<dim>::y] + scaling_factor * this->_beam.radius,
               _beam_center[axis<dim>::z]}}};
   }
 }

--- a/source/GoldakHeatSource.cc
+++ b/source/GoldakHeatSource.cc
@@ -55,6 +55,28 @@ double GoldakHeatSource<dim>::value(dealii::Point<dim> const &point,
     return heat_source;
   }
 }
+
+template <int dim>
+dealii::BoundingBox<dim> GoldakHeatSource<dim>::get_bounding_box() const
+{
+  if constexpr (dim == 2)
+  {
+    return {{{_beam_center[axis<dim>::x] - this->_beam.radius,
+              _beam_center[axis<dim>::z] - this->_beam.depth},
+             {_beam_center[axis<dim>::x] + this->_beam.radius,
+              _beam_center[axis<dim>::z]}}};
+  }
+  else
+  {
+    return {{{_beam_center[axis<dim>::x] - this->_beam.radius,
+              _beam_center[axis<dim>::y] - this->_beam.radius,
+              _beam_center[axis<dim>::z] - this->_beam.depth},
+             {_beam_center[axis<dim>::x] + this->_beam.radius,
+              _beam_center[axis<dim>::y] + this->_beam.radius,
+              _beam_center[axis<dim>::z]}}};
+  }
+}
+
 } // namespace adamantine
 
 INSTANTIATE_DIM(GoldakHeatSource)

--- a/source/GoldakHeatSource.hh
+++ b/source/GoldakHeatSource.hh
@@ -49,6 +49,8 @@ public:
   double value(dealii::Point<dim> const &point,
                double const height) const final;
 
+  dealii::BoundingBox<dim> get_bounding_box() const final;
+
 private:
   dealii::Point<3> _beam_center;
   double _alpha = std::numeric_limits<double>::signaling_NaN();

--- a/source/GoldakHeatSource.hh
+++ b/source/GoldakHeatSource.hh
@@ -49,7 +49,8 @@ public:
   double value(dealii::Point<dim> const &point,
                double const height) const final;
 
-  dealii::BoundingBox<dim> get_bounding_box() const final;
+  dealii::BoundingBox<dim>
+  get_bounding_box(double const scaling_factor) const final;
 
 private:
   dealii::Point<3> _beam_center;

--- a/source/HeatSource.hh
+++ b/source/HeatSource.hh
@@ -9,6 +9,7 @@
 #include <ScanPath.hh>
 #include <types.hh>
 
+#include <deal.II/base/bounding_box.h>
 #include <deal.II/base/point.h>
 
 namespace adamantine
@@ -93,6 +94,11 @@ public:
    * beam parameters vary in time (e.g. due to data assimilation).
    */
   virtual void set_beam_properties(boost::property_tree::ptree const &database);
+
+  /**
+   * Return a bounding box of the heat source.
+   */
+  virtual dealii::BoundingBox<dim> get_bounding_box() const = 0;
 
 protected:
   /**

--- a/source/HeatSource.hh
+++ b/source/HeatSource.hh
@@ -96,9 +96,10 @@ public:
   virtual void set_beam_properties(boost::property_tree::ptree const &database);
 
   /**
-   * Return a bounding box of the heat source.
+   * Return a scaled bounding box of the heat source.
    */
-  virtual dealii::BoundingBox<dim> get_bounding_box() const = 0;
+  virtual dealii::BoundingBox<dim>
+  get_bounding_box(double const scaling_factor) const = 0;
 
 protected:
   /**

--- a/source/ensemble_management.cc
+++ b/source/ensemble_management.cc
@@ -1,9 +1,14 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2021-2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2021-2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
+#include <CubeHeatSource.hh>
+#include <ElectronBeamHeatSource.hh>
+#include <GoldakHeatSource.hh>
 #include <ensemble_management.hh>
 #include <utils.hh>
+
+#include <random>
 
 namespace adamantine
 {
@@ -43,4 +48,125 @@ std::vector<double> get_normal_random_vector(unsigned int length,
   return output_vector;
 }
 
+template <int dim>
+std::vector<std::shared_ptr<HeatSource<dim>>> get_bounding_heat_sources(
+    std::vector<boost::property_tree::ptree> const &database_ensemble,
+    MPI_Comm global_communicator)
+{
+  // To bound the volumes of the Goldak and electron beam sources, we just need
+  // to know their diameter and their depths. This is not enough for the cube
+  // source but because the source is static and only use for testing, we just
+  // assume that the source is identical for all ensemble members.
+  // Use a std::vector instead of std::pair so deal.II can serialize the object.
+  std::vector<std::vector<std::vector<double>>> diameter_depth_ensemble;
+  for (auto const &database : database_ensemble)
+  {
+    std::vector<std::vector<double>> diameter_depth_beams;
+    boost::property_tree::ptree const &source_database =
+        database.get_child("sources");
+    // PropertyTreeInput sources.n_beams
+    unsigned int const n_beams = source_database.get<unsigned int>("n_beams");
+    for (unsigned int i = 0; i < n_beams; ++i)
+    {
+      boost::property_tree::ptree const &beam_database =
+          source_database.get_child("beam_" + std::to_string(i));
+
+      // PropertyTreeInput sources.beam_X.type
+      std::string type = beam_database.get<std::string>("type");
+      if (type != "cube")
+      {
+        // PropertyTreeInput sources.beam_X.diameter
+        double diameter = beam_database.get<double>("diameter");
+        // PropertyTreeInput sources.beam_X.depth
+        double depth = beam_database.get<double>("diameter");
+        diameter_depth_beams.push_back({diameter, depth});
+      }
+    }
+    diameter_depth_ensemble.push_back(diameter_depth_beams);
+  }
+
+  // Use all_gather to communicate the diameters and the depths
+  auto all_diameter_depth = dealii::Utilities::MPI::all_gather(
+      global_communicator, diameter_depth_ensemble);
+
+  // Compute the maximum diameter and depth
+  std::vector<double> diameter_max(diameter_depth_ensemble[0].size(), -1.);
+  std::vector<double> depth_max(diameter_depth_ensemble[0].size(), -1.);
+  for (auto const &diameter_depth_rank : all_diameter_depth)
+  {
+    for (unsigned int member = 0; member < diameter_depth_rank.size(); ++member)
+    {
+      for (unsigned int beam = 0; beam < diameter_depth_rank[member].size();
+           ++beam)
+      {
+        if (diameter_depth_rank[member][beam][0] > diameter_max[beam])
+        {
+          diameter_max[beam] = diameter_depth_rank[member][beam][0];
+        }
+        if (diameter_depth_rank[member][beam][1] > depth_max[beam])
+        {
+          depth_max[beam] = diameter_depth_rank[member][beam][1];
+        }
+      }
+    }
+  }
+
+  // Get the units database
+  boost::optional<boost::property_tree::ptree const &> units_optional_database =
+      database_ensemble[0].get_child_optional("units");
+
+  // Create the bounding sources
+  boost::property_tree::ptree const &source_database =
+      database_ensemble[0].get_child("sources");
+  // PropertyTreeInput sources.n_beams
+  unsigned int const n_beams = source_database.get<unsigned int>("n_beams");
+  std::vector<std::shared_ptr<HeatSource<dim>>> bounding_heat_sources(n_beams);
+  unsigned int bounding_source = 0;
+  for (unsigned int i = 0; i < n_beams; ++i)
+  {
+    boost::property_tree::ptree const &beam_database =
+        source_database.get_child("beam_" + std::to_string(i));
+
+    // PropertyTreeInput sources.beam_X.type
+    std::string type = beam_database.get<std::string>("type");
+    if (type == "goldak")
+    {
+      boost::property_tree::ptree modified_beam_database = beam_database;
+      modified_beam_database.put("diameter", diameter_max[bounding_source]);
+      modified_beam_database.put("depth", depth_max[bounding_source]);
+      ++bounding_source;
+
+      bounding_heat_sources[i] = std::make_shared<GoldakHeatSource<dim>>(
+          modified_beam_database, units_optional_database);
+    }
+    else if (type == "electron_beam")
+    {
+      boost::property_tree::ptree modified_beam_database = beam_database;
+      modified_beam_database.put("diameter", diameter_max[bounding_source]);
+      modified_beam_database.put("depth", depth_max[bounding_source]);
+      ++bounding_source;
+
+      bounding_heat_sources[i] = std::make_shared<ElectronBeamHeatSource<dim>>(
+          modified_beam_database, units_optional_database);
+    }
+    else if (type == "cube")
+    {
+      bounding_heat_sources[i] = std::make_shared<CubeHeatSource<dim>>(
+          beam_database, units_optional_database);
+    }
+  }
+
+  return bounding_heat_sources;
+}
+} // namespace adamantine
+
+//-------------------- Explicit Instantiations --------------------//
+namespace adamantine
+{
+template std::vector<std::shared_ptr<HeatSource<2>>> get_bounding_heat_sources(
+    std::vector<boost::property_tree::ptree> const &property_trees,
+    MPI_Comm global_communicator);
+template std::vector<std::shared_ptr<HeatSource<3>>> get_bounding_heat_sources(
+    std::vector<boost::property_tree::ptree> const &property_trees,
+    MPI_Comm global_communicator);
 } // namespace adamantine

--- a/source/ensemble_management.hh
+++ b/source/ensemble_management.hh
@@ -1,14 +1,19 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2021-2023, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2021-2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #ifndef ENSEMBLE_MANAGEMENT_HH
 #define ENSEMBLE_MANAGEMENT_HH
 
+#include <HeatSource.hh>
+
 #include <deal.II/base/mpi.h>
 
-#include <random>
+#include <boost/property_tree/ptree.hpp>
+
+#include <memory>
 #include <vector>
+
 namespace adamantine
 {
 /**
@@ -25,6 +30,15 @@ std::vector<double> get_normal_random_vector(unsigned int length,
                                              unsigned int n_rejected_draws,
                                              double mean, double stddev,
                                              bool verbose);
+
+/**
+ * Return the sources encompassing all the sources of the different ensemble
+ * members.
+ */
+template <int dim>
+std::vector<std::shared_ptr<HeatSource<dim>>> get_bounding_heat_sources(
+    std::vector<boost::property_tree::ptree> const &property_trees,
+    MPI_Comm global_communicator);
 } // namespace adamantine
 
 #endif

--- a/source/validate_input_database.cc
+++ b/source/validate_input_database.cc
@@ -309,14 +309,6 @@ void validate_input_database(boost::property_tree::ptree &database)
   ASSERT_THROW(database.count("refinement") != 0,
                "Error: A refinement section of the input file must exist.");
 
-  boost::optional<double> beam_cutoff_optional =
-      database.get_optional<double>("beam_cutoff");
-  if (beam_cutoff_optional)
-  {
-    ASSERT_THROW(beam_cutoff_optional.get() >= 0.0,
-                 "Error: The refinement beam cutoff must be non-negative.");
-  }
-
   // Tree: sources
   unsigned int n_beams = database.get<unsigned int>("sources.n_beams");
   for (unsigned int beam_index = 0; beam_index < n_beams; ++beam_index)


### PR DESCRIPTION
There are two problems with the way AMR currently works:
 1. each member refines its own mesh and therefore we cannot guarantee that all the members use the exact same mesh
 2. the way we flag the cells for refinement is very inefficient. For each time step, we loop over the entire mesh to build a list of the cells that we need to refine.

To fix problem 1., we build bounding sources that bound the sources of all the ensemble members. We use these common sources to determine which cells need to be refined.

To fix problem 2., we use ArborX to compute the intersections of the bounding sources with the mesh. I decided to accumulated all the bounding sources before calling ArborX. This is to avoid calling ArborX with a single bounding box. In my tests, this works well if the number of time steps between refinement is in the order of 100 000 or lower. For higher number of time steps, building the bounding boxes requires quite a bit of memory. If it's a problem in practice, we can revisit this.