### PR TITLE
Nix tweaks, CMake install configuration, directory handling improvements

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake -L

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,75 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "cppdbg",
+      "request": "launch",
+      "name": "Launch Adamantine (GDB)",
+      "cwd": "${workspaceFolder}",
+      "program": "${command:cmake.launchTargetPath}",
+      "args": [
+        "-i",
+        "${input:pickInputFile}",
+        "-o",
+        "${input:pickInputFile}.${input:shortDate}.output"
+      ]
+    }
+  ],
+  "inputs": [
+    {
+      "id": "pickInputFile",
+      "type": "command",
+      "command": "extension.commandvariable.pickStringRemember",
+      "args": {
+        "description": "Pick a info file to pass to adamantine",
+        "key": "debugInfoFile",
+        "rememberTransformed": "true",
+        "options": [
+          {
+            "label": "Use previous input",
+            "description": "${remember:debugInfoFile}",
+            "value": "${remember:debugInfoFile}"
+          },
+          {
+            "label": "Pick new input",
+            "value": "${pickFile:newDebugFile}"
+          }
+        ],
+        "pickFile": {
+          "newDebugFile": {
+            "description": "Pick new info file for adamantine",
+            "include": "**/*.info",
+            "exclude": "**/build/**",
+            "keyRemember": "newDebugFile"
+          }
+        },
+        "remember": {
+          "debugInfoFile": {
+            "key": "debugInfoFile",
+            "default": "Undefined - select an input first"
+          }
+        }
+      }
+    },
+    {
+      "id": "shortDate",
+      "type": "command",
+      "command": "extension.commandvariable.dateTime",
+      "args": {
+        "locale": "en-US",
+        "options": {
+          "weekday": "long",
+          "year": "numeric",
+          "month": "2-digit",
+          "day": "2-digit",
+          "hour12": false,
+          "hour": "2-digit",
+          "minute": "2-digit",
+          "second": "2-digit"
+        },
+        "template": "${year}${month}${day}T${hour}${minute}${second}"
+      }
+    }
+  ]
+}
+

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,101 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Launch Adamantine (mpirun)",
+      "type": "shell",
+      "command": "mpirun",
+      "args": [
+        "${command:cmake.launchTargetPath}",
+        "-i",
+        "${input:pickInputFile}",
+        "-o",
+        "${input:pickInputFile}.${input:shortDate}.output"
+      ],
+      "presentation": {
+        "reveal": "always",
+        "focus": false,
+        "panel": "dedicated",
+        "showReuseMessage": true,
+        "clear": false
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Launch Adamantine (direct)",
+      "type": "shell",
+      "command": "${command:cmake.launchTargetPath}",
+      "args": [
+        "-i",
+        "${input:pickInputFile}",
+        "-o",
+        "${input:pickInputFile}.${input:shortDate}.output"
+      ],
+      "presentation": {
+        "reveal": "always",
+        "focus": false,
+        "panel": "dedicated",
+        "showReuseMessage": true,
+        "clear": false
+      },
+      "problemMatcher": []
+    }
+  ],
+  "inputs": [
+    {
+      "id": "pickInputFile",
+      "type": "command",
+      "command": "extension.commandvariable.pickStringRemember",
+      "args": {
+        "description": "Pick a info file to pass to adamantine",
+        "key": "debugInfoFile",
+        "rememberTransformed": "true",
+        "options": [
+          {
+            "label": "Use previous input",
+            "description": "${remember:debugInfoFile}",
+            "value": "${remember:debugInfoFile}"
+          },
+          {
+            "label": "Pick new input",
+            "value": "${pickFile:newDebugFile}"
+          }
+        ],
+        "pickFile": {
+          "newDebugFile": {
+            "description": "Pick new info file for adamantine",
+            "include": "**/*.info",
+            "exclude": "**/build/**",
+            "keyRemember": "newDebugFile"
+          }
+        },
+        "remember": {
+          "debugInfoFile": {
+            "key": "debugInfoFile",
+            "default": "Undefined - select an input first"
+          }
+        }
+      }
+    },
+    {
+      "id": "shortDate",
+      "type": "command",
+      "command": "extension.commandvariable.dateTime",
+      "args": {
+        "locale": "en-US",
+        "options": {
+          "weekday": "long",
+          "year": "numeric",
+          "month": "2-digit",
+          "day": "2-digit",
+          "hour12": false,
+          "hour": "2-digit",
+          "minute": "2-digit",
+          "second": "2-digit"
+        },
+        "template": "${year}${month}${day}T${hour}${minute}${second}"
+      }
+    }
+  ]
+}
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,13 +14,15 @@ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 # TPL and adamantine
 include(SetupDealII)
 
-project(adamantine LANGUAGES CXX VERSION 1.0.9)
+project(Adamantine LANGUAGES CXX VERSION 1.0.9)
 
 include(SetupTPLs)
 include(SetupAdamantine)
 
 add_subdirectory(application)
 add_subdirectory(source)
