### PR TITLE
Improved directory handling

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,14 +14,14 @@
   ],
   "buildPresets": [
     {
-      "name":            "debug-gcc-ninja",
+      "name":            "build-debug-gcc-ninja",
       "displayName":     "Debug (gcc-ninja)",
       "description":     "Compile a debug build using GCC.",
       "configurePreset": "generic-gcc-ninja",
       "configuration":   "Debug"
     },
     {
-      "name":            "release-gcc-ninja",
+      "name":            "build-release-gcc-ninja",
       "displayName":     "Release (gcc-ninja)",
       "description":     "Compile a release build using GCC.",
       "configurePreset": "generic-gcc-ninja",

--- a/application/adamantine.cc
+++ b/application/adamantine.cc
@@ -146,7 +146,10 @@ int main(int argc, char *argv[])
     boost_po::options_description description("Options:");
     description.add_options()("help,h", "Produce help message.")(
         "input-file,i", boost_po::value<std::string>(),
-        "Name of the input file.");
+        "Name of the input file.")("output-dir,o",
+                                   boost_po::value<std::string>(),
+                                   "Output directory; defaults to the current working directory.");
+
     // Declare a map that will contains the values read. Parse the command
     // line and finally populate the map.
     boost_po::variables_map map;
@@ -196,6 +199,30 @@ int main(int argc, char *argv[])
       std::cerr << exception.what() << std::endl;
       return 0;
     }
+
+    // Abusing the database to pull out the output dir when writing the output
+    if (map.count("output-dir") == 1)
+    {
+      try
+      {
+        std::string outdir =
+            std::filesystem::absolute(map["output-dir"].as<std::string>())
+                .string() +
+            std::filesystem::path::preferred_separator;
+        std::filesystem::create_directories(outdir);
+
+        database.put("post_processor.output_dir", outdir);
+      }
+      catch (std::runtime_error const &exception)
+      {
+        std::cerr << exception.what() << std::endl;
+        return 0;
+      }
+    }
+
+    // Make adamantine behave a bit better and not lock up if not in cwd of
+    // current input file
+    std::filesystem::current_path(std::filesystem::absolute(filename).parent_path());
 
 #ifdef ADAMANTINE_WITH_CALIPER
     cali::ConfigManager caliper_manager;

--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -1201,12 +1201,15 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
       {
         std::cout << "Checkpoint reached" << std::endl;
       }
+
+      std::string output_dir =
+          post_processor_database.get<std::string>("output_dir", "");
       std::string filename_prefix =
           checkpoint_overwrite
               ? checkpoint_filename
               : checkpoint_filename + '_' + std::to_string(n_time_step);
       thermal_physics->save_checkpoint(filename_prefix, temperature);
-      std::ofstream file{filename_prefix + "_time.txt"};
+      std::ofstream file{output_dir + filename_prefix + "_time.txt"};
       boost::archive::text_oarchive oa{file};
       oa << time;
       oa << n_time_step;
@@ -2191,6 +2194,9 @@ run_ensemble(MPI_Comm const &global_communicator,
       {
         std::cout << "Checkpoint reached" << std::endl;
       }
+
+      std::string output_dir =
+          post_processor_database.get<std::string>("output_dir", "");
       std::string filename_prefix =
           checkpoint_overwrite
               ? checkpoint_filename
@@ -2201,7 +2207,7 @@ run_ensemble(MPI_Comm const &global_communicator,
             filename_prefix + '_' + std::to_string(first_local_member + member),
             solution_augmented_ensemble[member].block(base_state));
       }
-      std::ofstream file{filename_prefix + "_time.txt"};
+      std::ofstream file{output_dir + filename_prefix + "_time.txt"};
       boost::archive::text_oarchive oa{file};
       oa << time;
       oa << n_time_step;

--- a/source/PostProcessor.cc
+++ b/source/PostProcessor.cc
@@ -44,6 +44,9 @@ PostProcessor<dim>::PostProcessor(MPI_Comm const &communicator,
         _filename_prefix + "_m" + std::to_string(ensemble_member_index);
   }
 
+  // PropertyTreeInput post_processor.output_dir
+  _output_dir = database.get<std::string>("output_dir", "");
+
   // PropertyTreeInput post_processor.additional_output_refinement
   _additional_output_refinement =
       database.get<unsigned int>("additional_output_refinement", 0);
@@ -82,7 +85,7 @@ void PostProcessor<dim>::write_pvd() const
   unsigned int rank = dealii::Utilities::MPI::this_mpi_process(_communicator);
   if (rank == 0)
   {
-    std::ofstream output(_filename_prefix + ".pvd");
+    std::ofstream output(_output_dir + _filename_prefix + ".pvd");
     dealii::DataOutBase::write_pvd_record(output, _times_filenames);
   }
 }
@@ -172,7 +175,7 @@ void PostProcessor<dim>::write_pvtu(unsigned int time_step, double time)
   dealii::types::subdomain_id subdomain_id =
       dof_handler->get_triangulation().locally_owned_subdomain();
   _data_out.build_patches(_additional_output_refinement);
-  std::string local_filename = _filename_prefix + "." +
+  std::string local_filename = _output_dir + _filename_prefix + "." +
                                dealii::Utilities::to_string(time_step) + "." +
                                dealii::Utilities::to_string(subdomain_id);
   std::ofstream output((local_filename + ".vtu").c_str());
@@ -193,7 +196,7 @@ void PostProcessor<dim>::write_pvtu(unsigned int time_step, double time)
                                dealii::Utilities::to_string(i) + ".vtu";
       filenames.push_back(local_name);
     }
-    std::string pvtu_filename = _filename_prefix + "." +
+    std::string pvtu_filename = _output_dir + _filename_prefix + "." +
                                 dealii::Utilities::to_string(time_step) +
                                 ".pvtu";
     std::ofstream pvtu_output(pvtu_filename.c_str());

--- a/source/PostProcessor.hh
+++ b/source/PostProcessor.hh
@@ -162,6 +162,10 @@ private:
    */
   std::string _filename_prefix;
   /**
+   * Output directory name.
+   */
+  std::string _output_dir;
+  /**
    * Vector of pair of time and pvtu file.
    */
   std::vector<std::pair<double, std::string>> _times_filenames;

--- a/source/ensemble_management.cc
+++ b/source/ensemble_management.cc
@@ -247,8 +247,10 @@ std::vector<boost::property_tree::ptree> create_database_ensemble(
   {
     for (unsigned int member = 0; member < local_ensemble_size; ++member)
     {
-
+      std::string output_dir =
+          database.get<std::string>("post_processor.output_dir", "");
       std::string member_data_filename =
+          output_dir +
           database.get<std::string>("post_processor.filename_prefix") + "_m" +
           std::to_string(first_local_member + member) + "_data.txt";
       std::ofstream file(member_data_filename);


### PR DESCRIPTION
Split out of #364.

Allows for the explicit definition of the output directory via a '-o' flag on the command line. The quick implementation sticks the output dir in the input file ptree, so this has (unintended) side-effect of allowing configuration of the output directory from the .info file. The key is post_processing.output_dir.

Additionally, also makes a small change where if you call adamantine from a different directory than the .info file, it will change the PWD to that containing directory. This fixes a small bug where adamantine would just spin its heels waiting on files in the wrong locations.