### PR TITLE
Fix input file when using temperature-dependent materiel properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The following options are available:
     * width\_divisions: number of cell layers in width (only in 3D) (default value: 10)
 * materials (required):
   * n\_materials: number of materials (required)
-  * property\_format: format of the material property: table or polynomial (required)
+  * property\_format: format of the material property: `table` or `polynomial`. For `table`, the format of the matieral properties is as follows: `temperature_1,value_1|temperature_2,value_2|...` with `temperature_1 < temperature_2`. For `polynomial`, the format is as follows: `coeff_0,coeff_1,coeff_2` where `coeff_0` is the coefficient of `T^0`, `coeff_1` is the coefficient of `T^1`, etc  (required)
   * initial\_temperature: initial temperature of all the materials in kelvins (default value: 300)
   * new\_material\_temperature: temperature of all the material that is being added during the process in kelvins (default value: 300)
   * material\_X: property tree for the material with number X

--- a/source/MaterialProperty.hh
+++ b/source/MaterialProperty.hh
@@ -43,7 +43,7 @@ public:
    * Size of the table, i.e. number of temperature/property pairs, used to
    * describe the material properties.
    */
-  static unsigned int constexpr table_size = 4;
+  static unsigned int constexpr table_size = 12;
 
   /**
    * Constructor.

--- a/source/MaterialProperty.templates.hh
+++ b/source/MaterialProperty.templates.hh
@@ -868,7 +868,7 @@ void MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType>::
             {
               std::vector<std::string> parsed_property;
               boost::split(parsed_property, property_string,
-                           [](char c) { return c == ';'; });
+                           [](char c) { return c == '|'; });
               unsigned int const parsed_property_size = parsed_property.size();
               ASSERT_THROW(parsed_property_size <= table_size,
                            "Too many coefficients, increase the table size");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -106,3 +106,5 @@ adamantine_COPY_INPUT_FILE(integration_da_add_material_expt_ray_0_0.csv tests/da
 adamantine_COPY_INPUT_FILE(HourGlass_AOP.info tests/data)
 adamantine_COPY_INPUT_FILE(HourGlass_AOP.vtk tests/data)
 adamantine_COPY_INPUT_FILE(HourGlass_AOP_scan_path.txt tests/data)
+adamantine_COPY_INPUT_FILE(material_property_table.info tests/data)
+adamantine_COPY_INPUT_FILE(material_property_polynomial.info tests/data)

--- a/tests/data/material_property_polynomial.info
+++ b/tests/data/material_property_polynomial.info
@@ -1,0 +1,39 @@
+geometry
+{
+  import_mesh false
+  length 12
+  length_divisions 4
+  height 6
+  height_divisions 5
+}
+
+materials
+{
+  property_format polynomial
+  n_materials 2
+
+  material_0
+  {
+    solid
+    {
+      density 0.,1.
+      thermal_conductivity_x 0.,1.,2.
+      thermal_conductivity_z 0.,1.,2.
+    }
+  }
+  material_1
+  {
+    solid
+    {
+      density 1.,2.,3.
+      thermal_conductivity_x 1.,100.,20.,200.
+      thermal_conductivity_z 1.,100.,20.,200.
+    }
+    powder
+    {
+      density 15.,2.,3.
+      thermal_conductivity_x 10.,18.,200.
+      thermal_conductivity_z 10.,18.,200.
+    }
+  }
+}

--- a/tests/data/material_property_table.info
+++ b/tests/data/material_property_table.info
@@ -1,0 +1,41 @@
+geometry
+{
+  import_mesh false
+  length 12
+  length_divisions 4
+  height 6
+  height_divisions 5
+}
+
+materials
+{
+  property_format table
+  n_materials 2
+
+  material_0
+  {
+    solid
+    {
+      density 0.,1.
+      thermal_conductivity_x 0.,10.|10.,100.
+      thermal_conductivity_z 0.,10.|10.,100.
+      density 0.,1.|20.,2.|30.,3.
+    }
+  }
+
+  material_1
+  {
+    solid
+    {
+      density 0.,1.|20.,2.|30.,3.
+      thermal_conductivity_x 0.,10.|10.,100.|20.,200.
+      thermal_conductivity_z 0.,10.|10.,100.|20.,200.
+    }
+    powder
+    {
+      density 0.,1.|15.,2.|30.,3.
+      thermal_conductivity_x 0.,10.|10.,100.|18.,200.
+      thermal_conductivity_z 0.,10.|10.,100.|18.,200.
+    }
+  }
+}

--- a/tests/test_material_property.hh
+++ b/tests/test_material_property.hh
@@ -11,6 +11,7 @@
 #include <deal.II/grid/tria.h>
 #include <deal.II/lac/la_parallel_vector.h>
 
+#include <boost/property_tree/info_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 namespace tt = boost::test_tools;
@@ -264,13 +265,12 @@ void material_property_table()
 {
   MPI_Comm communicator = MPI_COMM_WORLD;
 
+  boost::property_tree::ptree database;
+  boost::property_tree::read_info("material_property_table.info", database);
+
   // Create the Geometry
-  boost::property_tree::ptree geometry_database;
-  geometry_database.put("import_mesh", false);
-  geometry_database.put("length", 12);
-  geometry_database.put("length_divisions", 4);
-  geometry_database.put("height", 6);
-  geometry_database.put("height_divisions", 5);
+  boost::property_tree::ptree geometry_database =
+      database.get_child("geometry");
   boost::optional<boost::property_tree::ptree const &> units_optional_database;
   adamantine::Geometry<2> geometry(communicator, geometry_database,
                                    units_optional_database);
@@ -295,25 +295,11 @@ void material_property_table()
   }
 
   // Create the MaterialProperty
-  boost::property_tree::ptree database;
-  database.put("property_format", "table");
-  database.put("n_materials", 2);
-  database.put("material_0.solid.density", "0., 1.");
-  database.put("material_0.solid.thermal_conductivity_x", "0., 10.; 10., 100.");
-  database.put("material_0.solid.thermal_conductivity_z", "0., 10.; 10., 100.");
-  database.put("material_1.solid.density", "0., 1.; 20., 2.; 30., 3.");
-  database.put("material_1.solid.thermal_conductivity_x",
-               "0., 10.; 10., 100.; 20., 200.");
-  database.put("material_1.solid.thermal_conductivity_z",
-               "0., 10.; 10., 100.; 20., 200.");
-  database.put("material_1.powder.density", "0., 1.; 15., 2.; 30., 3.");
-  database.put("material_1.powder.thermal_conductivity_x",
-               "0., 10.; 10., 100.; 18., 200.");
-  database.put("material_1.powder.thermal_conductivity_z",
-               "0., 10.; 10., 100.; 18., 200.");
+  boost::property_tree::ptree material_database =
+      database.get_child("materials");
   adamantine::MaterialProperty<2, 0, adamantine::SolidLiquidPowder,
                                MemorySpaceType>
-      mat_prop(communicator, triangulation, database);
+      mat_prop(communicator, triangulation, material_database);
   // Evaluate the material property at the given temperature
   dealii::FE_Q<2> fe(4);
   dealii::DoFHandler<2> dof_handler(triangulation);
@@ -382,13 +368,13 @@ void material_property_polynomials()
 {
   MPI_Comm communicator = MPI_COMM_WORLD;
 
+  boost::property_tree::ptree database;
+  boost::property_tree::read_info("material_property_polynomial.info",
+                                  database);
+
   // Create the Geometry
-  boost::property_tree::ptree geometry_database;
-  geometry_database.put("import_mesh", false);
-  geometry_database.put("length", 12);
-  geometry_database.put("length_divisions", 4);
-  geometry_database.put("height", 6);
-  geometry_database.put("height_divisions", 5);
+  boost::property_tree::ptree geometry_database =
+      database.get_child("geometry");
   boost::optional<boost::property_tree::ptree const &> units_optional_database;
   adamantine::Geometry<2> geometry(communicator, geometry_database,
                                    units_optional_database);
@@ -413,23 +399,11 @@ void material_property_polynomials()
   }
 
   // Create the MaterialProperty
-  boost::property_tree::ptree database;
-  database.put("property_format", "polynomial");
-  database.put("n_materials", 2);
-  database.put("material_0.solid.density", "0., 1.");
-  database.put("material_0.solid.thermal_conductivity_x", "0., 1., 2.");
-  database.put("material_0.solid.thermal_conductivity_z", "0., 1., 2.");
-  database.put("material_1.solid.density", " 1., 2., 3.");
-  database.put("material_1.solid.thermal_conductivity_x",
-               "1.,  100., 20., 200.");
-  database.put("material_1.solid.thermal_conductivity_z",
-               "1.,  100., 20., 200.");
-  database.put("material_1.powder.density", "15., 2., 3.");
-  database.put("material_1.powder.thermal_conductivity_x", " 10., 18., 200.");
-  database.put("material_1.powder.thermal_conductivity_z", " 10., 18., 200.");
+  boost::property_tree::ptree material_database =
+      database.get_child("materials");
   adamantine::MaterialProperty<2, 4, adamantine::SolidLiquidPowder,
                                MemorySpaceType>
-      mat_prop(communicator, triangulation, database);
+      mat_prop(communicator, triangulation, material_database);
   // Evaluate the material property at the given temperature
   dealii::FE_Q<2> fe(4);
   dealii::DoFHandler<2> dof_handler(triangulation);


### PR DESCRIPTION
This PR is related to https://github.com/adamantine-sim/adamantine/issues/357
 - Do not use `;` as a delimiter when reading material properties because Boost thinks it is a comment. 
 - Rewrite the tests to read from file instead of building a property tree in code. 
 - Improve documentation