+
+option(BUILD_SHARED_LIBS "Build the adamantine library as a shared object" ON)
 
 option(ADAMANTINE_ENABLE_COVERAGE "Measure coverage" OFF)
 if (ADAMANTINE_ENABLE_COVERAGE)
@@ -36,14 +38,14 @@ if (ADAMANTINE_ENABLE_TESTS)
   add_test(NAME indent_code
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     COMMAND ./indent
-    )
+  )
 endif()
 
 # Provide "indent" target for indenting all the header and the source files.
 add_custom_target(indent
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   COMMAND ./indent
-  )
+)
 
 if (ADAMANTINE_ENABLE_DOCUMENTATION)
     add_subdirectory(doc)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,33 @@
+{
+  "version": 6,
+  "configurePresets": [
+    {
+      "name":        "generic-gcc-ninja",
+      "displayName": "Generic (gcc-ninja)",
+      "description": "Basic configuration with the GCC toolchain using Ninja generator.",
+      "generator":   "Ninja Multi-Config",
+      "binaryDir":   "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER":   "gcc",
+        "CMAKE_CXX_COMPILER": "g++"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name":            "debug-gcc-ninja",
+      "displayName":     "Debug (gcc-ninja)",
+      "description":     "Compile a debug build using GCC.",
+      "configurePreset": "generic-gcc-ninja",
+      "configuration":   "Debug"
+    },
+    {
+      "name":            "release-gcc-ninja",
+      "displayName":     "Release (gcc-ninja)",
+      "description":     "Compile a release build using GCC.",
+      "configurePreset": "generic-gcc-ninja",
+      "configuration":   "Release"
+    }
+  ]
+}
+

--- a/NIX.md
+++ b/NIX.md
@@ -1,19 +1,61 @@
-# Nix Install
+## Nix
 
-First install the [Nix package manager][NIX] and then enable
-[Flakes]. See [nix.dev][nix.dev] for more help with Nix. To install
-without cloning from this repository use,
+First install the [Nix package manager][NIX] and then enable [Flakes][Flakes].
+Alternatively, check out the [Determinate Systems Installer][Determinate] for
+an out of the box experience. See [nix.dev][nix.dev] for more help with Nix.
 
-    $ nix develop github:adamantine-sim/adamantine
-	
-to install the latest version on master. To install the lastest release use,
+To get a shell with adamantine temporarily installed, run:
 
-    $ nix develop github:adamantine-sim/adamantine#release
-    
-To install from a working copy use,
+    $ nix shell github:adamantine-sim/adamantine
+    # Adamantine now available
+    $ adamantine --help
+
+To install this permanently, run:
+
+    $ nix profile install github:adamantine-sim/adamantine
+
+To get the latest stable release, use:
+
+    $ nix shell github:adamantine-sim/adamantine#adamantine.stable
+
+To build from a working copy use `nix develop` and run CMake manually:
 
     $ nix develop
-   
+    $ cmake -B build -GNinja
+    $ cmake --build build
+
+## direnv
+
+This repository also supports `direnv` for integration with both your shell and
+tools like VSCode.
+
+First install direnv from either your distro or via Nix:
+
+    # Via apt...
+    $ sudo apt install direnv
+    # ... or nix.
+    $ nix profile install direnv
+
+Setup direnv for your shell. Tutorials for various shells can be found
+[here][DirenvHook]. For bash:
+
+    $ echo "eval \"\$(direnv hook bash)\"" >> ~/.bashrc
+
+Restart your shell and then allow direnv:
+
+    $ cd path/to/my/adamantine
+    $ direnv allow
+
+This will automatically enter the nix development shell whenever you enter the
+adamantine directory.
+
+If you use VSCode, a great extension that adds direnv support can be found
+[here][DirenvVSCode].
+
+
 [NIX]: https://nixos.org/download.html
 [Flakes]: https://nixos.wiki/wiki/Flakes
 [nix.dev]: https://nix.dev
+[Determinate]: https://github.com/DeterminateSystems/nix-installer
+[DirenvHook]: https://direnv.net/docs/hook.html
+[DirenvVSCode]: https://marketplace.visualstudio.com/items?itemName=mkhl.direnv

--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -21,3 +21,5 @@ endif()
 
 file(COPY input.info DESTINATION ${CMAKE_BINARY_DIR}/bin)
 file(COPY input_scan_path.txt DESTINATION ${CMAKE_BINARY_DIR}/bin)
+
+install(TARGETS adamantine)

--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -1201,12 +1201,15 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
       {
         std::cout << "Checkpoint reached" << std::endl;
       }
+
+      std::string output_dir =
+          post_processor_database.get<std::string>("output_dir");
       std::string filename_prefix =
           checkpoint_overwrite
               ? checkpoint_filename
               : checkpoint_filename + '_' + std::to_string(n_time_step);
       thermal_physics->save_checkpoint(filename_prefix, temperature);
