### PR TITLE
Rework data assimilation variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,10 +224,7 @@ The following options are available:
 * ensemble (optional):
   * ensemble\_simulation: whether to perform an ensemble of simulations (default value: false)
   * ensemble\_size: the number of ensemble members for the ensemble Kalman filter (EnKF) (default value: 5)
-  * initial\_temperature\_stddev: the standard deviation for the initial temperature of the material (default value: 0.0)
-  * new\_material\_temperature\_stddev: the standard deviation for the temperature of material added during the process (default value: 0.0)
-  * beam\_0\_max\_power\_stddev: the standard deviation for the max power for beam 0 (if it exists) (default value: 0.0)
-  * beam\_0\_absorption\_efficiency\_stddev: the standard deviation for the absorption efficiency for beam 0 (if it exists) (default value: 0.0)
+  * variable\_stddev: standard deviation associated to `variable`. `variable` is an other variable of the input file, for instance `sources.beam_0.max_power`. The input file accepts multiple `variable_stddev` at once  (required if `ensemble_simulation`is true). Note that this does not work for temperature dependent variables.
 * data\_assimilation (optional):
   * assimilate\_data: whether to perform data assimilation (default value: false)
   * localization\_cutoff\_function: the function used to decrease the sample covariance as the relevant points become farther away: gaspari\_cohn, step\_function, none (default: none)

