### PR TITLE
Update CI

### DIFF
--- a/ci/jenkins_config
+++ b/ci/jenkins_config
@@ -25,6 +25,9 @@ pipeline {
                 label 'nvidia-docker || rocm-docker'
             }
           }
+          environment {
+            BOOST_TEST_LOG_LEVEL = 'test_suite'
+          }
           steps {
             sh 'rm -rf build && mkdir -p build'
               dir('build') {
@@ -39,7 +42,7 @@ pipeline {
                   ..
                 '''
                 sh 'make -j8'
-                sh 'ctest --timeout 3600 --no-compress-output -R test_ -T Test'
+                sh 'ctest -V --timeout 3600 --no-compress-output -R test_ -T Test'
               }
           }
           post {
@@ -57,6 +60,9 @@ pipeline {
                 label 'nvidia-docker && ampere'
             }
           }
+          environment {
+            BOOST_TEST_LOG_LEVEL = 'test_suite'
+          }
           steps {
             sh 'rm -rf build && mkdir -p build'
               dir('build') {
@@ -70,7 +76,7 @@ pipeline {
                   ..
                 '''
                 sh 'make -j8'
-                sh 'ctest --timeout 3600 --no-compress-output -R test_ -T Test'
+                sh 'ctest -V --timeout 3600 --no-compress-output -R test_ -T Test'
               }
           }
           post {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(UNIT_TESTS "")
 list(APPEND
      UNIT_TESTS
      test_data_assimilator
+     test_experimental_data
      test_geometry
      test_heat_source
      test_implicit_operator
@@ -30,7 +31,6 @@ list(APPEND
 set(MPI_UNIT_TESTS "")
 list(APPEND
      MPI_UNIT_TESTS
-     test_experimental_data
      test_integration_2d
      test_integration_2d_device
      test_integration_3d

--- a/tests/test_experimental_data.cc
+++ b/tests/test_experimental_data.cc
@@ -76,68 +76,63 @@ BOOST_AUTO_TEST_CASE(set_vector_with_experimental_data_point_cloud)
 {
   MPI_Comm communicator = MPI_COMM_WORLD;
 
-  if (dealii::Utilities::MPI::n_mpi_processes(communicator) == 1)
+  adamantine::PointsValues<3> points_values;
+  // Create the points
+  points_values.points.emplace_back(0, 0, 1.);
+  points_values.points.emplace_back(0, 0.5, 1.);
+  points_values.points.emplace_back(0, 1., 1.);
+  points_values.points.emplace_back(0.5, 0., 1.);
+  points_values.points.emplace_back(0.5, 0.5, 1.);
+  points_values.points.emplace_back(0.5, 1., 1.);
+  points_values.points.emplace_back(1., 0., 1.);
+  points_values.points.emplace_back(1., 0.5, 1.);
+  points_values.points.emplace_back(1., 1., 1.);
+  // Create the values
+  points_values.values = {1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.};
+
+  boost::property_tree::ptree database;
+  database.put("import_mesh", false);
+  database.put("length", 1);
+  database.put("length_divisions", 2);
+  database.put("height", 1);
+  database.put("height_divisions", 2);
+  database.put("width", 1);
+  database.put("width_divisions", 2);
+  boost::optional<boost::property_tree::ptree const &> units_optional_database;
+  adamantine::Geometry<3> geometry(communicator, database,
+                                   units_optional_database);
+  dealii::parallel::distributed::Triangulation<3> const &tria =
+      geometry.get_triangulation();
+
+  dealii::FE_Q<3> fe(1);
+  dealii::DoFHandler<3> dof_handler(tria);
+  dof_handler.distribute_dofs(fe);
+
+  auto locally_owned_dofs = dof_handler.locally_owned_dofs();
+  dealii::IndexSet locally_relevant_dofs;
+  dealii::DoFTools::extract_locally_relevant_dofs(dof_handler,
+                                                  locally_relevant_dofs);
+  dealii::LinearAlgebra::distributed::Vector<double> temperature(
+      locally_owned_dofs, locally_relevant_dofs, communicator);
+
+  auto expt_to_dof_mapping =
+      adamantine::get_expt_to_dof_mapping(points_values, dof_handler);
+
+  for (unsigned int i = 0; i < points_values.values.size(); ++i)
   {
+    temperature[expt_to_dof_mapping.second[i]] = points_values.values[i];
+  }
 
-    adamantine::PointsValues<3> points_values;
-    // Create the points
-    points_values.points.emplace_back(0, 0, 1.);
-    points_values.points.emplace_back(0, 0.5, 1.);
-    points_values.points.emplace_back(0, 1., 1.);
-    points_values.points.emplace_back(0.5, 0., 1.);
-    points_values.points.emplace_back(0.5, 0.5, 1.);
-    points_values.points.emplace_back(0.5, 1., 1.);
-    points_values.points.emplace_back(1., 0., 1.);
-    points_values.points.emplace_back(1., 0.5, 1.);
-    points_values.points.emplace_back(1., 1., 1.);
-    // Create the values
-    points_values.values = {1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.};
+  temperature.compress(dealii::VectorOperation::insert);
 
-    boost::property_tree::ptree database;
-    database.put("import_mesh", false);
-    database.put("length", 1);
-    database.put("length_divisions", 2);
-    database.put("height", 1);
-    database.put("height_divisions", 2);
-    database.put("width", 1);
-    database.put("width_divisions", 2);
-    boost::optional<boost::property_tree::ptree const &>
-        units_optional_database;
-    adamantine::Geometry<3> geometry(communicator, database,
-                                     units_optional_database);
-    dealii::parallel::distributed::Triangulation<3> const &tria =
-        geometry.get_triangulation();
+  std::vector<double> temperature_ref = {
+      0, 0, 0, 0, 0,   0,   0,   0,   0,   0,   0,   0,   0, 0,
+      0, 0, 0, 0, 1.2, 1.5, 1.3, 1.6, 1.8, 1.9, 1.4, 1.7, 2};
 
-    dealii::FE_Q<3> fe(1);
-    dealii::DoFHandler<3> dof_handler(tria);
-    dof_handler.distribute_dofs(fe);
-
-    auto locally_owned_dofs = dof_handler.locally_owned_dofs();
-    dealii::IndexSet locally_relevant_dofs;
-    dealii::DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                                    locally_relevant_dofs);
-    dealii::LinearAlgebra::distributed::Vector<double> temperature(
-        locally_owned_dofs, locally_relevant_dofs, communicator);
-
-    auto expt_to_dof_mapping =
-        adamantine::get_expt_to_dof_mapping(points_values, dof_handler);
-
-    for (unsigned int i = 0; i < points_values.values.size(); ++i)
-    {
-      temperature[expt_to_dof_mapping.second[i]] = points_values.values[i];
-    }
-
-    temperature.compress(dealii::VectorOperation::insert);
-
-    std::vector<double> temperature_ref = {
-        0, 0, 0, 0, 0,   0,   0,   0,   0,   0,   0,   0,   0, 0,
-        0, 0, 0, 0, 1.2, 1.5, 1.3, 1.6, 1.8, 1.9, 1.4, 1.7, 2};
-
-    for (unsigned int i = 0; i < temperature.locally_owned_size(); ++i)
-    {
-      BOOST_TEST(temperature.local_element(i) ==
-                 temperature_ref[locally_owned_dofs.nth_index_in_set(i)]);
-    }
+  for (unsigned int i = 0; i < temperature.locally_owned_size(); ++i)
+  {
+    BOOST_TEST(temperature.local_element(i) ==
+               temperature_ref[locally_owned_dofs.nth_index_in_set(i)]);
   }
 }
 
@@ -145,66 +140,51 @@ BOOST_AUTO_TEST_CASE(read_experimental_data_ray_tracing_from_file)
 {
   MPI_Comm communicator = MPI_COMM_WORLD;
 
-  auto n_mpi_processes = dealii::Utilities::MPI::n_mpi_processes(communicator);
-  if (n_mpi_processes == 1)
+  boost::property_tree::ptree database;
+  database.put("import_mesh", false);
+  database.put("length", 1);
+  database.put("length_divisions", 2);
+  database.put("height", 1);
+  database.put("height_divisions", 2);
+  database.put("width", 1);
+  database.put("width_divisions", 2);
+  boost::optional<boost::property_tree::ptree const &> units_optional_database;
+  adamantine::Geometry<3> geometry(communicator, database,
+                                   units_optional_database);
+  dealii::parallel::distributed::Triangulation<3> const &tria =
+      geometry.get_triangulation();
+
+  dealii::FE_Q<3> fe(1);
+  dealii::DoFHandler<3> dof_handler(tria);
+  dof_handler.distribute_dofs(fe);
+
+  // Read the rays from file
+  boost::property_tree::ptree experiment_database;
+  experiment_database.put("file",
+                          "raytracing_experimental_data_#camera_#frame.csv");
+  experiment_database.put("last_frame", 0);
+  experiment_database.put("first_camera_id", 0);
+  experiment_database.put("last_camera_id", 0);
+  adamantine::RayTracing ray_tracing(experiment_database, dof_handler);
+  ray_tracing.read_next_frame();
+
+  // Compute the intersection points
+  auto points_values = ray_tracing.get_points_values();
+
+  // Reference solution
+  std::vector<double> values_ref = {1, 2, 3, 5};
+  std::vector<dealii::Point<3>> points_ref;
+  points_ref.emplace_back(0., 0.1, 0.2);
+  points_ref.emplace_back(1., 0.1, 0.001);
+  points_ref.emplace_back(1.0, 1.0, 0.1);
+  points_ref.emplace_back(1.0, 0., 0.5);
+
+  BOOST_TEST(points_values.values.size() = values_ref.size());
+  BOOST_TEST(points_values.points.size() = points_ref.size());
+  for (unsigned int i = 0; i < values_ref.size(); ++i)
   {
-    boost::property_tree::ptree database;
-    database.put("import_mesh", false);
-    database.put("length", 1);
-    database.put("length_divisions", 2);
-    database.put("height", 1);
-    database.put("height_divisions", 2);
-    database.put("width", 1);
-    database.put("width_divisions", 2);
-    boost::optional<boost::property_tree::ptree const &>
-        units_optional_database;
-    adamantine::Geometry<3> geometry(communicator, database,
-                                     units_optional_database);
-    dealii::parallel::distributed::Triangulation<3> const &tria =
-        geometry.get_triangulation();
-
-    dealii::FE_Q<3> fe(1);
-    dealii::DoFHandler<3> dof_handler(tria);
-    dof_handler.distribute_dofs(fe);
-
-    // Read the rays from file
-    boost::property_tree::ptree experiment_database;
-    experiment_database.put("file",
-                            "raytracing_experimental_data_#camera_#frame.csv");
-    experiment_database.put("last_frame", 0);
-    experiment_database.put("first_camera_id", 0);
-    experiment_database.put("last_camera_id", 0);
-    adamantine::RayTracing ray_tracing(experiment_database, dof_handler);
-    ray_tracing.read_next_frame();
-
-    // Compute the intersection points
-    auto points_values = ray_tracing.get_points_values();
-
-    // Reference solution
-    std::vector<double> values_ref = {1, 2, 3, 5};
-    std::vector<dealii::Point<3>> points_ref;
-    points_ref.emplace_back(0., 0.1, 0.2);
-    points_ref.emplace_back(1., 0.1, 0.001);
-    points_ref.emplace_back(1.0, 1.0, 0.1);
-    points_ref.emplace_back(1.0, 0., 0.5);
-
-    if (dealii::Utilities::MPI::this_mpi_process(communicator) == 0)
-    {
-      BOOST_TEST(points_values.values.size() = values_ref.size());
-      BOOST_TEST(points_values.points.size() = points_ref.size());
-      for (unsigned int i = 0; i < values_ref.size(); ++i)
-      {
-        BOOST_TEST(points_values.values[i] == values_ref[i]);
-        BOOST_TEST(points_values.points[i] == points_ref[i]);
-      }
-    }
-    else
-    {
-      std::cout << "'read_experimental_data_ray_tracing_from_file' is "
-                   "currently skipped for multiple "
-                   "MPI processes"
-                << std::endl;
-    }
+    BOOST_TEST(points_values.values[i] == values_ref[i]);
+    BOOST_TEST(points_values.points[i] == points_ref[i]);
   }
 }
 
@@ -239,86 +219,74 @@ BOOST_AUTO_TEST_CASE(project_ray_data_on_mesh, *utf::tolerance(1e-12))
   // NOTE: Currently this is using an IR data file that's not calibrated
   // particularly well. That's ok for these purposes, but we may eventually
   // want to switch to a "better" IR file.
-
   MPI_Comm communicator = MPI_COMM_WORLD;
-  auto n_mpi_processes = dealii::Utilities::MPI::n_mpi_processes(communicator);
-  if (n_mpi_processes == 1)
+
+  // Oversize version of the mesh from the Tormach wall build
+  boost::property_tree::ptree database;
+  database.put("import_mesh", false);
+  database.put("length", 400.0e-3);
+  database.put("length_divisions", 8);
+  database.put("height", 200.0e-3);
+  database.put("height_divisions", 4);
+  database.put("width", 400.0e-3);
+  database.put("width_divisions", 8);
+  database.put("material_height", 100.0e-3);
+  boost::optional<boost::property_tree::ptree const &> units_optional_database;
+
+  adamantine::Geometry<3> geometry(communicator, database,
+                                   units_optional_database);
+  dealii::parallel::distributed::Triangulation<3> const &tria =
+      geometry.get_triangulation();
+
+  dealii::hp::FECollection<3> fe_collection;
+  fe_collection.push_back(dealii::FE_Q<3>(1));
+  fe_collection.push_back(dealii::FE_Nothing<3>());
+  dealii::DoFHandler<3> dof_handler(tria);
+  dof_handler.distribute_dofs(fe_collection);
+
+  auto active_cells = 0;
+  auto inactive_cells = 0;
+
+  double const material_height = database.get("material_height", 1e9);
+  for (auto const &cell :
+       dealii::filter_iterators(dof_handler.active_cell_iterators(),
+                                dealii::IteratorFilters::LocallyOwnedCell()))
   {
-
-    // Oversize version of the mesh from the Tormach wall build
-    boost::property_tree::ptree database;
-    database.put("import_mesh", false);
-    database.put("length", 400.0e-3);
-    database.put("length_divisions", 8);
-    database.put("height", 200.0e-3);
-    database.put("height_divisions", 4);
-    database.put("width", 400.0e-3);
-    database.put("width_divisions", 8);
-    database.put("material_height", 100.0e-3);
-    boost::optional<boost::property_tree::ptree const &>
-        units_optional_database;
-
-    adamantine::Geometry<3> geometry(communicator, database,
-                                     units_optional_database);
-    dealii::parallel::distributed::Triangulation<3> const &tria =
-        geometry.get_triangulation();
-
-    dealii::hp::FECollection<3> fe_collection;
-    fe_collection.push_back(dealii::FE_Q<3>(1));
-    fe_collection.push_back(dealii::FE_Nothing<3>());
-    dealii::DoFHandler<3> dof_handler(tria);
-    dof_handler.distribute_dofs(fe_collection);
-
-    auto active_cells = 0;
-    auto inactive_cells = 0;
-
-    double const material_height = database.get("material_height", 1e9);
-    for (auto const &cell :
-         dealii::filter_iterators(dof_handler.active_cell_iterators(),
-                                  dealii::IteratorFilters::LocallyOwnedCell()))
+    // If the center of the cell is below material_height, it contains
+    // material otherwise it does not.
+    if (cell->center()[2] < material_height)
     {
-      // If the center of the cell is below material_height, it contains
-      // material otherwise it does not.
-      if (cell->center()[2] < material_height)
-      {
-        cell->set_active_fe_index(0);
-        active_cells++;
-      }
-      else
-      {
-        cell->set_active_fe_index(1);
-        inactive_cells++;
-      }
+      cell->set_active_fe_index(0);
+      active_cells++;
     }
-
-    BOOST_CHECK(active_cells == 128);
-    BOOST_CHECK(inactive_cells == 128);
-
-    // Read the rays from file
-    boost::property_tree::ptree experiment_database;
-    experiment_database.put("file", "rays_cam-#camera-#frame_test_full.csv");
-    experiment_database.put("last_frame", 0);
-    experiment_database.put("first_camera_id", 0);
-    experiment_database.put("last_camera_id", 0);
-
-    adamantine::RayTracing ray_tracing(experiment_database, dof_handler);
-    ray_tracing.read_next_frame();
-
-    // Compute the intersection points
-    auto points_values = ray_tracing.get_points_values();
-
-    BOOST_CHECK(points_values.points.size() == 174954);
-
-    // Get the experiment to dof mapping
-    auto expt_to_dof_mapping =
-        adamantine::get_expt_to_dof_mapping<3>(points_values, dof_handler);
-
-    BOOST_CHECK(expt_to_dof_mapping.first.size() == 174954);
+    else
+    {
+      cell->set_active_fe_index(1);
+      inactive_cells++;
+    }
   }
-  else
-  {
-    std::cout << "'project_ray_data_on_mesh' is currently skipped for multiple "
-                 "MPI processes"
-              << std::endl;
-  }
+
+  BOOST_CHECK(active_cells == 128);
+  BOOST_CHECK(inactive_cells == 128);
+
+  // Read the rays from file
+  boost::property_tree::ptree experiment_database;
+  experiment_database.put("file", "rays_cam-#camera-#frame_test_full.csv");
+  experiment_database.put("last_frame", 0);
+  experiment_database.put("first_camera_id", 0);
+  experiment_database.put("last_camera_id", 0);
+
+  adamantine::RayTracing ray_tracing(experiment_database, dof_handler);
+  ray_tracing.read_next_frame();
+
+  // Compute the intersection points
+  auto points_values = ray_tracing.get_points_values();
+
+  BOOST_CHECK(points_values.points.size() == 174954);
+
+  // Get the experiment to dof mapping
+  auto expt_to_dof_mapping =
+      adamantine::get_expt_to_dof_mapping<3>(points_values, dof_handler);
+
+  BOOST_CHECK(expt_to_dof_mapping.first.size() == 174954);
 }

--- a/tests/test_material_deposition.cc
+++ b/tests/test_material_deposition.cc
@@ -19,6 +19,33 @@
 #include "main.cc"
 
 namespace utf = boost::unit_test;
+namespace tt = boost::test_tools;
+
+struct serial_only
+{
+  // We need a dummy variable, otherwise we get a warning about using an
+  // uninitialized object. The warning prevents us to use a lambda function.
+  int dummy = 1;
+
+  serial_only() = default;
+
+  tt::assertion_result operator()(utf::test_unit_id)
+  {
+    MPI_Comm communicator = MPI_COMM_WORLD;
+    auto n_mpi_processes =
+        dealii::Utilities::MPI::n_mpi_processes(communicator);
+    if (n_mpi_processes == 1)
+    {
+      return true;
+    }
+    else
+    {
+      tt::assertion_result ans(false);
+      ans.message() << "the test only works in serial";
+      return ans;
+    }
+  }
+};
 
 BOOST_AUTO_TEST_CASE(read_material_deposition_file_2d, *utf::tolerance(1e-13))
 {
@@ -104,134 +131,127 @@ BOOST_AUTO_TEST_CASE(read_material_deposition_file_3d, *utf::tolerance(1e-13))
   }
 }
 
-BOOST_AUTO_TEST_CASE(get_elements_to_activate_2d)
+BOOST_AUTO_TEST_CASE(get_elements_to_activate_2d,
+                     *utf::precondition(serial_only()))
 {
-  MPI_Comm communicator = MPI_COMM_WORLD;
-  if (dealii::Utilities::MPI::n_mpi_processes(communicator) == 1)
+  // Geometry database
+  boost::property_tree::ptree geometry_database;
+  geometry_database.put("import_mesh", false);
+  geometry_database.put("length", 12);
+  geometry_database.put("length_divisions", 12);
+  geometry_database.put("height", 6);
+  geometry_database.put("height_divisions", 6);
+  boost::optional<boost::property_tree::ptree const &> units_optional_database;
+
+  adamantine::Geometry<2> geometry(communicator, geometry_database,
+                                   units_optional_database);
+  dealii::parallel::distributed::Triangulation<2> const &tria =
+      geometry.get_triangulation();
+
+  dealii::hp::FECollection<2> fe_collection;
+  fe_collection.push_back(dealii::FE_Q<2>(1));
+  fe_collection.push_back(dealii::FE_Nothing<2>());
+  dealii::DoFHandler<2> dof_handler(tria);
+  dof_handler.distribute_dofs(fe_collection);
+  for (auto const &cell :
+       dealii::filter_iterators(dof_handler.active_cell_iterators(),
+                                dealii::IteratorFilters::LocallyOwnedCell()))
+    cell->set_active_fe_index(1);
+
+  std::vector<dealii::BoundingBox<2>> bounding_boxes;
+  bounding_boxes.emplace_back(
+      std::make_pair(dealii::Point<2>(0.1, 0.1), dealii::Point<2>(0.2, 0.2)));
+  bounding_boxes.emplace_back(
+      std::make_pair(dealii::Point<2>(1.1, 0.1), dealii::Point<2>(2.2, 0.2)));
+  bounding_boxes.emplace_back(
+      std::make_pair(dealii::Point<2>(4.5, 4.5), dealii::Point<2>(5.5, 5.5)));
+
+  auto elements_to_activate =
+      adamantine::get_elements_to_activate(dof_handler, bounding_boxes);
+
+  BOOST_TEST(elements_to_activate.size() == bounding_boxes.size());
+
+  std::vector<std::vector<dealii::CellId>> cell_id_ref(3);
+  cell_id_ref[0].push_back(dealii::CellId("0_0:"));
+  cell_id_ref[1].push_back(dealii::CellId("1_0:"));
+  cell_id_ref[1].push_back(dealii::CellId("4_0:"));
+  cell_id_ref[2].push_back(dealii::CellId("40_0:"));
+  cell_id_ref[2].push_back(dealii::CellId("41_0:"));
+  cell_id_ref[2].push_back(dealii::CellId("42_0:"));
+  cell_id_ref[2].push_back(dealii::CellId("43_0:"));
+
+  for (unsigned int i = 0; i < cell_id_ref.size(); ++i)
   {
-    // Geometry database
-    boost::property_tree::ptree geometry_database;
-    geometry_database.put("import_mesh", false);
-    geometry_database.put("length", 12);
-    geometry_database.put("length_divisions", 12);
-    geometry_database.put("height", 6);
-    geometry_database.put("height_divisions", 6);
-    boost::optional<boost::property_tree::ptree const &>
-        units_optional_database;
-
-    adamantine::Geometry<2> geometry(communicator, geometry_database,
-                                     units_optional_database);
-    dealii::parallel::distributed::Triangulation<2> const &tria =
-        geometry.get_triangulation();
-
-    dealii::hp::FECollection<2> fe_collection;
-    fe_collection.push_back(dealii::FE_Q<2>(1));
-    fe_collection.push_back(dealii::FE_Nothing<2>());
-    dealii::DoFHandler<2> dof_handler(tria);
-    dof_handler.distribute_dofs(fe_collection);
-    for (auto const &cell :
-         dealii::filter_iterators(dof_handler.active_cell_iterators(),
-                                  dealii::IteratorFilters::LocallyOwnedCell()))
-      cell->set_active_fe_index(1);
-
-    std::vector<dealii::BoundingBox<2>> bounding_boxes;
-    bounding_boxes.emplace_back(
-        std::make_pair(dealii::Point<2>(0.1, 0.1), dealii::Point<2>(0.2, 0.2)));
-    bounding_boxes.emplace_back(
-        std::make_pair(dealii::Point<2>(1.1, 0.1), dealii::Point<2>(2.2, 0.2)));
-    bounding_boxes.emplace_back(
-        std::make_pair(dealii::Point<2>(4.5, 4.5), dealii::Point<2>(5.5, 5.5)));
-
-    auto elements_to_activate =
-        adamantine::get_elements_to_activate(dof_handler, bounding_boxes);
-
-    BOOST_TEST(elements_to_activate.size() == bounding_boxes.size());
-
-    std::vector<std::vector<dealii::CellId>> cell_id_ref(3);
-    cell_id_ref[0].push_back(dealii::CellId("0_0:"));
-    cell_id_ref[1].push_back(dealii::CellId("1_0:"));
-    cell_id_ref[1].push_back(dealii::CellId("4_0:"));
-    cell_id_ref[2].push_back(dealii::CellId("40_0:"));
-    cell_id_ref[2].push_back(dealii::CellId("41_0:"));
-    cell_id_ref[2].push_back(dealii::CellId("42_0:"));
-    cell_id_ref[2].push_back(dealii::CellId("43_0:"));
-
-    for (unsigned int i = 0; i < cell_id_ref.size(); ++i)
+    BOOST_TEST(elements_to_activate[i].size() == cell_id_ref[i].size());
+    for (unsigned int j = 0; j < cell_id_ref[i].size(); ++j)
     {
-      BOOST_TEST(elements_to_activate[i].size() == cell_id_ref[i].size());
-      for (unsigned int j = 0; j < cell_id_ref[i].size(); ++j)
-      {
-        BOOST_TEST(elements_to_activate[i][j]->id() == cell_id_ref[i][j]);
-      }
+      BOOST_TEST(elements_to_activate[i][j]->id() == cell_id_ref[i][j]);
     }
   }
 }
 
-BOOST_AUTO_TEST_CASE(get_elements_to_activate_3d)
+BOOST_AUTO_TEST_CASE(get_elements_to_activate_3d,
+                     *utf::precondition(serial_only()))
 {
   MPI_Comm communicator = MPI_COMM_WORLD;
-  if (dealii::Utilities::MPI::n_mpi_processes(communicator) == 1)
+  // Geometry database
+  boost::property_tree::ptree geometry_database;
+  geometry_database.put("import_mesh", false);
+  geometry_database.put("length", 12);
+  geometry_database.put("length_divisions", 12);
+  geometry_database.put("width", 6);
+  geometry_database.put("width_divisions", 6);
+  geometry_database.put("height", 6);
+  geometry_database.put("height_divisions", 6);
+  boost::optional<boost::property_tree::ptree const &> units_optional_database;
+
+  adamantine::Geometry<3> geometry(communicator, geometry_database,
+                                   units_optional_database);
+  dealii::parallel::distributed::Triangulation<3> const &tria =
+      geometry.get_triangulation();
+
+  dealii::hp::FECollection<3> fe_collection;
+  fe_collection.push_back(dealii::FE_Q<3>(1));
+  fe_collection.push_back(dealii::FE_Nothing<3>());
+  dealii::DoFHandler<3> dof_handler(tria);
+  dof_handler.distribute_dofs(fe_collection);
+  for (auto const &cell :
+       dealii::filter_iterators(dof_handler.active_cell_iterators(),
+                                dealii::IteratorFilters::LocallyOwnedCell()))
+    cell->set_active_fe_index(1);
+
+  std::vector<dealii::BoundingBox<3>> bounding_boxes;
+  bounding_boxes.emplace_back(std::make_pair(dealii::Point<3>(0.1, 0.1, 0.1),
+                                             dealii::Point<3>(0.2, 0.2, 0.2)));
+  bounding_boxes.emplace_back(std::make_pair(dealii::Point<3>(1.1, 0.1, 0.1),
+                                             dealii::Point<3>(2.2, 0.2, 0.2)));
+  bounding_boxes.emplace_back(std::make_pair(dealii::Point<3>(4.5, 4.5, 4.5),
+                                             dealii::Point<3>(5.5, 5.5, 5.5)));
+
+  auto elements_to_activate =
+      adamantine::get_elements_to_activate(dof_handler, bounding_boxes);
+
+  BOOST_TEST(elements_to_activate.size() == bounding_boxes.size());
+
+  std::vector<std::vector<dealii::CellId>> cell_id_ref(3);
+  cell_id_ref[0].push_back(dealii::CellId("0_0:"));
+  cell_id_ref[1].push_back(dealii::CellId("1_0:"));
+  cell_id_ref[1].push_back(dealii::CellId("8_0:"));
+  cell_id_ref[2].push_back(dealii::CellId("272_0:"));
+  cell_id_ref[2].push_back(dealii::CellId("273_0:"));
+  cell_id_ref[2].push_back(dealii::CellId("276_0:"));
+  cell_id_ref[2].push_back(dealii::CellId("277_0:"));
+  cell_id_ref[2].push_back(dealii::CellId("274_0:"));
+  cell_id_ref[2].push_back(dealii::CellId("275_0:"));
+  cell_id_ref[2].push_back(dealii::CellId("278_0:"));
+  cell_id_ref[2].push_back(dealii::CellId("279_0:"));
+
+  for (unsigned int i = 0; i < cell_id_ref.size(); ++i)
   {
-    // Geometry database
-    boost::property_tree::ptree geometry_database;
-    geometry_database.put("import_mesh", false);
-    geometry_database.put("length", 12);
-    geometry_database.put("length_divisions", 12);
-    geometry_database.put("width", 6);
-    geometry_database.put("width_divisions", 6);
-    geometry_database.put("height", 6);
-    geometry_database.put("height_divisions", 6);
-    boost::optional<boost::property_tree::ptree const &>
-        units_optional_database;
-
-    adamantine::Geometry<3> geometry(communicator, geometry_database,
-                                     units_optional_database);
-    dealii::parallel::distributed::Triangulation<3> const &tria =
-        geometry.get_triangulation();
-
-    dealii::hp::FECollection<3> fe_collection;
-    fe_collection.push_back(dealii::FE_Q<3>(1));
-    fe_collection.push_back(dealii::FE_Nothing<3>());
-    dealii::DoFHandler<3> dof_handler(tria);
-    dof_handler.distribute_dofs(fe_collection);
-    for (auto const &cell :
-         dealii::filter_iterators(dof_handler.active_cell_iterators(),
-                                  dealii::IteratorFilters::LocallyOwnedCell()))
-      cell->set_active_fe_index(1);
-
-    std::vector<dealii::BoundingBox<3>> bounding_boxes;
-    bounding_boxes.emplace_back(std::make_pair(
-        dealii::Point<3>(0.1, 0.1, 0.1), dealii::Point<3>(0.2, 0.2, 0.2)));
-    bounding_boxes.emplace_back(std::make_pair(
-        dealii::Point<3>(1.1, 0.1, 0.1), dealii::Point<3>(2.2, 0.2, 0.2)));
-    bounding_boxes.emplace_back(std::make_pair(
-        dealii::Point<3>(4.5, 4.5, 4.5), dealii::Point<3>(5.5, 5.5, 5.5)));
-
-    auto elements_to_activate =
-        adamantine::get_elements_to_activate(dof_handler, bounding_boxes);
-
-    BOOST_TEST(elements_to_activate.size() == bounding_boxes.size());
-
-    std::vector<std::vector<dealii::CellId>> cell_id_ref(3);
-    cell_id_ref[0].push_back(dealii::CellId("0_0:"));
-    cell_id_ref[1].push_back(dealii::CellId("1_0:"));
-    cell_id_ref[1].push_back(dealii::CellId("8_0:"));
-    cell_id_ref[2].push_back(dealii::CellId("272_0:"));
-    cell_id_ref[2].push_back(dealii::CellId("273_0:"));
-    cell_id_ref[2].push_back(dealii::CellId("276_0:"));
-    cell_id_ref[2].push_back(dealii::CellId("277_0:"));
-    cell_id_ref[2].push_back(dealii::CellId("274_0:"));
-    cell_id_ref[2].push_back(dealii::CellId("275_0:"));
-    cell_id_ref[2].push_back(dealii::CellId("278_0:"));
-    cell_id_ref[2].push_back(dealii::CellId("279_0:"));
-
-    for (unsigned int i = 0; i < cell_id_ref.size(); ++i)
+    BOOST_TEST(elements_to_activate[i].size() == cell_id_ref[i].size());
+    for (unsigned int j = 0; j < cell_id_ref[i].size(); ++j)
     {
-      BOOST_TEST(elements_to_activate[i].size() == cell_id_ref[i].size());
-      for (unsigned int j = 0; j < cell_id_ref[i].size(); ++j)
-      {
-        BOOST_TEST(elements_to_activate[i][j]->id() == cell_id_ref[i][j]);
-      }
+      BOOST_TEST(elements_to_activate[i][j]->id() == cell_id_ref[i][j]);
     }
   }
 }

--- a/tests/test_material_deposition.cc
+++ b/tests/test_material_deposition.cc
@@ -134,6 +134,8 @@ BOOST_AUTO_TEST_CASE(read_material_deposition_file_3d, *utf::tolerance(1e-13))
 BOOST_AUTO_TEST_CASE(get_elements_to_activate_2d,
                      *utf::precondition(serial_only()))
 {
+  MPI_Comm communicator = MPI_COMM_WORLD;
+
   // Geometry database
   boost::property_tree::ptree geometry_database;
   geometry_database.put("import_mesh", false);
@@ -194,6 +196,7 @@ BOOST_AUTO_TEST_CASE(get_elements_to_activate_3d,
                      *utf::precondition(serial_only()))
 {
   MPI_Comm communicator = MPI_COMM_WORLD;
+
   // Geometry database
   boost::property_tree::ptree geometry_database;
   geometry_database.put("import_mesh", false);


### PR DESCRIPTION
This PR does the following:
 - there is only one test in `test_experimental_data.cc` that's working in parallel. All the others were skip. I found it misleading to run the entire executable in parallel when almost all the tests are skipped. Let's only run the executable in serial.
 - there are two tests in `material_deposition` that only works in serial. Use Boost precondition to skip them in parallel. When using `BOOST_TEST_LOG_LEVEL=test_suite`, we now get a message that the tests are skipped.
 - increase the verbosity of the tests in Jenkins CI.