-      std::ofstream file{filename_prefix + "_time.txt"};
+      std::ofstream file{output_dir + filename_prefix + "_time.txt"};
       boost::archive::text_oarchive oa{file};
       oa << time;
       oa << n_time_step;
@@ -2191,6 +2194,9 @@ run_ensemble(MPI_Comm const &global_communicator,
       {
         std::cout << "Checkpoint reached" << std::endl;
       }
+
+      std::string output_dir =
+          post_processor_database.get<std::string>("output_dir");
       std::string filename_prefix =
           checkpoint_overwrite
               ? checkpoint_filename
@@ -2201,7 +2207,7 @@ run_ensemble(MPI_Comm const &global_communicator,
             filename_prefix + '_' + std::to_string(first_local_member + member),
             solution_augmented_ensemble[member].block(base_state));
       }
-      std::ofstream file{filename_prefix + "_time.txt"};
+      std::ofstream file{output_dir + filename_prefix + "_time.txt"};
       boost::archive::text_oarchive oa{file};
       oa << time;
       oa << n_time_step;

--- a/cmake/templates/AdamantineConfig.cmake.in
+++ b/cmake/templates/AdamantineConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1736916166,
@@ -36,8 +18,8 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
       }
     },
     "systems": {
@@ -52,6 +34,24 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -30,11 +30,13 @@
         dealii  = callPackage ./nix/dependencies/dealii.nix  {};
       };
     in rec {
+      default = adamantine.devel;
+
       inherit libs;
 
       adamantine = rec {
         devel = callPackage ./nix/adamantine/common.nix {
-          version = self.dirtyShortRev;
+          version = self.shortRev or self.dirtyShortRev;
           src     = self;
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,272 +1,40 @@
 ## See NIX.md for help getting started with Nix
 
 {
+  description = "Software to simulate heat transfer for additive manufacturing";
+
   inputs = {
-    nixpkgs = {
-      url = "github:nixos/nixpkgs/nixos-24.11";
-    };
-    flake-utils = {
-      url = "github:numtide/flake-utils";
-    };
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+    utils.url   = "github:numtide/flake-utils";
   };
-  outputs = { nixpkgs, flake-utils, ... }: flake-utils.lib.eachDefaultSystem (system:
-    let
-      pkgs = import nixpkgs {
+
+  outputs = inputs @ { self, utils, ... }: utils.lib.eachDefaultSystem (system: rec {
+    config = rec {
+      pkgs = import inputs.nixpkgs {
         inherit system;
-        config.allowUnfree = true;
+        inherit (import ./nix/nixpkgs/config.nix {}) overlays config;
+      };
+    };
+
+    lib = with config; {
+      callPackage = set: pkgs.lib.callPackageWith (pkgs // set);
+    };
+
+    packages = with config; rec {
+      libs = let
+        callPackage = lib.callPackage libs;
+      in {
+        adiak   = callPackage ./nix/dependencies/adiak.nix   {};
+        caliper = callPackage ./nix/dependencies/caliper.nix {};
+        arborx  = callPackage ./nix/dependencies/arborx.nix  {};
+        dealii  = callPackage ./nix/dependencies/dealii.nix  {};
       };
 
-      adiak = (with pkgs; stdenv.mkDerivation {
-        pname = "adiak";
-        version = "0.4.0";
+      adamantine = (lib.callPackage libs) ./nix/adamantine/common.nix { version = self.dirtyShortRev; src = self; };
+    };
 
-        src = fetchgit {
-          url = "https://github.com/LLNL/Adiak";
-          rev = "v0.4.0";
-          sha256 = "sha256-S4ZLU6f/njdZXyoQdCJIDzpQTSmfapZiRe4zIex5f0Q=";
-          fetchSubmodules = true;
-        };
-
-        buildInputs = [
-          cmake
-        ];
-
-        cmakeFlags = [
-          "-DBUILD_SHARED_LIBS=ON"
-          "-DCMAKE_BUILD_TYPE=Release"
-        ];
-      });
-
-      caliper = (with pkgs; stdenv.mkDerivation {
-        pname = "caliper";
-        version = "2.10.0";
-
-        src = fetchgit {
-          url = "https://github.com/LLNL/caliper";
-          rev = "9b5b5efe9096e3f2b306fcca91ae739ae5d00716";
-          sha256 = "sha256-4rnPbRYtciohLnThtonTrUBO+d8vyWvJsCgoqbJI5Rg=";
-          fetchSubmodules = true;
-        };
-
-        buildInputs = [
-          cmake
-          adiak
-          python3
-          openmpi
-        ];
-
-        cmakeFlags = [
-          "-DCMAKE_BUILD_TYPE=Release"
-          "-DBUILD_SHARED_LIBS=ON"
-          "-DWITH_ADIAK=ON"
-          "-DWITH_LIBDW=ON"
-          "-DWITH_LIBPFM=ON"
-          "-DWITH_LIBUNWIND=ON"
-          "-DWITH_MPI=ON"
-          "-DWITH_SAMPLER=ON"
-        ];
-      });
-
-      arborx = (with pkgs; stdenv.mkDerivation {
-        pname = "arborx";
-        version = "1.5";
-
-        src = fetchgit {
-          url = "https://github.com/arborx/ArborX";
-          rev = "v1.5";
-          sha256 = "sha256-qEC4BocPyH9mmU9Ys0nNu8s0l3HQGPHg8B1oNcGwXOQ=";
-          fetchSubmodules = true;
-        };
-
-        buildInputs = [
-          cmake
-          openmpi
-          trilinos_override
-        ];
-
-        cmakeFlags = [
-          "-DCMAKE_BUILD_TYPE=Release"
-          "-DBUILD_SHARED_LIBS=ON"
-          "-DCMAKE_CXX_EXTENSIONS=OFF"
-          "-DARBORX_ENABLE_MPI=ON"
-        ];
-      });
-
-      deal_II_952 = (with pkgs; stdenv.mkDerivation {
-        pname = "deal_II";
-        version = "9.5.2";
-        src = fetchgit {
-          url = "https://github.com/dealii/dealii";
-          rev = "6f07117be556bf929220c50820b4dead54dc31d0";
-          sha256 = "sha256-wJIrSuEDU19eZT66MN0DIuSiWQ1/gdu+gHeMYrbQkxk=";
-          fetchSubmodules = true;
-        };
-
-        buildInputs = [
-          cmake
-          openmpi
-          trilinos_override
-          arborx
-          p4est
-          boost183
-        ];
-
-        cmakeFlags = [
-          "-DCMAKE_BUILD_TYPE=DebugRelease"
-          "-DCMAKE_CXX_STANDARD=17"
-          "-DCMAKE_CXX_EXTENSIONS=OFF"
-          "-DDEAL_II_WITH_TBB=OFF"
-          "-DDEAL_II_WITH_64BIT_INDICES=ON"
-          "-DDEAL_II_WITH_COMPLEX_VALUES=OFF"
-          "-DDEAL_II_WITH_MPI=ON"
-          "-DDEAL_II_WITH_P4EST=ON"
-          "-DP4EST_DIR=${p4est}"
-          "-DDEAL_II_WITH_ARBORX=ON"
-          "-DARBORX_DIR=${arborx}"
-          "-DDEAL_II_WITH_TRILINOS=ON"
-          "-DTRILINOS_DIR=${trilinos_override}"
-          "-DDEAL_II_TRILINOS_WITH_SEACAS=OFF"
-          "-DDEAL_II_COMPONENT_EXAMPLES=OFF"
-          "-DDEAL_II_WITH_ADOLC=OFF"
-          "-DDEAL_II_ALLOW_BUNDLED=OFF"
-         ];
-      });
-
-      deal_II_962 = deal_II_952.overrideAttrs ( with pkgs; previousAttrs : rec {
-        version = "9.6.2";
-        src = previousAttrs.src.override {
-          rev = "v9.6.2";
-          sha256 = "sha256-YVOQbvzWWSl9rmYd6LBx4w2S8wuxhVF8T2dKdOphta4=";
-        };
-      });
-      
-      trilinos_extra_args = ''
-        -DTrilinos_ENABLE_ML=ON
-        -DBoost_INCLUDE_DIRS=${pkgs.boost183}/include
-        -DBoostLib_INCLUDE_DIRS=${pkgs.boost183}/include
-        -DBoostLib_LIBRARY_DIRS=${pkgs.boost183}/lib
-        -DTPL_ENABLE_BoostLib=ON
-      '';
-      trilinos_withMPI = pkgs.trilinos.override ( previous: { withMPI = true; boost = pkgs.boost183; });
-      trilinos_override = trilinos_withMPI.overrideAttrs ( previousAttrs : rec {
-          preConfigure = previousAttrs.preConfigure + ''
-                       cmakeFlagsArray+=(${trilinos_extra_args})
-                       '';            
-          version = "14.4.0";
-          src = previousAttrs.src.override {
-            rev = "${previousAttrs.pname}-release-${pkgs.lib.replaceStrings [ "." ] [ "-" ] version}";
-            sha256 = "sha256-jbXQYEyf/p9F2I/I7jP+0/6OOcH5ArFlUk6LHn453qY=";
-          };
-        }
-      );
-
-      adamantine-base = (with pkgs; stdenv.mkDerivation rec {
-        pname = "adamantine";
-        version = "1.0";
-
-        src = fetchgit {
-          url = "https://github.com/adamantine-sim/adamantine";
-          rev = "v1.0";
-          sha256 = "sha256-pwwGgk4uIEOkyNLN26nRYvkzQZR53TJW14R9P99E3Ts=";
-        };
-
-        buildInputs = [
-          arborx
-          adiak
-          caliper
-          cmake
-          p4est
-          trilinos_override
-          boost183
-        ] ++ propagatedBuildInputs;
-
-        
-        propagatedBuildInputs = [
-          openmpi
-        ];
-
-        cmakeFlags = [
-          "-DADAMANTINE_ENABLE_ADIAK=ON"
-          "-DADAMANTINE_ENABLE_CALIPER=ON"
-          "-DBOOST_DIR=${boost183}"
-        ];
-
-        installPhase = ''
-          mkdir -p $out/bin
-          cp bin/adamantine $out/bin
-        '';
-
-        doCheck = true;
-        check = ''
-          ctest -R integration_2d
-        '';
-      });
-
-      adamantine-release = adamantine-base.overrideAttrs ( with pkgs; previousAttrs : rec {
-        buildInputs = previousAttrs.buildInputs ++ [ deal_II_952 ];
-        cmakeFlags = previousAttrs.cmakeFlags ++ [
-          "-DDEAL_II_DIR=${deal_II_952}"
-          "-DCMAKE_BUILD_TYPE=Release"
-          "-DCMAKE_CXX_FLAGS=-ffast-math"
-        ];
-      });
-      
-      adamantine-latest = adamantine-base.overrideAttrs ( with pkgs; previousAttrs : rec {
-        version = "latest";
-        src = pkgs.lib.cleanSource ./.;
-        buildInputs = previousAttrs.buildInputs ++ [ deal_II_962 ];
-        cmakeFlags = previousAttrs.cmakeFlags ++ [
-          "-DDEAL_II_DIR=${deal_II_962}"
-          "-DCMAKE_BUILD_TYPE=Release"
-          "-DCMAKE_CXX_FLAGS=-ffast-math"
-        ];
-      });
-
-      adamantine-debug = adamantine-base.overrideAttrs ( with pkgs; previousAttrs : rec {
-        version = "debug";
-        separateDebugInfo = true;
-        src = pkgs.lib.cleanSource ./.;
-        buildInputs = previousAttrs.buildInputs ++ [ deal_II_962 ];
-        cmakeFlags = previousAttrs.cmakeFlags ++ [
-          "-DDEAL_II_DIR=${deal_II_962}"
-          "-DCMAKE_BUILD_TYPE=Debug"
-          "-DCMAKE_CXX_FLAGS=-O0"
-          "-DCMAKE_CXX_FLAGS_DEBUG=-g3"
-        ];
-      });
-      
-      myDebugInfoDirs = pkgs.symlinkJoin {
-        name = "myDebugInfoDirs";
-        paths = with pkgs; [
-          adamantine-debug.debug
-        ];
-      };
-      
-    in rec {
-      defaultApp = flake-utils.lib.mkApp {
-        drv = defaultPackage;
-      };
-      defaultPackage = adamantine-latest;
-
-      devShells.default = pkgs.mkShell {
-        buildInputs = [
-          adamantine-latest
-        ];
-      };
-
-      devShells.release = pkgs.mkShell {
-        buildInputs = [
-          adamantine-release
-        ];
-      };
-
-      devShells.debug = pkgs.mkShell {
-        NIX_DEBUG_INFO_DIRS = "${pkgs.lib.getLib myDebugInfoDirs}/lib/debug";
-        buildInputs = [
-          adamantine-debug
-          pkgs.gdb
-        ];
-      };
-    }
-  );
+    devShells = with config; rec {
+      # TODO
+    };
+  });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
           src     = self;
         };
 
+        # Maybe rename if there are ever staging and stable releases.
         stable = callPackage ./nix/adamantine/stable.nix { inherit callPackage; };
       };
     };
@@ -74,7 +75,8 @@
         ];
 
         # Ensure the locales point at the correct archive location.
-        LOCALE_ARCHIVE = "${pkgs.glibcLocales}/lib/locale/locale-archive";
+        LOCALE_ARCHIVE = pkgs.lib.optional (pkgs.stdenv.hostPlatform.isLinux)
+          "${pkgs.glibcLocales}/lib/locale/locale-archive";
       };
     };
   });

