### PR TITLE
Add support for different boundary conditions on different faces

### DIFF
--- a/source/ThermalOperator.hh
+++ b/source/ThermalOperator.hh
@@ -1,4 +1,4 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -26,7 +26,8 @@ class ThermalOperator final : public ThermalOperatorBase<dim, MemorySpaceType>
 {
 public:
   ThermalOperator(
-      MPI_Comm const &communicator, BoundaryType boundary_type,
+      MPI_Comm const &communicator,
+      std::vector<BoundaryType> const &boundary_types,
       MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType>
           &material_properties,
       std::vector<std::shared_ptr<HeatSource<dim>>> const &heat_sources);
@@ -170,9 +171,14 @@ private:
    */
   MPI_Comm const &_communicator;
   /**
-   * Type of boundary.
+   * Flag set to true if all the boundary conditions are adiabatic. It is set to
+   * false otherwise.
    */
-  BoundaryType _boundary_type;
+  bool _adiabatic_only_bc = true;
+  /**
+   * Types of boundary.
+   */
+  std::vector<BoundaryType> _boundary_types;
   /**
    * Current height of the heat sources.
    */

--- a/source/ThermalOperatorDevice.hh
+++ b/source/ThermalOperatorDevice.hh
@@ -1,4 +1,4 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -20,7 +20,7 @@ class ThermalOperatorDevice final
 {
 public:
   ThermalOperatorDevice(MPI_Comm const &communicator,
-                        BoundaryType boundary_type,
+                        std::vector<BoundaryType> const &boundary_types,
                         MaterialProperty<dim, p_order, MaterialStates,
                                          MemorySpaceType> &material_properties);
 
@@ -110,9 +110,14 @@ private:
    */
   MPI_Comm const &_communicator;
   /**
-   * Type of boundary.
+   * Flag set to true if all the boundary conditions are adiabatic. It is set to
+   * false otherwise.
    */
-  BoundaryType _boundary_type;
+  bool _adiabatic_only_bc = true;
+  /**
+   * Types of boundary.
+   */
+  std::vector<BoundaryType> _boundary_types;
   dealii::types::global_dof_index _m;
   unsigned int _n_owned_cells;
   typename dealii::CUDAWrappers::MatrixFree<dim, double>::AdditionalData

--- a/source/ThermalPhysics.hh
+++ b/source/ThermalPhysics.hh
@@ -1,4 +1,4 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -172,9 +172,9 @@ private:
    */
   double _current_source_height = 0.;
   /**
-   * Type of boundary.
+   * Types of boundary.
    */
-  BoundaryType _boundary_type;
+  std::vector<BoundaryType> _boundary_types;
   /**
    * Associated geometry.
    */

--- a/tests/test_implicit_operator.cc
+++ b/tests/test_implicit_operator.cc
@@ -1,4 +1,4 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2017 - 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2017 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -86,11 +86,12 @@ BOOST_AUTO_TEST_CASE(implicit_operator)
   heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
+  std::vector<adamantine::BoundaryType> boundary(
+      2, adamantine::BoundaryType::adiabatic);
   auto thermal_operator = std::make_shared<
       adamantine::ThermalOperator<2, false, 0, 2, adamantine::SolidLiquidPowder,
                                   dealii::MemorySpace::Host>>(
-      communicator, adamantine::BoundaryType::adiabatic, mat_properties,
-      heat_sources);
+      communicator, boundary, mat_properties, heat_sources);
   std::vector<double> deposition_cos(
       geometry.get_triangulation().n_locally_owned_active_cells(), 1.);
   std::vector<double> deposition_sin(

--- a/tests/test_post_processor.cc
+++ b/tests/test_post_processor.cc
@@ -1,4 +1,4 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -84,10 +84,11 @@ BOOST_AUTO_TEST_CASE(thermal_post_processor)
       beam_database, units_optional_database);
 
   // Initialize the ThermalOperator
+  std::vector<adamantine::BoundaryType> boundary(
+      2, adamantine::BoundaryType::adiabatic);
   adamantine::ThermalOperator<2, false, 0, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
-      thermal_operator(communicator, adamantine::BoundaryType::adiabatic,
-                       mat_properties, heat_sources);
+      thermal_operator(communicator, boundary, mat_properties, heat_sources);
   std::vector<double> deposition_cos(
       geometry.get_triangulation().n_locally_owned_active_cells(), 1.);
   std::vector<double> deposition_sin(

--- a/tests/test_thermal_operator.cc
+++ b/tests/test_thermal_operator.cc
@@ -1,4 +1,4 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -100,10 +100,11 @@ BOOST_AUTO_TEST_CASE(thermal_operator, *utf::tolerance(1e-15))
   heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
+  std::vector<adamantine::BoundaryType> boundary(
+      2, adamantine::BoundaryType::adiabatic);
   adamantine::ThermalOperator<2, false, 1, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
-      thermal_operator(communicator, adamantine::BoundaryType::adiabatic,
-                       mat_properties, heat_sources);
+      thermal_operator(communicator, boundary, mat_properties, heat_sources);
   std::vector<double> deposition_cos(
       geometry.get_triangulation().n_locally_owned_active_cells(), 1.);
   std::vector<double> deposition_sin(
@@ -208,10 +209,11 @@ BOOST_AUTO_TEST_CASE(spmv, *utf::tolerance(1e-12))
   heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
+  std::vector<adamantine::BoundaryType> boundary(
+      2, adamantine::BoundaryType::adiabatic);
   adamantine::ThermalOperator<2, false, 2, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
-      thermal_operator(communicator, adamantine::BoundaryType::adiabatic,
-                       mat_properties, heat_sources);
+      thermal_operator(communicator, boundary, mat_properties, heat_sources);
   std::vector<double> deposition_cos(
       geometry.get_triangulation().n_locally_owned_active_cells(), 1.);
   std::vector<double> deposition_sin(
@@ -320,10 +322,11 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic, *utf::tolerance(1e-12))
   heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
+  std::vector<adamantine::BoundaryType> boundary(
+      2, adamantine::BoundaryType::adiabatic);
   adamantine::ThermalOperator<2, false, 2, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
-      thermal_operator(communicator, adamantine::BoundaryType::adiabatic,
-                       mat_properties, heat_sources);
+      thermal_operator(communicator, boundary, mat_properties, heat_sources);
   std::vector<double> deposition_cos(
       geometry.get_triangulation().n_locally_owned_active_cells(), 1.);
   std::vector<double> deposition_sin(
@@ -461,10 +464,11 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic_angle, *utf::tolerance(1e-10))
   std::vector<std::shared_ptr<adamantine::HeatSource<3>>> heat_sources;
 
   // Initialize the ThermalOperator
+  std::vector<adamantine::BoundaryType> boundary(
+      2, adamantine::BoundaryType::adiabatic);
   adamantine::ThermalOperator<3, false, 1, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
-      thermal_operator(communicator, adamantine::BoundaryType::adiabatic,
-                       mat_properties, heat_sources);
+      thermal_operator(communicator, boundary, mat_properties, heat_sources);
   double constexpr deposition_angle = M_PI / 6.;
   std::vector<double> deposition_cos(
       geometry.get_triangulation().n_locally_owned_active_cells(),
@@ -632,10 +636,11 @@ BOOST_AUTO_TEST_CASE(spmv_rad, *utf::tolerance(1e-12))
   heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
+  std::vector<adamantine::BoundaryType> boundary(
+      2, adamantine::BoundaryType::radiative);
   adamantine::ThermalOperator<2, false, 1, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
-      thermal_operator(communicator, adamantine::BoundaryType::radiative,
-                       mat_properties, heat_sources);
+      thermal_operator(communicator, boundary, mat_properties, heat_sources);
   std::vector<double> deposition_cos(
       geometry.get_triangulation().n_locally_owned_active_cells(), 1.);
   std::vector<double> deposition_sin(
@@ -819,10 +824,11 @@ BOOST_AUTO_TEST_CASE(spmv_conv, *utf::tolerance(1e-12))
   heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
+  std::vector<adamantine::BoundaryType> boundary(
+      2, adamantine::BoundaryType::convective);
   adamantine::ThermalOperator<2, false, 1, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
-      thermal_operator(communicator, adamantine::BoundaryType::convective,
-                       mat_properties, heat_sources);
+      thermal_operator(communicator, boundary, mat_properties, heat_sources);
   std::vector<double> deposition_cos(
       geometry.get_triangulation().n_locally_owned_active_cells(), 1.);
   std::vector<double> deposition_sin(

--- a/tests/test_thermal_operator_device.cc
+++ b/tests/test_thermal_operator_device.cc
@@ -1,4 +1,4 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -76,11 +76,12 @@ BOOST_AUTO_TEST_CASE(thermal_operator_dev, *utf::tolerance(1e-10))
                      mat_prop_database);
 
   // Initialize the ThermalOperator
+  std::vector<adamantine::BoundaryType> boundary(
+      2, adamantine::BoundaryType::adiabatic);
   adamantine::ThermalOperatorDevice<2, false, 0, 2,
                                     adamantine::SolidLiquidPowder,
                                     dealii::MemorySpace::Default>
-      thermal_operator_dev(communicator, adamantine::BoundaryType::adiabatic,
-                           mat_properties);
+      thermal_operator_dev(communicator, boundary, mat_properties);
   thermal_operator_dev.compute_inverse_mass_matrix(dof_handler,
                                                    affine_constraints);
   std::vector<double> deposition_cos(
@@ -170,11 +171,12 @@ BOOST_AUTO_TEST_CASE(spmv, *utf::tolerance(1e-12))
                      mat_prop_database);
 
   // Initialize the ThermalOperator
+  std::vector<adamantine::BoundaryType> boundary(
+      2, adamantine::BoundaryType::adiabatic);
   adamantine::ThermalOperatorDevice<2, false, 3, 2,
                                     adamantine::SolidLiquidPowder,
                                     dealii::MemorySpace::Default>
-      thermal_operator_dev(communicator, adamantine::BoundaryType::adiabatic,
-                           mat_properties);
+      thermal_operator_dev(communicator, boundary, mat_properties);
   thermal_operator_dev.compute_inverse_mass_matrix(dof_handler,
                                                    affine_constraints);
   std::vector<double> deposition_cos(
@@ -295,11 +297,12 @@ BOOST_AUTO_TEST_CASE(mf_spmv, *utf::tolerance(1.5e-12))
   heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
+  std::vector<adamantine::BoundaryType> boundary(
+      2, adamantine::BoundaryType::adiabatic);
   adamantine::ThermalOperatorDevice<2, false, 4, 2,
                                     adamantine::SolidLiquidPowder,
                                     dealii::MemorySpace::Default>
-      thermal_operator_dev(communicator, adamantine::BoundaryType::adiabatic,
-                           mat_properties);
+      thermal_operator_dev(communicator, boundary, mat_properties);
   thermal_operator_dev.compute_inverse_mass_matrix(dof_handler,
                                                    affine_constraints);
   std::vector<double> deposition_cos(
@@ -314,8 +317,8 @@ BOOST_AUTO_TEST_CASE(mf_spmv, *utf::tolerance(1.5e-12))
 
   adamantine::ThermalOperator<2, false, 4, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
-      thermal_operator_host(communicator, adamantine::BoundaryType::adiabatic,
-                            mat_properties_host, heat_sources);
+      thermal_operator_host(communicator, boundary, mat_properties_host,
+                            heat_sources);
   thermal_operator_host.compute_inverse_mass_matrix(dof_handler,
                                                     affine_constraints);
   thermal_operator_host.reinit(dof_handler, affine_constraints, q_collection);
@@ -417,11 +420,12 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic_angle, *utf::tolerance(1e-10))
                      mat_prop_database);
 
   // Initialize the ThermalOperatorDevice
+  std::vector<adamantine::BoundaryType> boundary(
+      2, adamantine::BoundaryType::adiabatic);
   adamantine::ThermalOperatorDevice<3, false, 3, 2,
                                     adamantine::SolidLiquidPowder,
                                     dealii::MemorySpace::Default>
-      thermal_operator_dev(communicator, adamantine::BoundaryType::adiabatic,
-                           mat_properties);
+      thermal_operator_dev(communicator, boundary, mat_properties);
   double constexpr deposition_angle = M_PI / 6.;
   std::vector<double> deposition_cos(
       geometry.get_triangulation().n_locally_owned_active_cells(),

--- a/tests/test_thermal_physics.cc
+++ b/tests/test_thermal_physics.cc
@@ -1,4 +1,4 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -62,6 +62,11 @@ BOOST_AUTO_TEST_CASE(radiation_bcs_host)
 BOOST_AUTO_TEST_CASE(convection_bcs_host)
 {
   convection_bcs<dealii::MemorySpace::Host>();
+}
+
+BOOST_AUTO_TEST_CASE(multiple_bcs_host)
+{
+  multiple_bcs<dealii::MemorySpace::Host>();
 }
 
 BOOST_AUTO_TEST_CASE(reference_temperature_host)

--- a/tests/test_thermal_physics.hh
+++ b/tests/test_thermal_physics.hh
@@ -1,4 +1,4 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -553,6 +553,114 @@ void convection_bcs()
   database.put("time_stepping.method", "forward_euler");
   // Boundary database
   database.put("boundary.type", "convective");
+  // Build ThermalPhysics
+  adamantine::ThermalPhysics<2, 0, 2, adamantine::SolidLiquidPowder,
+                             dealii::MemorySpace::Host, dealii::QGauss<1>>
+      physics(communicator, database, geometry, material_properties);
+  physics.setup();
+  dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> solution;
+  double constexpr initial_temperature = 10;
+  physics.initialize_dof_vector(initial_temperature, solution);
+  std::vector<adamantine::Timer> timers(adamantine::Timing::n_timers);
+  double time = 0;
+  while (time < 100)
+  {
+    time = physics.evolve_one_time_step(time, 0.005, solution, timers);
+  }
+
+  double max = -1;
+  double min = 1e4;
+  if (std::is_same<MemorySpaceType, dealii::MemorySpace::Host>::value)
+  {
+    for (auto v : solution)
+    {
+      if (max < v)
+        max = v;
+      if (min > v)
+        min = v;
+    }
+  }
+  else
+  {
+    dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host>
+        solution_host(solution.get_partitioner());
+    solution_host.import(solution, dealii::VectorOperation::insert);
+    for (auto v : solution_host)
+    {
+      if (max < v)
+        max = v;
+      if (min > v)
+        min = v;
+    }
+  }
+
+  BOOST_TEST(min >= 10.);
+  BOOST_TEST(min <= 20.);
+  BOOST_TEST(max > 10.);
+  BOOST_TEST(max <= 20.);
+}
+
+template <typename MemorySpaceType>
+void multiple_bcs()
+{
+  MPI_Comm communicator = MPI_COMM_WORLD;
+
+  // Geometry database
+  boost::property_tree::ptree geometry_database;
+  geometry_database.put("import_mesh", false);
+  geometry_database.put("length", 5);
+  geometry_database.put("length_divisions", 5);
+  geometry_database.put("height", 5);
+  geometry_database.put("height_divisions", 5);
+  boost::optional<boost::property_tree::ptree const &> units_optional_database;
+  // Build Geometry
+  adamantine::Geometry<2> geometry(communicator, geometry_database,
+                                   units_optional_database);
+  boost::property_tree::ptree material_property_database;
+  // MaterialProperty database
+  material_property_database.put("property_format", "polynomial");
+  material_property_database.put("n_materials", 1);
+  material_property_database.put("material_0.solid.density", 1.);
+  material_property_database.put("material_0.powder.density", 1.);
+  material_property_database.put("material_0.liquid.density", 1.);
+  material_property_database.put("material_0.solid.specific_heat", 1.);
+  material_property_database.put("material_0.powder.specific_heat", 1.);
+  material_property_database.put("material_0.liquid.specific_heat", 1.);
+  material_property_database.put("material_0.solid.thermal_conductivity_x", 1.);
+  material_property_database.put("material_0.solid.thermal_conductivity_z", 1.);
+  material_property_database.put("material_0.powder.thermal_conductivity_x",
+                                 1.);
+  material_property_database.put("material_0.powder.thermal_conductivity_z",
+                                 1.);
+  material_property_database.put("material_0.liquid.thermal_conductivity_x",
+                                 1.);
+  material_property_database.put("material_0.liquid.thermal_conductivity_z",
+                                 1.);
+  material_property_database.put("material_0.solid.emissivity", 1.);
+  material_property_database.put("material_0.powder.emissivity", 1.);
+  material_property_database.put("material_0.liquid.emissivity", 1.);
+  material_property_database.put(
+      "material_0.solid.convection_heat_transfer_coef", 1.);
+  material_property_database.put(
+      "material_0.powder.convection_heat_transfer_coef", 1.);
+  material_property_database.put(
+      "material_0.liquid.convection_heat_transfer_coef", 1.);
+  material_property_database.put("material_0.radiation_temperature_infty", 0.0);
+  material_property_database.put("material_0.convection_temperature_infty",
+                                 20.0);
+  // Build MaterialProperty
+  adamantine::MaterialProperty<2, 0, adamantine::SolidLiquidPowder,
+                               MemorySpaceType>
+      material_properties(communicator, geometry.get_triangulation(),
+                          material_property_database);
+  boost::property_tree::ptree database;
+  // Source database
+  database.put("sources.n_beams", 0);
+  // Time-stepping database
+  database.put("time_stepping.method", "forward_euler");
+  // Boundary database
+  database.put("boundary.type", "convective");
+  database.put("boundary.boundary_0", "adiabatic");
   // Build ThermalPhysics
   adamantine::ThermalPhysics<2, 0, 2, adamantine::SolidLiquidPowder,
                              dealii::MemorySpace::Host, dealii::QGauss<1>>


### PR DESCRIPTION
I still need to add the documentation but this may help @AshGannon with issues she is currently having. This PR add the possibility to have different boundary conditions for different faces. The input should look like:
```
 boundary 
 {
    type convective ; this is the default boundary conditions. In particular this is
; what's applied to the layer we build

    boundary_0
  {
    type adiabatic ; the face with the boundary id 0 will be adiabatic
  }
 } 
```
The boundary ids depend on the mesh. It's different if you use a deal.II mesh or a cubit mesh.