### PR TITLE
Return early if the heat source is almost zero

### DIFF
--- a/source/ElectronBeamHeatSource.cc
+++ b/source/ElectronBeamHeatSource.cc
@@ -1,4 +1,4 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2020 - 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2020 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -49,6 +49,13 @@ double ElectronBeamHeatSource<dim>::value(dealii::Point<dim> const &point,
     {
       xpy_squared +=
           std::pow(point[axis<dim>::y] - _beam_center[axis<dim>::y], 2);
+    }
+
+    // Evaluating the exponential is very expensive. Return early if we know
+    // that the heat source will be small.
+    if (xpy_squared > 5. * this->_beam.radius_squared)
+    {
+      return 0.;
     }
 
     // Electron beam heat source equation

--- a/source/GoldakHeatSource.cc
+++ b/source/GoldakHeatSource.cc
@@ -1,4 +1,4 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2020 - 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2020 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -45,6 +45,13 @@ double GoldakHeatSource<dim>::value(dealii::Point<dim> const &point,
     {
       xpy_squared +=
           std::pow(point[axis<dim>::y] - _beam_center[axis<dim>::y], 2);
+    }
+
+    // Evaluating the exponential is very expensive. Return early if we know
+    // that the heat source will be small.
+    if (xpy_squared > 5. * this->_beam.radius_squared)
+    {
+      return 0.;
     }
 
     // Goldak heat source equation


### PR DESCRIPTION
The heat source contains an exponential and evaluating it is very expensive. We can get a 10% speedup in the operator evaluation by returning early if we know that the exponential will be close to zero.