--- a/nix/adamantine/common.nix
+++ b/nix/adamantine/common.nix
@@ -1,7 +1,7 @@
 {
     src, version,
 
-    stdenv, fetchFromGitHub,
+    lib, stdenv, fetchFromGitHub,
 
     cmake,
 
@@ -38,16 +38,14 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DADAMANTINE_ENABLE_ADIAK=ON"
     "-DADAMANTINE_ENABLE_CALIPER=ON"
+    "-DCMAKE_CXX_FLAGS=-ffast-math"
+    "-DBUILD_SHARED_LIBS=ON"
   ];
 
-  installPhase = ''
+  # Manual install if using versions 1.0 since adamantine was lacking CMake installs.
+  installPhase = lib.optional (version == "1.0") ''
     mkdir -p $out/bin
     cp bin/adamantine $out/bin
-  '';
-
-  doCheck = true;
-  check = ''
-    ctest -R integration_2d
   '';
 }
 

--- a/nix/adamantine/common.nix
+++ b/nix/adamantine/common.nix
@@ -5,7 +5,10 @@
 
     cmake,
 
-    arborx, adiak, caliper, p4est, trilinos-mpi, boost, openmpi, dealii
+    arborx, adiak, caliper, p4est, trilinos-mpi, boost, openmpi, dealii,
+
+    # Allow extra args as needed for callPackage chaining - not ideal.
+    ...
 }:
 
 stdenv.mkDerivation rec {

--- a/nix/adamantine/common.nix
+++ b/nix/adamantine/common.nix
@@ -1,0 +1,50 @@
+{
+    src, version,
+
+    stdenv, fetchFromGitHub,
+
+    cmake,
+
+    arborx, adiak, caliper, p4est, trilinos-mpi, boost, openmpi, dealii
+}:
+
+stdenv.mkDerivation rec {
+  pname = "adamantine";
+  inherit version;
+
+  inherit src;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    arborx
+    adiak
+    caliper
+    p4est
+    trilinos-mpi
+    boost
+    dealii
+  ];
+
+  propagatedBuildInputs = [
+    openmpi
+  ];
+
+  cmakeFlags = [
+    "-DADAMANTINE_ENABLE_ADIAK=ON"
+    "-DADAMANTINE_ENABLE_CALIPER=ON"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp bin/adamantine $out/bin
+  '';
+
+  doCheck = true;
+  check = ''
+    ctest -R integration_2d
+  '';
+}
+

--- a/nix/adamantine/stable.nix
+++ b/nix/adamantine/stable.nix
@@ -1,0 +1,13 @@
+attrs @ { callPackage, fetchFromGitHub, ... }:
+
+callPackage ./common.nix (
+  rec {
+    version = "1.0";
+    src = fetchFromGitHub {
+      owner = "adamantine-sim";
+      repo  = "adamantine";
+      rev   = "v${version}";
+      hash  = "sha256-pwwGgk4uIEOkyNLN26nRYvkzQZR53TJW14R9P99E3Ts=";
+    };
+  } // attrs
+)

--- a/nix/dependencies/adiak.nix
+++ b/nix/dependencies/adiak.nix
@@ -1,0 +1,29 @@
+{
+  stdenv, fetchFromGitHub,
+
+  cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "adiak";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "LLNL";
+    repo  = "Adiak";
+    rev   = "v${version}";
+    hash  = "sha256-S4ZLU6f/njdZXyoQdCJIDzpQTSmfapZiRe4zIex5f0Q=";
+
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DCMAKE_BUILD_TYPE=Release"
+  ];
+}
+

