### PR TITLE
Output solution just before and after data assimilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ The following options are available:
 * memory\_space (optional): device (use GPU if Kokkos compiled with GPU support) or host (use CPU) (default value: host)
 * post\_processor (required):
   * filename\_prefix: prefix of output files (required)
-  * time\_steps\_between\_output: number of time steps between the
-  fields being written to the output files (default value: 1)
+  * time\_steps\_between\_output: number of time steps between the fields being written to the output files (default value: 1)
+  * output\_on\_data\_assimilation: output fields just before and just after data assimilation (default: true) **[since 1.1]**
   * additional\_output\_refinement: additional levels of refinement for the output (default: 0)
 * refinement (required):
   * n\_refinements: number of times the cells on the paths of the beams are refined (default value: 2)

--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -1718,7 +1718,7 @@ run_ensemble(MPI_Comm const &global_communicator,
       refinement_database.get("time_steps_between_refinement", 10);
   // PropertyTreeInput time_stepping.time_step
   double time_step = time_stepping_database.get<double>("time_step");
-  double const da_time_window = 2. * time_step;
+  double const da_time_half_window = 1.01 * time_step;
   // PropertyTreeInput time_stepping.scan_path_for_duration
   bool const scan_path_for_duration =
       time_stepping_database.get("scan_path_for_duration", false);
@@ -1971,7 +1971,7 @@ run_ensemble(MPI_Comm const &global_communicator,
       double frame_time = std::numeric_limits<double>::max();
       if ((experimental_frame_index + 1) < frame_time_stamps[0].size())
       {
-        if (time > da_time + da_time_window)
+        if (time > da_time + da_time_half_window)
         {
           da_time = frame_time_stamps[0][experimental_frame_index + 1];
         }
@@ -2232,8 +2232,8 @@ run_ensemble(MPI_Comm const &global_communicator,
 
     // ----- Output the solution -----
     if ((n_time_step % time_steps_output == 0) ||
-        (output_on_da && time > (da_time - da_time_window) &&
-         time < (da_time + da_time_window)))
+        (output_on_da && time > (da_time - da_time_half_window) &&
+         time < (da_time + da_time_half_window)))
     {
       for (unsigned int member = 0; member < local_ensemble_size; ++member)
       {


### PR DESCRIPTION
With this PR, we output the solution just before and just after the data assimilation. This is on top of the "regular" outputs. This is on by default but it can be turned off to make a movie.

@stvdwtt I am not sure about the name of the input variable. If you have a better name, let me know.