--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -1426,9 +1426,8 @@ run_ensemble(MPI_Comm const &global_communicator,
   // duplicating everything.
 
   // PropertyTreeInput ensemble.initial_temperature_stddev
-  const double initial_temperature_stddev =
+  double const initial_temperature_stddev =
       ensemble_database.get("initial_temperature_stddev", 0.0);
-
   unsigned int n_rejected_draws = first_local_member;
   std::vector<double> initial_temperature =
       adamantine::get_normal_random_vector(
@@ -1436,9 +1435,8 @@ run_ensemble(MPI_Comm const &global_communicator,
           initial_temperature_stddev, verbose_output);
 
   // PropertyTreeInput ensemble.new_material_temperature_stddev
-  const double new_material_temperature_stddev =
+  double const new_material_temperature_stddev =
       ensemble_database.get("new_material_temperature_stddev", 0.0);
-
   // Update the number of rejected draws to make sure that the variables are not
   // correlated.
   n_rejected_draws += global_ensemble_size;
@@ -1448,18 +1446,16 @@ run_ensemble(MPI_Comm const &global_communicator,
           new_material_temperature_stddev, verbose_output);
 
   // PropertyTreeInput ensemble.beam_0_max_power_stddev
-  const double beam_0_max_power_stddev =
+  double const beam_0_max_power_stddev =
       ensemble_database.get("beam_0_max_power_stddev", 0.0);
-
   n_rejected_draws += global_ensemble_size;
   std::vector<double> beam_0_max_power = adamantine::get_normal_random_vector(
       local_ensemble_size, n_rejected_draws, beam_0_max_power_mean,
       beam_0_max_power_stddev, verbose_output);
 
   // PropertyTreeInput ensemble.beam_0_absorption_stddev
-  const double beam_0_absorption_stddev =
+  double const beam_0_absorption_stddev =
       ensemble_database.get("beam_0_absorption_stddev", 0.0);
-
   n_rejected_draws += global_ensemble_size;
   std::vector<double> beam_0_absorption = adamantine::get_normal_random_vector(
       local_ensemble_size, n_rejected_draws, beam_0_absorption_mean,

--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -1355,8 +1355,6 @@ run_ensemble(MPI_Comm const &global_communicator,
       database.get_child("post_processor");
   boost::property_tree::ptree refinement_database =
       database.get_child("refinement");
-  boost::property_tree::ptree ensemble_database =
-      database.get_child("ensemble");
   boost::property_tree::ptree material_database =
       database.get_child("materials");
 
@@ -1384,33 +1382,10 @@ run_ensemble(MPI_Comm const &global_communicator,
                  quadrature_type.begin(),
                  [](unsigned char c) { return std::tolower(c); });
 
-  // ------ Get means of ensemble parameters -----
-  // PropertyTreeInput materials.initial_temperature
-  double const initial_temperature_mean =
-      database.get("materials.initial_temperature", 300.);
-  // Get the nominal (mean) values of the ensemble parameters
-  // PropertyTreeInput materials.new_material_temperature
-  double const new_material_temperature_mean =
-      database.get("materials.new_material_temperature", 300.);
-
-  // PropertyTreeInput sources.n_beams
-  unsigned int const n_beams = database.get<unsigned int>("sources.n_beams");
-  double beam_0_max_power_mean = 0.0;
-  double beam_0_absorption_mean = 0.0;
-  if (n_beams > 0)
-  {
-    // PropertyTreeInput sources.beam_0.max_power
-    beam_0_max_power_mean = database.get<double>("sources.beam_0.max_power");
-
-    // PropertyTreeInput sources.beam_0.absorption_efficiency
-    beam_0_absorption_mean =
-        database.get<double>("sources.beam_0.absorption_efficiency");
-  }
-
   // ------ Split MPI communicator -----
   // PropertyTreeInput ensemble.ensemble_size
   unsigned int const global_ensemble_size =
-      ensemble_database.get("ensemble_size", 5);
+      database.get("ensemble.ensemble_size", 5);
   // Distribute the processors among the ensemble members
   MPI_Comm local_communicator;
   unsigned int local_ensemble_size = std::numeric_limits<unsigned int>::max();
@@ -1425,63 +1400,11 @@ run_ensemble(MPI_Comm const &global_communicator,
   // between ensemble members. For now, we'll do the simpler approach of
   // duplicating everything.
 
-  // PropertyTreeInput ensemble.initial_temperature_stddev
-  double const initial_temperature_stddev =
-      ensemble_database.get("initial_temperature_stddev", 0.0);
-  unsigned int n_rejected_draws = first_local_member;
-  std::vector<double> initial_temperature =
-      adamantine::get_normal_random_vector(
-          local_ensemble_size, n_rejected_draws, initial_temperature_mean,
-          initial_temperature_stddev, verbose_output);
-
-  // PropertyTreeInput ensemble.new_material_temperature_stddev
-  double const new_material_temperature_stddev =
-      ensemble_database.get("new_material_temperature_stddev", 0.0);
-  // Update the number of rejected draws to make sure that the variables are not
-  // correlated.
-  n_rejected_draws += global_ensemble_size;
-  std::vector<double> new_material_temperature =
-      adamantine::get_normal_random_vector(
-          local_ensemble_size, n_rejected_draws, new_material_temperature_mean,
-          new_material_temperature_stddev, verbose_output);
-
-  // PropertyTreeInput ensemble.beam_0_max_power_stddev
-  double const beam_0_max_power_stddev =
-      ensemble_database.get("beam_0_max_power_stddev", 0.0);
-  n_rejected_draws += global_ensemble_size;
-  std::vector<double> beam_0_max_power = adamantine::get_normal_random_vector(
-      local_ensemble_size, n_rejected_draws, beam_0_max_power_mean,
-      beam_0_max_power_stddev, verbose_output);
-
-  // PropertyTreeInput ensemble.beam_0_absorption_stddev
-  double const beam_0_absorption_stddev =
-      ensemble_database.get("beam_0_absorption_stddev", 0.0);
-  n_rejected_draws += global_ensemble_size;
-  std::vector<double> beam_0_absorption = adamantine::get_normal_random_vector(
-      local_ensemble_size, n_rejected_draws, beam_0_absorption_mean,
-      beam_0_absorption_stddev, verbose_output);
-
-  // Write the ensemble variables in files to simplify data analysis.
-  if (dealii::Utilities::MPI::this_mpi_process(local_communicator) == 0)
-  {
-    for (unsigned int member = 0; member < local_ensemble_size; ++member)
-    {
-
-      std::string member_data_filename =
-          post_processor_database.get<std::string>("filename_prefix") + "_m" +
-          std::to_string(first_local_member + member) + "_data.txt";
-      std::ofstream file(member_data_filename);
-      file << "Initial temperature: " << initial_temperature[member] << "\n";
-      file << "New material temperature: " << new_material_temperature[member]
-           << "\n";
-      file << "Beam_0 max power: " << beam_0_max_power[member] << "\n";
-      file << "Beam_0 absorption: " << beam_0_absorption[member] << "\n";
-    }
-  }
-
   // Create a new property tree database for each ensemble member
-  std::vector<boost::property_tree::ptree> database_ensemble(
-      local_ensemble_size, database);
+  std::vector<boost::property_tree::ptree> database_ensemble =
+      adamantine::create_database_ensemble(
+          database, local_communicator, first_local_member, local_ensemble_size,
+          global_ensemble_size);
 
   std::vector<std::unique_ptr<
       adamantine::ThermalPhysicsInterface<dim, MemorySpaceType>>>
@@ -1581,16 +1504,8 @@ run_ensemble(MPI_Comm const &global_communicator,
     solution_augmented_ensemble[member].reinit(2);
 
     // Edit the database for the ensemble
-    if (n_beams > 0)
+    if (database.get<unsigned int>("sources.n_beams") > 0)
     {
-      // PropertyTreeInput sources.beam_0.max_power
-      database_ensemble[member].put("sources.beam_0.max_power",
-                                    beam_0_max_power[member]);
-
-      // PropertyTreeInput sources.beam_0.absorption_efficiency
-      database_ensemble[member].put("sources.beam_0.absorption_efficiency",
-                                    beam_0_absorption[member]);
-
       // Populate the parameter augmentation block of the augmented state
       // ensemble
       if (assimilate_data)
@@ -1609,13 +1524,15 @@ run_ensemble(MPI_Comm const &global_communicator,
               adamantine::AugmentedStateParameters::beam_0_absorption)
           {
             solution_augmented_ensemble[member].block(augmented_state)[index] =
-                beam_0_absorption[member];
+                database_ensemble[member].get<double>(
+                    "sources.beam_0.absorption_efficiency");
           }
           else if (augmented_state_parameters.at(index) ==
                    adamantine::AugmentedStateParameters::beam_0_max_power)
           {
             solution_augmented_ensemble[member].block(augmented_state)[index] =
-                beam_0_max_power[member];
+                database_ensemble[member].get<double>(
+                    "sources.beam_0.max_power");
           }
         }
       }
@@ -1643,7 +1560,7 @@ run_ensemble(MPI_Comm const &global_communicator,
     {
       thermal_physics_ensemble[member]->setup();
       thermal_physics_ensemble[member]->initialize_dof_vector(
-          initial_temperature[member],
+          database_ensemble[member].get("materials.initial_temperature", 300.),
           solution_augmented_ensemble[member].block(base_state));
     }
     else
@@ -2002,7 +1919,8 @@ run_ensemble(MPI_Comm const &global_communicator,
 #endif
 
           thermal_physics_ensemble[member]->add_material_end(
-              new_material_temperature[member],
+              database_ensemble[member].get(
+                  "materials.new_material_temperature", 300.),
               solution_augmented_ensemble[member].block(base_state));
 
           solution_augmented_ensemble[member].collect_sizes();

--- a/source/ensemble_management.hh
+++ b/source/ensemble_management.hh
@@ -17,21 +17,6 @@
 namespace adamantine
 {
 /**
- * Return a vector of size @p length, with random values drawn following a
- * normal distribution of average @p mean and standard deviation @p stddev. The
- * first @p n_rejected_draws are rejected. @p n_rejected_draws is used to
- * ensure that wether we use one MPI rank or ten, we use the same random
- * numbers. If we don't reject the first few draws, all the processors will use
- * the same "random" numbers since they have the same seed. We also reject
- * negative values even because our physical quantities must be positive. If @p
- * verbose is true, we output a message when a negative value was rejected.
- */
-std::vector<double> get_normal_random_vector(unsigned int length,
-                                             unsigned int n_rejected_draws,
-                                             double mean, double stddev,
-                                             bool verbose);
-
-/**
  * Return the sources encompassing all the sources of the different ensemble
  * members.
  */
@@ -39,6 +24,16 @@ template <int dim>
 std::vector<std::shared_ptr<HeatSource<dim>>> get_bounding_heat_sources(
     std::vector<boost::property_tree::ptree> const &property_trees,
     MPI_Comm global_communicator);
+
+/**
+ * Given an input property tree @p database, return @p local_ensemble_size
+ * databases each one modified to respect the standard deviation of each
+ * quantity (if provided).
+ */
+std::vector<boost::property_tree::ptree> create_database_ensemble(
+    boost::property_tree::ptree const &database, MPI_Comm local_communicator,
+    unsigned int first_local_member, unsigned int local_ensemble_size,
+    unsigned int global_ensemble_size);
 } // namespace adamantine
 
 #endif

--- a/source/validate_input_database.cc
+++ b/source/validate_input_database.cc
@@ -421,31 +421,7 @@ void validate_input_database(boost::property_tree::ptree &database)
   }
 
   // Tree: ensemble
-  boost::optional<double> initial_temperature_stddev =
-      database.get_optional<double>("ensemble.initial_temperature_stddev");
-  if (initial_temperature_stddev)
-  {
-    ASSERT_THROW(initial_temperature_stddev.get() >= 0.0,
-                 "Error: The standard deviation for the initial temperature "
-                 "must be non-negative.");
-  }
-  boost::optional<double> new_material_temperature_stddev =
-      database.get_optional<double>("ensemble.new_material_temperature_stddev");
-  if (new_material_temperature_stddev)
-  {
-    ASSERT_THROW(
-        new_material_temperature_stddev.get() >= 0.0,
-        "Error: The standard deviation for the new material temperature "
-        "must be non-negative.");
-  }
-  boost::optional<double> beam_0_max_power_stddev =
-      database.get_optional<double>("ensembe.beam_0_max_power_stddev");
-  if (beam_0_max_power_stddev)
-  {
-    ASSERT_THROW(beam_0_max_power_stddev.get() >= 0.0,
-                 "Error: The standard deviation for the beam 0 max power "
-                 "must be non-negative.");
-  }
+  // We check the input in ensemble_management.cc
 
   // Tree: data_assimilation
   boost::optional<double> convergence_tolerance =

--- a/tests/data/bare_plate_L_da.info
+++ b/tests/data/bare_plate_L_da.info
@@ -2,7 +2,10 @@ ensemble
 {
   ensemble_simulation true
   ensemble_size 3
-  initial_temperature_stddev 50.0
+  materials
+  {
+    initial_temperature_stddev 50.0
+  }
 }
 experiment
 {
@@ -63,6 +66,8 @@ materials
   n_materials 1
 
   property_format polynomial
+  initial_temperature 300
+
   material_0
   {
     solid

--- a/tests/data/bare_plate_L_da_augmented.info
+++ b/tests/data/bare_plate_L_da_augmented.info
@@ -2,7 +2,13 @@ ensemble
 {
   ensemble_simulation true
   ensemble_size 3
-  beam_0_absorption_stddev 0.1
+  sources
+  {
+    beam_0
+    {
+      absorption_efficiency_stddev 0.1
+    }
+  }
 }
 experiment
 {

--- a/tests/data/bare_plate_L_ensemble.info
+++ b/tests/data/bare_plate_L_ensemble.info
@@ -2,7 +2,10 @@ ensemble
 {
   ensemble_simulation true
   ensemble_size 3
-  initial_temperature_stddev 10.0
+  materials
+  {
+    initial_temperature_stddev 10.0
+  }
 }
 
 physics
@@ -41,6 +44,8 @@ materials
   n_materials 1
 
   property_format polynomial
+  initial_temperature 300
+
   material_0
   {
     solid

--- a/tests/data/integration_da_add_material.info
+++ b/tests/data/integration_da_add_material.info
@@ -2,8 +2,17 @@ ensemble
 {
   ensemble_simulation true
   ensemble_size 3
-  initial_temperature_stddev 5.0
-  beam_0_absorption_stddev 0.05
+  materials
+  {
+    initial_temperature_stddev 5.0
+  }
+  sources
+  {
+    beam_0
+    {
+      absorption_efficiency_stddev 0.05
+    }
+  }
 }
 experiment
 {
@@ -73,9 +82,10 @@ materials
   n_materials 1
 
   property_format polynomial
+  initial_temperature 285
+
   material_0
   {
-    initial_temperature 285
     solid
     {
       density 7904; [kg/m^3] For now all the states needs to have the same

--- a/tests/test_ensemble_management.cc
+++ b/tests/test_ensemble_management.cc
@@ -1,47 +1,118 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2021 - 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2021 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #include <ensemble_management.hh>
 
-#include <numeric>
+#include <deal.II/base/mpi.h>
 
 #define BOOST_TEST_MODULE EnsembleManagement
 
-#include <boost/accumulators/accumulators.hpp>
-#include <boost/accumulators/statistics.hpp>
+#include <filesystem>
 
 #include "main.cc"
 
 namespace utf = boost::unit_test;
 
-// Fairly loose tolerance because this is a statistical check
-BOOST_AUTO_TEST_CASE(fill_and_sync_random_vector, *utf::tolerance(10.))
+BOOST_AUTO_TEST_CASE(database_ensemble)
 {
+  MPI_Comm communicator = MPI_COMM_WORLD;
 
-  // Create the random vector
-  double mean = 12.2;
-  double stddev = 0.25;
-  unsigned int ensemble_size = 5000;
-  std::vector<double> vec = adamantine::get_normal_random_vector(
-      ensemble_size, 0, mean, stddev, false);
+  unsigned int const global_ensemble_size = 6;
+  unsigned int const n_procs =
+      dealii::Utilities::MPI::n_mpi_processes(communicator);
+  unsigned int const rank =
+      dealii::Utilities::MPI::this_mpi_process(communicator);
+  unsigned int const local_ensemble_size = global_ensemble_size / n_procs;
+  unsigned int const fist_local_member = rank * local_ensemble_size;
 
-  // Check vector size
-  BOOST_TEST(vec.size() == ensemble_size);
+  boost::property_tree::ptree database;
+  database.put("alpha.beta", 100.);
+  database.put("ensemble.alpha.beta_stddev", 10.);
+  database.put("gamma.delta", 200.);
+  database.put("ensemble.gamma.delta_stddev", 20.);
+  database.put("post_processor.filename_prefix", "ensemble_management");
 
-  // Check vector mean
-  double mean_check =
-      std::accumulate(vec.cbegin(), vec.cend(), 0.) / ensemble_size;
+  auto database_ensemble = adamantine::create_database_ensemble(
+      database, communicator, fist_local_member, local_ensemble_size,
+      global_ensemble_size);
 
-  BOOST_TEST(mean == mean_check);
-
-  // Check vector variance
-  boost::accumulators::accumulator_set<
-      double, boost::accumulators::features<boost::accumulators::tag::variance>>
-      acc;
-  for (unsigned int member = 0; member < ensemble_size; ++member)
+  if (n_procs == 1)
   {
-    acc(vec[member]);
+    BOOST_TEST(database_ensemble[0].get<double>("alpha.beta") ==
+               101.34529658472329);
+    BOOST_TEST(database_ensemble[1].get<double>("alpha.beta") ==
+               98.536182188102771);
+    BOOST_TEST(database_ensemble[2].get<double>("alpha.beta") ==
+               104.60650182383064);
+    BOOST_TEST(database_ensemble[3].get<double>("alpha.beta") ==
+               81.286156895893981);
+    BOOST_TEST(database_ensemble[4].get<double>("alpha.beta") ==
+               101.63711684234313);
+    BOOST_TEST(database_ensemble[5].get<double>("alpha.beta") ==
+               97.857466117910562);
+
+    BOOST_TEST(database_ensemble[0].get<double>("gamma.delta") ==
+               205.97190519115932);
+    BOOST_TEST(database_ensemble[1].get<double>("gamma.delta") ==
+               183.44111635285606);
+    BOOST_TEST(database_ensemble[2].get<double>("gamma.delta") ==
+               200.20430868691838);
+    BOOST_TEST(database_ensemble[3].get<double>("gamma.delta") ==
+               221.10932887760762);
+    BOOST_TEST(database_ensemble[4].get<double>("gamma.delta") ==
+               189.06317994350883);
+    BOOST_TEST(database_ensemble[5].get<double>("gamma.delta") ==
+               223.49135354909728);
+
+    std::filesystem::remove("ensemble_management_m0_data.txt");
+    std::filesystem::remove("ensemble_management_m1_data.txt");
+    std::filesystem::remove("ensemble_management_m2_data.txt");
+    std::filesystem::remove("ensemble_management_m3_data.txt");
+    std::filesystem::remove("ensemble_management_m4_data.txt");
+    std::filesystem::remove("ensemble_management_m5_data.txt");
   }
-  BOOST_TEST(stddev * stddev == boost::accumulators::variance(acc));
+  else
+  {
+    if (rank == 0)
+    {
+      BOOST_TEST(database_ensemble[0].get<double>("alpha.beta") ==
+                 101.34529658472329);
+      BOOST_TEST(database_ensemble[1].get<double>("alpha.beta") ==
+                 98.536182188102771);
+      BOOST_TEST(database_ensemble[2].get<double>("alpha.beta") ==
+                 104.60650182383064);
+
+      BOOST_TEST(database_ensemble[0].get<double>("gamma.delta") ==
+                 205.97190519115932);
+      BOOST_TEST(database_ensemble[1].get<double>("gamma.delta") ==
+                 183.44111635285606);
+      BOOST_TEST(database_ensemble[2].get<double>("gamma.delta") ==
+                 200.20430868691838);
+
+      std::filesystem::remove("ensemble_management_m0_data.txt");
+      std::filesystem::remove("ensemble_management_m1_data.txt");
+      std::filesystem::remove("ensemble_management_m2_data.txt");
+    }
+    else
+    {
+      BOOST_TEST(database_ensemble[0].get<double>("alpha.beta") ==
+                 81.286156895893981);
+      BOOST_TEST(database_ensemble[1].get<double>("alpha.beta") ==
+                 101.63711684234313);
+      BOOST_TEST(database_ensemble[2].get<double>("alpha.beta") ==
+                 97.857466117910562);
+
+      BOOST_TEST(database_ensemble[0].get<double>("gamma.delta") ==
+                 221.10932887760762);
+      BOOST_TEST(database_ensemble[1].get<double>("gamma.delta") ==
+                 189.06317994350883);
+      BOOST_TEST(database_ensemble[2].get<double>("gamma.delta") ==
+                 223.49135354909728);
+
+      std::filesystem::remove("ensemble_management_m3_data.txt");
+      std::filesystem::remove("ensemble_management_m4_data.txt");
+      std::filesystem::remove("ensemble_management_m5_data.txt");
+    }
+  }
 }


### PR DESCRIPTION
This PR reworks how we set variables for data assimilation. Currently the variables that we can set are hard-coded, for instance `beam_0_max_power_stddev` sets the standard deviation for the maximum power of `beam_0`. Instead of hard-coding the values, this PR rework how we can set the standard deviation. With this PR, `beam_0_max_power_stddev` is replaced by `sources.beam_0.max_power_stddev`. The idea is to follow the naming scheme of the variable and to add `_stddev` at the end of the name. We then check that the original variable exists. Since nothing is hard-coded, more variables can be used for data assimilation. Note however that data assimilation only works for scalar values and therefore it does not work for temperature dependent variables.