--- a/nix/dependencies/arborx.nix
+++ b/nix/dependencies/arborx.nix
@@ -1,0 +1,36 @@
+{
+  stdenv, fetchFromGitHub,
+
+  cmake,
+
+  openmpi, trilinos-mpi
+}:
+
+stdenv.mkDerivation rec {
+  pname = "arborx";
+  version = "1.5";
+
+  src = fetchFromGitHub {
+    owner = "arborx";
+    repo  = "ArborX";
+    rev   = "v${version}";
+    hash  = "sha256-XhvWKex7sKACY90emvV9uGw/ACI00dLq1HoeG2nWthk=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    openmpi
+    trilinos-mpi
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DCMAKE_CXX_EXTENSIONS=OFF"
+    "-DARBORX_ENABLE_MPI=ON"
+  ];
+}
+

--- a/nix/dependencies/caliper.nix
+++ b/nix/dependencies/caliper.nix
@@ -1,0 +1,42 @@
+{
+    stdenv, fetchFromGitHub,
+
+    cmake, python3,
+
+    adiak, openmpi
+}:
+
+stdenv.mkDerivation rec {
+  pname = "caliper";
+  version = "2.10.0";
+
+  src = fetchFromGitHub {
+    owner = "LLNL";
+    repo  = "caliper";
+    rev   = "v${version}";
+    hash  = "sha256-4rnPbRYtciohLnThtonTrUBO+d8vyWvJsCgoqbJI5Rg=";
+
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    python3
+  ];
+
+  buildInputs = [
+    adiak
+    openmpi
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DWITH_ADIAK=ON"
+    "-DWITH_LIBDW=ON"
+    "-DWITH_LIBPFM=ON"
+    "-DWITH_LIBUNWIND=ON"
+    "-DWITH_MPI=ON"
+    "-DWITH_SAMPLER=ON"
+  ];
+}

--- a/nix/dependencies/dealii.nix
+++ b/nix/dependencies/dealii.nix
@@ -1,0 +1,45 @@
+{
+  stdenv, fetchFromGitHub,
+
+  cmake,
+
+  openmpi, trilinos-mpi, arborx, p4est, boost
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dealii";
+  version = "9.6.2";
+
+  src = fetchFromGitHub {
+    owner = "dealii";
+    repo  = "dealii";
+    rev   = "v${version}";
+    hash  = "sha256-sIyGSEmGc2JMKwvFRkJJLROUNdLKVhPgfUx1IfjT3dI=";
+  };
+
+  buildInputs = [
+    cmake
+    openmpi
+    trilinos-mpi
+    arborx
+    p4est
+    boost
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=DebugRelease"
+    "-DCMAKE_CXX_STANDARD=17"
+    "-DCMAKE_CXX_EXTENSIONS=OFF"
+    "-DDEAL_II_WITH_TBB=OFF"
+    "-DDEAL_II_WITH_64BIT_INDICES=ON"
+    "-DDEAL_II_WITH_COMPLEX_VALUES=OFF"
+    "-DDEAL_II_WITH_MPI=ON"
+    "-DDEAL_II_WITH_P4EST=ON"
+    "-DDEAL_II_WITH_ARBORX=ON"
+    "-DDEAL_II_WITH_TRILINOS=ON"
+    "-DDEAL_II_TRILINOS_WITH_SEACAS=OFF"
+    "-DDEAL_II_COMPONENT_EXAMPLES=OFF"
+    "-DDEAL_II_WITH_ADOLC=OFF"
+    "-DDEAL_II_ALLOW_BUNDLED=OFF"
+  ];
+}

--- a/nix/dependencies/dealii.nix
+++ b/nix/dependencies/dealii.nix
@@ -17,8 +17,11 @@ stdenv.mkDerivation rec {
     hash  = "sha256-sIyGSEmGc2JMKwvFRkJJLROUNdLKVhPgfUx1IfjT3dI=";
   };
 
-  buildInputs = [
+  nativeBuildInputs = [
     cmake
+  ];
+
+  buildInputs = [
     openmpi
     trilinos-mpi
     arborx

--- a/nix/nixpkgs/config.nix
+++ b/nix/nixpkgs/config.nix
@@ -7,7 +7,7 @@
         version = "14.4.0";
 
         preConfigure = prev.preConfigure + ''
-            cmakeFlagsArray+=(-DTrilinos_ENABLE_ML=ON);
+          cmakeFlagsArray+=(-DTrilinos_ENABLE_ML=ON);
         '';
 
         src = prev.src.override {

--- a/nix/nixpkgs/config.nix
+++ b/nix/nixpkgs/config.nix
@@ -12,6 +12,7 @@
 
         src = prev.src.override {
           sha256 = "sha256-jbXQYEyf/p9F2I/I7jP+0/6OOcH5ArFlUk6LHn453qY=";
+          rev = "${prev.pname}-release-${prevPkgs.lib.replaceStrings [ "." ] [ "-" ] version}";
         };
       });
     }

--- a/nix/nixpkgs/config.nix
+++ b/nix/nixpkgs/config.nix
@@ -1,0 +1,23 @@
+{ ... }:
+
+{
+  overlays = [(
+    finalPkgs: prevPkgs: {
+      trilinos-mpi = prevPkgs.trilinos-mpi.overrideAttrs (final: prev: rec {
+        version = "14.4.0";
+
+        preConfigure = prev.preConfigure + ''
+            cmakeFlagsArray+=(-DTrilinos_ENABLE_ML=ON);
+        '';
+
+        src = prev.src.override {
+          sha256 = "sha256-jbXQYEyf/p9F2I/I7jP+0/6OOcH5ArFlUk6LHn453qY=";
+        };
+      });
+    }
+  )];
+
+  config = {
+    allowUnfree = true;
+  };
+}

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -72,24 +72,58 @@ set(Adamantine_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/validate_input_database.cc
   )
 
-# Because the Adamantine library is just used to simplify testing, we make it
-# static. Thus, once the application is created it can be moved around. The
-# other libraries can still be shared.
-add_library(Adamantine STATIC ${Adamantine_SOURCES} ${Adamantine_HEADERS})
+add_library(${PROJECT_NAME} ${Adamantine_SOURCES} ${Adamantine_HEADERS})
 
-DEAL_II_SETUP_TARGET(Adamantine)
+DEAL_II_SETUP_TARGET(${PROJECT_NAME})
 
-set_target_properties(Adamantine PROPERTIES
+set_target_properties(${PROJECT_NAME} PROPERTIES
     CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
 )
 
-target_link_libraries(Adamantine Boost::boost)
-target_link_libraries(Adamantine Boost::chrono)
-target_link_libraries(Adamantine Boost::program_options)
-target_link_libraries(Adamantine MPI::MPI_CXX)
-target_include_directories(Adamantine PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(${PROJECT_NAME} Boost::boost)
+target_link_libraries(${PROJECT_NAME} Boost::chrono)
+target_link_libraries(${PROJECT_NAME} Boost::program_options)
+target_link_libraries(${PROJECT_NAME} MPI::MPI_CXX)
 if (ADAMANTINE_ENABLE_CALIPER)
-  target_link_libraries(Adamantine caliper)
+  target_link_libraries(${PROJECT_NAME} caliper)
 endif()
+
+target_include_directories(
+    ${PROJECT_NAME} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+
+# Install w/ find_package() support
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
+install(
+    TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}Targets
+)
+
+configure_package_config_file(
+    "${PROJECT_SOURCE_DIR}/cmake/templates/${PROJECT_NAME}Config.cmake.in"
+    "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    INSTALL_DESTINATION lib/cmake/${PROJECT_NAME}
+)
+
+install(
+    EXPORT      ${PROJECT_NAME}Targets
+    DESTINATION lib/cmake/${PROJECT_NAME}
+)
+install(
+    FILES       "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake" "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    DESTINATION lib/cmake/${PROJECT_NAME}
+)
+install(
+    DIRECTORY   "${CMAKE_CURRENT_LIST_DIR}/"
+    DESTINATION include
+)

--- a/source/PostProcessor.cc
+++ b/source/PostProcessor.cc
@@ -44,6 +44,9 @@ PostProcessor<dim>::PostProcessor(MPI_Comm const &communicator,
         _filename_prefix + "_m" + std::to_string(ensemble_member_index);
   }
 
+  // PropertyTreeInput post_processor.output_dir
+  _output_dir = database.get<std::string>("output_dir");
+
   // PropertyTreeInput post_processor.additional_output_refinement
   _additional_output_refinement =
       database.get<unsigned int>("additional_output_refinement", 0);
@@ -82,7 +85,7 @@ void PostProcessor<dim>::write_pvd() const
   unsigned int rank = dealii::Utilities::MPI::this_mpi_process(_communicator);
   if (rank == 0)
   {
-    std::ofstream output(_filename_prefix + ".pvd");
+    std::ofstream output(_output_dir + _filename_prefix + ".pvd");
     dealii::DataOutBase::write_pvd_record(output, _times_filenames);
   }
 }
@@ -172,7 +175,7 @@ void PostProcessor<dim>::write_pvtu(unsigned int time_step, double time)
   dealii::types::subdomain_id subdomain_id =
       dof_handler->get_triangulation().locally_owned_subdomain();
   _data_out.build_patches(_additional_output_refinement);
-  std::string local_filename = _filename_prefix + "." +
+  std::string local_filename = _output_dir + _filename_prefix + "." +
                                dealii::Utilities::to_string(time_step) + "." +
                                dealii::Utilities::to_string(subdomain_id);
   std::ofstream output((local_filename + ".vtu").c_str());
@@ -193,7 +196,7 @@ void PostProcessor<dim>::write_pvtu(unsigned int time_step, double time)
                                dealii::Utilities::to_string(i) + ".vtu";
       filenames.push_back(local_name);
     }
-    std::string pvtu_filename = _filename_prefix + "." +
+    std::string pvtu_filename = _output_dir + _filename_prefix + "." +
                                 dealii::Utilities::to_string(time_step) +
                                 ".pvtu";
     std::ofstream pvtu_output(pvtu_filename.c_str());

--- a/source/PostProcessor.hh
+++ b/source/PostProcessor.hh
@@ -162,6 +162,10 @@ private:
    */
   std::string _filename_prefix;
   /**
+   * Output directory name.
+   */
+  std::string _output_dir;
+  /**
    * Vector of pair of time and pvtu file.
    */
   std::vector<std::pair<double, std::string>> _times_filenames;

--- a/source/ensemble_management.cc
+++ b/source/ensemble_management.cc
@@ -247,8 +247,10 @@ std::vector<boost::property_tree::ptree> create_database_ensemble(
   {
     for (unsigned int member = 0; member < local_ensemble_size; ++member)
     {
-
+      std::string output_dir =
+          database.get<std::string>("post_processor.output_dir");
       std::string member_data_filename =
+          output_dir +
           database.get<std::string>("post_processor.filename_prefix") + "_m" +
           std::to_string(first_local_member + member) + "_data.txt";
       std::ofstream file(member_data_filename);


### PR DESCRIPTION
Got slightly carried away while helping Ashley make use of the `flake.nix` for a native development environment, so I figured I would push back all the changes I made.

- Reworks nix flake to use more standard packaging scheme / `nix develop` shells. Support for direnv.
- Adds standard CMake install template for automatic install + support for downstream `find_package` calls.
- Adds basic `CMakePresets.json`.
- Adds new `-o` output flag for directly specifying the output directory for files, can be specified in `post_processing.output_dir` if not specified on the command line.
- Also sneaks in a `.gitignore`, let me know if you don't want this.
- Always changes adamantine `cwd` to the input path to avoid looking in the wrong place for files. This means files are now specified relative to the `.info` file.
- VSCode tasks/debug config using the command-variable plugin.

Let me know if some parts of this are unwanted, I'm happy to break this up or cherry-pick whatever you want out of these commits.

cc @wd15 for nix testing, let me know if this affects your workflow.