### PR TITLE
Introduce Boundary class and 'clamped' bc

### DIFF
--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -1,10 +1,11 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #ifndef ADAMANTINE_HH
 #define ADAMANTINE_HH
 
+#include <Boundary.hh>
 #include <DataAssimilator.hh>
 #include <ExperimentalData.hh>
 #include <Geometry.hh>
@@ -218,13 +219,14 @@ std::unique_ptr<adamantine::ThermalPhysicsInterface<dim, MemorySpaceType>>
 initialize(MPI_Comm const &communicator,
            boost::property_tree::ptree const &database,
            adamantine::Geometry<dim> &geometry,
+           adamantine::Boundary const &boundary,
            adamantine::MaterialProperty<dim, p_order, MaterialStates,
                                         MemorySpaceType> &material_properties)
 {
   return std::make_unique<
       adamantine::ThermalPhysics<dim, p_order, fe_degree, MaterialStates,
                                  MemorySpaceType, QuadratureType>>(
-      communicator, database, geometry, material_properties);
+      communicator, database, geometry, boundary, material_properties);
 }
 
 template <int dim, int p_order, int fe_degree, typename MaterialStates,
@@ -233,21 +235,21 @@ std::unique_ptr<adamantine::ThermalPhysicsInterface<dim, MemorySpaceType>>
 initialize_quadrature(
     std::string const &quadrature_type, MPI_Comm const &communicator,
     boost::property_tree::ptree const &database,
-    adamantine::Geometry<dim> &geometry,
+    adamantine::Geometry<dim> &geometry, adamantine::Boundary const &boundary,
     adamantine::MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType>
         &material_properties)
 {
   if (quadrature_type.compare("gauss") == 0)
     return initialize<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
                       dealii::QGauss<1>>(communicator, database, geometry,
-                                         material_properties);
+                                         boundary, material_properties);
   else
   {
     adamantine::ASSERT_THROW(quadrature_type.compare("lobatto") == 0,
                              "quadrature should be Gauss or Lobatto.");
     return initialize<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
-                      dealii::QGaussLobatto<1>>(communicator, database,
-                                                geometry, material_properties);
+                      dealii::QGaussLobatto<1>>(
+        communicator, database, geometry, boundary, material_properties);
   }
 }
 
@@ -257,7 +259,7 @@ std::unique_ptr<adamantine::ThermalPhysicsInterface<dim, MemorySpaceType>>
 initialize_thermal_physics(
     unsigned int fe_degree, std::string const &quadrature_type,
     MPI_Comm const &communicator, boost::property_tree::ptree const &database,
-    adamantine::Geometry<dim> &geometry,
+    adamantine::Geometry<dim> &geometry, adamantine::Boundary const &boundary,
     adamantine::MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType>
         &material_properties)
 {
@@ -266,34 +268,39 @@ initialize_thermal_physics(
   case 1:
   {
     return initialize_quadrature<dim, p_order, 1, MaterialStates,
-                                 MemorySpaceType>(
-        quadrature_type, communicator, database, geometry, material_properties);
+                                 MemorySpaceType>(quadrature_type, communicator,
+                                                  database, geometry, boundary,
+                                                  material_properties);
   }
   case 2:
   {
     return initialize_quadrature<dim, p_order, 2, MaterialStates,
-                                 MemorySpaceType>(
-        quadrature_type, communicator, database, geometry, material_properties);
+                                 MemorySpaceType>(quadrature_type, communicator,
+                                                  database, geometry, boundary,
+                                                  material_properties);
   }
   case 3:
   {
     return initialize_quadrature<dim, p_order, 3, MaterialStates,
-                                 MemorySpaceType>(
-        quadrature_type, communicator, database, geometry, material_properties);
+                                 MemorySpaceType>(quadrature_type, communicator,
+                                                  database, geometry, boundary,
+                                                  material_properties);
   }
   case 4:
   {
     return initialize_quadrature<dim, p_order, 4, MaterialStates,
-                                 MemorySpaceType>(
-        quadrature_type, communicator, database, geometry, material_properties);
+                                 MemorySpaceType>(quadrature_type, communicator,
+                                                  database, geometry, boundary,
+                                                  material_properties);
   }
   default:
   {
     adamantine::ASSERT_THROW(fe_degree == 5,
                              "fe_degree should be between 1 and 5.");
     return initialize_quadrature<dim, p_order, 5, MaterialStates,
-                                 MemorySpaceType>(
-        quadrature_type, communicator, database, geometry, material_properties);
+                                 MemorySpaceType>(quadrature_type, communicator,
+                                                  database, geometry, boundary,
+                                                  material_properties);
   }
   }
 }
@@ -760,8 +767,7 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
   // Extract the physics property tree
   boost::property_tree::ptree physics_database = database.get_child("physics");
   bool const use_thermal_physics = physics_database.get<bool>("thermal");
-  [[maybe_unused]] bool const use_mechanical_physics =
-      physics_database.get<bool>("mechanical");
+  bool const use_mechanical_physics = physics_database.get<bool>("mechanical");
 
   // Extract the discretization property tree
   boost::property_tree::ptree discretization_database =
@@ -774,6 +780,13 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
   // Extract the verbosity
   // PropertyTreeInput verbose_output
   bool const verbose_output = database.get("verbose_output", false);
+
+  // Create the Boundary
+  boost::property_tree::ptree boundary_database =
+      database.get_child("boundary");
+  adamantine::Boundary boundary(boundary_database,
+                                geometry.get_triangulation().get_boundary_ids(),
+                                use_mechanical_physics && !use_thermal_physics);
 
   // Create ThermalPhysics if necessary
   std::unique_ptr<adamantine::ThermalPhysicsInterface<dim, MemorySpaceType>>
@@ -788,7 +801,7 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
     std::string quadrature_type =
         discretization_database.get("thermal.quadrature", "gauss");
     thermal_physics = initialize_thermal_physics<dim>(
-        fe_degree, quadrature_type, communicator, database, geometry,
+        fe_degree, quadrature_type, communicator, database, geometry, boundary,
         material_properties);
     heat_sources = thermal_physics->get_heat_sources();
     post_processor_database.put("thermal_output", true);
@@ -826,7 +839,7 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
         discretization_database.get<unsigned int>("mechanical.fe_degree");
     mechanical_physics = std::make_unique<adamantine::MechanicalPhysics<
         dim, p_order, MaterialStates, MemorySpaceType>>(
-        communicator, fe_degree, geometry, material_properties,
+        communicator, fe_degree, geometry, boundary, material_properties,
         material_reference_temps);
     post_processor_database.put("mechanical_output", true);
   }
@@ -1404,6 +1417,8 @@ run_ensemble(MPI_Comm const &global_communicator,
   // Mandatory subtrees
   boost::property_tree::ptree geometry_database =
       database.get_child("geometry");
+  boost::property_tree::ptree boundary_database =
+      database.get_child("boundary");
   boost::property_tree::ptree discretization_database =
       database.get_child("discretization");
   boost::property_tree::ptree time_stepping_database =
@@ -1471,6 +1486,8 @@ run_ensemble(MPI_Comm const &global_communicator,
       heat_sources_ensemble(local_ensemble_size);
 
   std::vector<std::unique_ptr<adamantine::Geometry<dim>>> geometry_ensemble;
+
+  std::vector<std::unique_ptr<adamantine::Boundary>> boundary_ensemble;
 
   std::vector<std::unique_ptr<adamantine::MaterialProperty<
       dim, p_order, MaterialStates, MemorySpaceType>>>
@@ -1600,6 +1617,11 @@ run_ensemble(MPI_Comm const &global_communicator,
     geometry_ensemble.push_back(std::make_unique<adamantine::Geometry<dim>>(
         local_communicator, geometry_database, units_optional_database));
 
+    boundary_ensemble.push_back(std::make_unique<adamantine::Boundary>(
+        boundary_database,
+        geometry_ensemble.back()->get_triangulation().get_boundary_ids(),
+        false));
+
     material_properties_ensemble.push_back(
         std::make_unique<adamantine::MaterialProperty<
             dim, p_order, MaterialStates, MemorySpaceType>>(
@@ -1609,7 +1631,7 @@ run_ensemble(MPI_Comm const &global_communicator,
     thermal_physics_ensemble[member] = initialize_thermal_physics<dim>(
         fe_degree, quadrature_type, local_communicator,
         database_ensemble[member], *geometry_ensemble[member],
-        *material_properties_ensemble[member]);
+        *boundary_ensemble[member], *material_properties_ensemble[member]);
     heat_sources_ensemble[member] =
         thermal_physics_ensemble[member]->get_heat_sources();
 

--- a/source/Boundary.cc
+++ b/source/Boundary.cc
@@ -1,0 +1,109 @@
+/* SPDX-FileCopyrightText: Copyright (c) 2025, the adamantine authors.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#include <Boundary.hh>
+#include <utils.hh>
+
+#include <algorithm>
+
+namespace adamantine
+{
+Boundary::Boundary(boost::property_tree::ptree const &database,
+                   std::vector<dealii::types::boundary_id> const &boundary_ids,
+                   bool const mechanical_only)
+{
+  _types.resize(*std::max_element(boundary_ids.begin(), boundary_ids.end()) + 1,
+                BoundaryType::invalid);
+  // Set the default boundary condition. It can be overwritten for given
+  // boundary ids. It is the boundary used for the current layer. If we solve a
+  // mechanical problem only, it is not necessary to set a global boundary type.
+  // It is traction-free by default.
+  if (!mechanical_only)
+  {
+    // PropertyTreeInput boundary.type
+    std::string boundary_type_str = database.get<std::string>("type");
+    BoundaryType default_boundary = parse_boundary_line(boundary_type_str);
+    for (auto &boundary : _types)
+    {
+      boundary = default_boundary;
+    }
+  }
+  // Check if the user wants to use different boundaries for different part
+  // of the domain's boundary.
+  for (auto const id : boundary_ids)
+  {
+    // PropertyTreeInput boundary.boundary_id.type
+    auto boundary_type_str = database.get_optional<std::string>(
+        "boundary_" + std::to_string(id) + ".type");
+    if (boundary_type_str)
+    {
+      _types[id] = parse_boundary_line(*boundary_type_str);
+    }
+  }
+}
+
+std::vector<dealii::types::boundary_id>
+Boundary::get_boundary_ids(BoundaryType type) const
+{
+  std::vector<dealii::types::boundary_id> ids;
+  for (unsigned int i = 0; i < _types.size(); ++i)
+  {
+    if (_types[i] & type)
+    {
+      ids.push_back(i);
+    }
+  }
+
+  return ids;
+}
+
+BoundaryType Boundary::parse_boundary_line(std::string boundary_type_str)
+{
+  BoundaryType boundary_type = BoundaryType::invalid;
+  std::string delimiter = ",";
+
+  // Lambda function to parse the string
+  auto parse_boundary_type =
+      [](std::string const &boundary, BoundaryType &boundary_type)
+  {
+    // Parse thermal bc
+    if (boundary == "adiabatic")
+    {
+      boundary_type = BoundaryType::adiabatic;
+    }
+    else
+    {
+      if (boundary == "radiative")
+      {
+        boundary_type |= BoundaryType::radiative;
+      }
+      else if (boundary == "convective")
+      {
+        boundary_type |= BoundaryType::convective;
+      }
+      else
+      {
+        ASSERT_THROW(boundary == "clamped", "Unknown boundary type.");
+      }
+    }
+
+    // Parse mechanical bc
+    if (boundary == "clamped")
+    {
+      boundary_type |= BoundaryType::clamped;
+    }
+  };
+
+  size_t pos_str = 0;
+  while ((pos_str = boundary_type_str.find(delimiter)) != std::string::npos)
+  {
+    std::string boundary = boundary_type_str.substr(0, pos_str);
+    parse_boundary_type(boundary, boundary_type);
+    boundary_type_str.erase(0, pos_str + delimiter.length());
+  }
+  parse_boundary_type(boundary_type_str, boundary_type);
+
+  return boundary_type;
+}
+} // namespace adamantine

--- a/source/Boundary.hh
+++ b/source/Boundary.hh
@@ -1,0 +1,129 @@
+/* SPDX-FileCopyrightText: Copyright (c) 2025, the adamantine authors.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ */
+
+#ifndef BOUNDARY_HH
+#define BOUNDARY_HH
+
+#include <deal.II/base/types.h>
+
+#include <boost/property_tree/ptree.hpp>
+
+#include <string>
+#include <vector>
+
+namespace adamantine
+{
+/**
+ * Enum on the different types of boundary condition supported. Some of them can
+ * be combined, for example radiative and convective.
+ */
+enum BoundaryType
+{
+  invalid = 0,
+  adiabatic = 0x1,
+  radiative = 0x2,
+  convective = 0x4,
+  clamped = 0x8
+};
+
+/**
+ * Global operator which returns an object in which all bits are set which are
+ * either set in the first or the second argument. This operator exists since if
+ * it did not then the result of the bit-or operator | would be an integer which
+ * would in turn trigger a compiler warning when we tried to assign it to an
+ * object of type BoundaryType.
+ */
+inline BoundaryType operator|(const BoundaryType b1, const BoundaryType b2)
+{
+  return static_cast<BoundaryType>(static_cast<unsigned int>(b1) |
+                                   static_cast<unsigned int>(b2));
+}
+
+/**
+ * Global operator which sets the bits from the second argument also in the
+ * first one.
+ */
+inline BoundaryType &operator|=(BoundaryType &b1, const BoundaryType b2)
+{
+  b1 = b1 | b2;
+  return b1;
+}
+
+/**
+ * Global operator which returns an object in which all bits are set which are
+ * set in the first as well as the second argument. This operator exists since
+ * if it did not then the result of the bit-and operator & would be an integer
+ * which would in turn trigger a compiler warning when we tried to assign it to
+ * an object of type BoundaryType.
+ */
+inline BoundaryType operator&(const BoundaryType b1, const BoundaryType b2)
+{
+  return static_cast<BoundaryType>(static_cast<unsigned int>(b1) &
+                                   static_cast<unsigned int>(b2));
+}
+
+/**
+ * Global operator which clears all the bits in the first argument if they are
+ * not also set in the second argument.
+ */
+inline BoundaryType &operator&=(BoundaryType &b1, const BoundaryType b2)
+{
+  b1 = b1 & b2;
+  return b1;
+}
+
+/**
+ * This class parses the Boundary database and stores the BoundaryType
+ * associated with each boundary id.
+ */
+class Boundary
+{
+public:
+  /**
+   * Constructor.
+   */
+  Boundary(boost::property_tree::ptree const &database,
+           std::vector<dealii::types::boundary_id> const &boundary_ids,
+           bool const mechanical_only);
+
+  /**
+   * Return the number of boundary ids associated with the Geometry.
+   */
+  unsigned int n_boundary_ids() const;
+
+  /**
+   * Return the BoundaryType associated with the given boundary id.
+   */
+  BoundaryType get_boundary_type(dealii::types::boundary_id boundary_id) const;
+
+  /**
+   * Return all the boundary ids associated with the given BoundaryType
+   */
+  std::vector<dealii::types::boundary_id>
+  get_boundary_ids(BoundaryType type) const;
+
+private:
+  /**
+   * Vector of all the BoundaryType present in the Geometry.
+   */
+  std::vector<BoundaryType> _types;
+
+  /**
+   * Return the BoundaryType associated with the given string.
+   */
+  BoundaryType parse_boundary_line(std::string boundary_type_str);
+};
+
+inline unsigned int Boundary::n_boundary_ids() const { return _types.size(); }
+
+inline BoundaryType Boundary::get_boundary_type(unsigned int boundary_id) const
+{
+  if (boundary_id < _types.size() - 1)
+    return _types[boundary_id];
+  else
+    return _types.back();
+}
+} // namespace adamantine
+
+#endif

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(Adamantine_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/BeamHeatSourceProperties.hh
     ${CMAKE_CURRENT_SOURCE_DIR}/BodyForce.hh
+    ${CMAKE_CURRENT_SOURCE_DIR}/Boundary.hh
     ${CMAKE_CURRENT_SOURCE_DIR}/CubeHeatSource.hh
     ${CMAKE_CURRENT_SOURCE_DIR}/DataAssimilator.hh
     ${CMAKE_CURRENT_SOURCE_DIR}/ElectronBeamHeatSource.hh
@@ -39,6 +40,7 @@ set(Adamantine_HEADERS
   )
 set(Adamantine_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/BodyForce.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/Boundary.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/CubeHeatSource.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/DataAssimilator.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/ElectronBeamHeatSource.cc

--- a/source/MechanicalPhysics.hh
+++ b/source/MechanicalPhysics.hh
@@ -1,10 +1,11 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2022 - 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2022 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #ifndef MECHANICAL_PHYSICS_HH
 #define MECHANICAL_PHYSICS_HH
 
+#include <Boundary.hh>
 #include <Geometry.hh>
 #include <MechanicalOperator.hh>
 
@@ -26,7 +27,7 @@ public:
    * Constructor.
    */
   MechanicalPhysics(MPI_Comm const &communicator, unsigned int const fe_degree,
-                    Geometry<dim> &geometry,
+                    Geometry<dim> &geometry, Boundary const &boundary,
                     MaterialProperty<dim, p_order, MaterialStates,
                                      MemorySpaceType> &material_properties,
                     std::vector<double> const &initial_temperatures);
@@ -95,6 +96,10 @@ private:
    * Associated Geometry.
    */
   Geometry<dim> &_geometry;
+  /**
+   * Associated Boundary.
+   */
+  Boundary _boundary;
   /**
    * Associated MaterialProperty.
    */

--- a/source/ThermalOperator.hh
+++ b/source/ThermalOperator.hh
@@ -5,6 +5,7 @@
 #ifndef THERMAL_OPERATOR_HH
 #define THERMAL_OPERATOR_HH
 
+#include <Boundary.hh>
 #include <HeatSource.hh>
 #include <MaterialProperty.hh>
 #include <MaterialStates.hh>
@@ -26,8 +27,7 @@ class ThermalOperator final : public ThermalOperatorBase<dim, MemorySpaceType>
 {
 public:
   ThermalOperator(
-      MPI_Comm const &communicator,
-      std::vector<BoundaryType> const &boundary_types,
+      MPI_Comm const &communicator, Boundary const &boundary,
       MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType>
           &material_properties,
       std::vector<std::shared_ptr<HeatSource<dim>>> const &heat_sources);
@@ -176,13 +176,13 @@ private:
    */
   bool _adiabatic_only_bc = true;
   /**
-   * Types of boundary.
-   */
-  std::vector<BoundaryType> _boundary_types;
-  /**
    * Current height of the heat sources.
    */
   double _current_source_height = 0.;
+  /**
+   * Boundary ids associated to the domain.
+   */
+  Boundary _boundary;
   /**
    * Data to configure the MatrixFree object.
    */

--- a/source/ThermalOperatorDevice.hh
+++ b/source/ThermalOperatorDevice.hh
@@ -5,6 +5,7 @@
 #ifndef THERMAL_OPERATOR_DEVICE_HH
 #define THERMAL_OPERATOR_DEVICE_HH
 
+#include <Boundary.hh>
 #include <MaterialProperty.hh>
 #include <ThermalOperatorBase.hh>
 
@@ -19,8 +20,7 @@ class ThermalOperatorDevice final
     : public ThermalOperatorBase<dim, MemorySpaceType>
 {
 public:
-  ThermalOperatorDevice(MPI_Comm const &communicator,
-                        std::vector<BoundaryType> const &boundary_types,
+  ThermalOperatorDevice(MPI_Comm const &communicator, Boundary const &boundary,
                         MaterialProperty<dim, p_order, MaterialStates,
                                          MemorySpaceType> &material_properties);
 
@@ -114,10 +114,6 @@ private:
    * false otherwise.
    */
   bool _adiabatic_only_bc = true;
-  /**
-   * Types of boundary.
-   */
-  std::vector<BoundaryType> _boundary_types;
   dealii::types::global_dof_index _m;
   unsigned int _n_owned_cells;
   typename dealii::CUDAWrappers::MatrixFree<dim, double>::AdditionalData

--- a/source/ThermalOperatorDevice.templates.hh
+++ b/source/ThermalOperatorDevice.templates.hh
@@ -450,22 +450,17 @@ template <int dim, bool use_table, int p_order, int fe_degree,
 ThermalOperatorDevice<dim, use_table, p_order, fe_degree, MaterialStates,
                       MemorySpaceType>::
     ThermalOperatorDevice(
-        MPI_Comm const &communicator,
-        std::vector<BoundaryType> const &boundary_types,
+        MPI_Comm const &communicator, Boundary const &boundary,
         MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType>
             &material_properties)
-    : _communicator(communicator), _boundary_types(boundary_types), _m(0),
-      _n_owned_cells(0), _material_properties(material_properties),
+    : _communicator(communicator), _m(0), _n_owned_cells(0),
+      _material_properties(material_properties),
       _inverse_mass_matrix(
           new dealii::LA::distributed::Vector<double, MemorySpaceType>())
 {
-  for (auto const boundary : _boundary_types)
-  {
-    if (!(boundary & BoundaryType::adiabatic))
-    {
-      _adiabatic_only_bc = false;
-    }
-  }
+  _adiabatic_only_bc =
+      boundary.get_boundary_ids(BoundaryType::adiabatic).size() ==
+      boundary.n_boundary_ids();
 
   _matrix_free_data.mapping_update_flags = dealii::update_gradients |
                                            dealii::update_JxW_values |

--- a/source/ThermalPhysics.hh
+++ b/source/ThermalPhysics.hh
@@ -5,6 +5,7 @@
 #ifndef THERMAL_PHYSICS_HH
 #define THERMAL_PHYSICS_HH
 
+#include <Boundary.hh>
 #include <Geometry.hh>
 #include <HeatSource.hh>
 #include <ImplicitOperator.hh>
@@ -37,7 +38,7 @@ public:
    */
   ThermalPhysics(MPI_Comm const &communicator,
                  boost::property_tree::ptree const &database,
-                 Geometry<dim> &geometry,
+                 Geometry<dim> &geometry, Boundary const &boundary,
                  MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType>
                      &material_properties);
 
@@ -172,13 +173,13 @@ private:
    */
   double _current_source_height = 0.;
   /**
-   * Types of boundary.
-   */
-  std::vector<BoundaryType> _boundary_types;
-  /**
    * Associated geometry.
    */
   Geometry<dim> &_geometry;
+  /**
+   * Associated boundary.
+   */
+  Boundary _boundary;
   /**
    * Associated Lagrange finite elements.
    */

--- a/source/ThermalPhysics.templates.hh
+++ b/source/ThermalPhysics.templates.hh
@@ -40,48 +40,6 @@ namespace adamantine
 {
 namespace
 {
-BoundaryType parse_boundary_line(std::string boundary_type_str)
-{
-  BoundaryType boundary_type = BoundaryType::invalid;
-  std::string delimiter = ",";
-
-  // Lambda function to parse the string
-  auto parse_boundary_type =
-      [](std::string const &boundary, BoundaryType &boundary_type)
-  {
-    if (boundary == "adiabatic")
-    {
-      boundary_type = BoundaryType::adiabatic;
-    }
-    else
-    {
-      if (boundary == "radiative")
-      {
-        boundary_type |= BoundaryType::radiative;
-      }
-      else if (boundary == "convective")
-      {
-        boundary_type |= BoundaryType::convective;
-      }
-      else
-      {
-        ASSERT_THROW(false, "Unknown boundary type.");
-      }
-    }
-  };
-
-  size_t pos_str = 0;
-  while ((pos_str = boundary_type_str.find(delimiter)) != std::string::npos)
-  {
-    std::string boundary = boundary_type_str.substr(0, pos_str);
-    parse_boundary_type(boundary, boundary_type);
-    boundary_type_str.erase(0, pos_str + delimiter.length());
-  }
-  parse_boundary_type(boundary_type_str, boundary_type);
-
-  return boundary_type;
-}
-
 template <int dim, int fe_degree, typename MemorySpaceType,
           std::enable_if_t<
               std::is_same<MemorySpaceType, dealii::MemorySpace::Host>::value,
@@ -135,7 +93,7 @@ evaluate_thermal_physics_impl(
     dealii::hp::FECollection<dim> const &fe_collection, double const t,
     dealii::DoFHandler<dim> const &dof_handler,
     std::vector<std::shared_ptr<HeatSource<dim>>> const &heat_sources,
-    double current_source_height, std::vector<BoundaryType> boundary_types,
+    double current_source_height, Boundary const &boundary,
     MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType>
         &material_properties,
     dealii::AffineConstraints<double> const &affine_constraints,
@@ -186,14 +144,9 @@ evaluate_thermal_physics_impl(
           dealii::update_JxW_values);
   unsigned int const n_face_q_points = face_quadrature.size();
   dealii::Vector<double> cell_source(dofs_per_cell);
-  bool adiabatic_only_bc = true;
-  for (auto const boundary : boundary_types)
-  {
-    if (!(boundary & BoundaryType::adiabatic))
-    {
-      adiabatic_only_bc = false;
-    }
-  }
+  bool const adiabatic_only_bc =
+      boundary.get_boundary_ids(BoundaryType::adiabatic).size() ==
+      boundary.n_boundary_ids();
   ASSERT_THROW(
       adiabatic_only_bc,
       "On GPU, only adiabatic boundary conditions are currently supported.");
@@ -243,9 +196,7 @@ evaluate_thermal_physics_impl(
           double rad_temperature_infty = 0.;
           double rad_heat_transfer_coef = 0.;
           BoundaryType boundary_type =
-              face->boundary_id() < boundary_types.size()
-                  ? boundary_types[face->boundary_id()]
-                  : boundary_types.back();
+              boundary.get_boundary_type(face->boundary_id());
           if (boundary_type & BoundaryType::convective)
           {
             conv_temperature_infty = material_properties.get_cell_value(
@@ -322,10 +273,11 @@ ThermalPhysics<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
                QuadratureType>::
     ThermalPhysics(MPI_Comm const &communicator,
                    boost::property_tree::ptree const &database,
-                   Geometry<dim> &geometry,
+                   Geometry<dim> &geometry, Boundary const &boundary,
                    MaterialProperty<dim, p_order, MaterialStates,
                                     MemorySpaceType> &material_properties)
-    : _geometry(geometry), _dof_handler(_geometry.get_triangulation()),
+    : _geometry(geometry), _boundary(boundary),
+      _dof_handler(_geometry.get_triangulation()),
       _cell_weights(
           _dof_handler,
           dealii::parallel::CellWeights<dim>::ndofs_weighting({1, 1})),
@@ -378,34 +330,6 @@ ThermalPhysics<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
     }
   }
 
-  // Create the boundary condition types
-  boost::property_tree::ptree boundary_database =
-      database.get_child("boundary");
-  std::vector<dealii::types::boundary_id> boundary_ids =
-      _geometry.get_triangulation().get_boundary_ids();
-  _boundary_types.resize(boundary_ids.size() + 1, BoundaryType::invalid);
-  // Set the default boundary condition. It can be overwritten for given
-  // boundary ids. It is the boundary used for the current layer.
-  // PropertyTreeInput boundary.type
-  std::string boundary_type_str = boundary_database.get<std::string>("type");
-  BoundaryType default_boundary = parse_boundary_line(boundary_type_str);
-  for (auto &boundary : _boundary_types)
-  {
-    boundary = default_boundary;
-  }
-  // Check if the user wants to use different boundaries for different part
-  // of the domain's boundary.
-  for (auto const id : boundary_ids)
-  {
-    // PropertyTreeInput boundary.boundary_id.type
-    auto boundary_type_str = boundary_database.get_optional<std::string>(
-        "boundary_" + std::to_string(id) + ".type");
-    if (boundary_type_str)
-    {
-      _boundary_types[id] = parse_boundary_line(*boundary_type_str);
-    }
-  }
-
   // Create the thermal operator
   if (std::is_same<MemorySpaceType, dealii::MemorySpace::Host>::value)
   {
@@ -414,16 +338,14 @@ ThermalPhysics<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
       _thermal_operator =
           std::make_shared<ThermalOperator<dim, true, p_order, fe_degree,
                                            MaterialStates, MemorySpaceType>>(
-              communicator, _boundary_types, _material_properties,
-              _heat_sources);
+              communicator, _boundary, _material_properties, _heat_sources);
     }
     else
     {
       _thermal_operator =
           std::make_shared<ThermalOperator<dim, false, p_order, fe_degree,
                                            MaterialStates, MemorySpaceType>>(
-              communicator, _boundary_types, _material_properties,
-              _heat_sources);
+              communicator, _boundary, _material_properties, _heat_sources);
     }
   }
   else
@@ -432,13 +354,13 @@ ThermalPhysics<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
     {
       _thermal_operator = std::make_shared<ThermalOperatorDevice<
           dim, true, p_order, fe_degree, MaterialStates, MemorySpaceType>>(
-          communicator, _boundary_types, _material_properties);
+          communicator, _boundary, _material_properties);
     }
     else
     {
       _thermal_operator = std::make_shared<ThermalOperatorDevice<
           dim, false, p_order, fe_degree, MaterialStates, MemorySpaceType>>(
-          communicator, _boundary_types, _material_properties);
+          communicator, _boundary, _material_properties);
     }
   }
 
@@ -998,7 +920,7 @@ ThermalPhysics<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
       return evaluate_thermal_physics_impl<dim, true, p_order, fe_degree,
                                            MaterialStates, MemorySpaceType>(
           _thermal_operator, _fe_collection, t, _dof_handler, _heat_sources,
-          _current_source_height, _boundary_types, _material_properties,
+          _current_source_height, _boundary, _material_properties,
           _affine_constraints, y, timers);
     }
     else
@@ -1006,7 +928,7 @@ ThermalPhysics<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
       return evaluate_thermal_physics_impl<dim, false, p_order, fe_degree,
                                            MaterialStates, MemorySpaceType>(
           _thermal_operator, _fe_collection, t, _dof_handler, _heat_sources,
-          _current_source_height, _boundary_types, _material_properties,
+          _current_source_height, _boundary, _material_properties,
           _affine_constraints, y, timers);
     }
   }

--- a/source/types.hh
+++ b/source/types.hh
@@ -1,4 +1,4 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -185,64 +185,6 @@ struct axis<3>
   static unsigned int constexpr y = 1;
   static unsigned int constexpr z = 2;
 };
-
-/**
- * Enum on the different types of boundary condition supported. Some of them can
- * be combined, for example radiative and convective.
- */
-enum BoundaryType
-{
-  invalid = 0,
-  adiabatic = 0x1,
-  radiative = 0x2,
-  convective = 0x4,
-};
-
-/**
- * Global operator which returns an object in which all bits are set which are
- * either set in the first or the second argument. This operator exists since if
- * it did not then the result of the bit-or operator | would be an integer which
- * would in turn trigger a compiler warning when we tried to assign it to an
- * object of type BoundaryType.
- */
-inline BoundaryType operator|(const BoundaryType b1, const BoundaryType b2)
-{
-  return static_cast<BoundaryType>(static_cast<unsigned int>(b1) |
-                                   static_cast<unsigned int>(b2));
-}
-
-/**
- * Global operator which sets the bits from the second argument also in the
- * first one.
- */
-inline BoundaryType &operator|=(BoundaryType &b1, const BoundaryType b2)
-{
-  b1 = b1 | b2;
-  return b1;
-}
-
-/**
- * Global operator which returns an object in which all bits are set which are
- * set in the first as well as the second argument. This operator exists since
- * if it did not then the result of the bit-and operator & would be an integer
- * which would in turn trigger a compiler warning when we tried to assign it to
- * an object of type BoundaryType.
- */
-inline BoundaryType operator&(const BoundaryType b1, const BoundaryType b2)
-{
-  return static_cast<BoundaryType>(static_cast<unsigned int>(b1) &
-                                   static_cast<unsigned int>(b2));
-}
-
-/**
- * Global operator which clears all the bits in the first argument if they are
- * not also set in the second argument.
- */
-inline BoundaryType &operator&=(BoundaryType &b1, const BoundaryType b2)
-{
-  b1 = b1 & b2;
-  return b1;
-}
 
 } // namespace adamantine
 

--- a/source/validate_input_database.cc
+++ b/source/validate_input_database.cc
@@ -1,7 +1,8 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2021 - 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2021 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
+#include <Boundary.hh>
 #include <types.hh>
 #include <utils.hh>
 #include <validate_input_database.hh>
@@ -33,31 +34,39 @@ void validate_input_database(boost::property_tree::ptree &database)
   std::string delimiter = ",";
   auto parse_boundary_type = [&](std::string const &boundary)
   {
-    if (boundary == "adiabatic")
+    if (use_thermal_physics)
     {
-      ASSERT_THROW(
-          boundary_type == BoundaryType::invalid,
-          "Error: Adiabatic condition cannot be combined with another type.");
-      boundary_type = BoundaryType::adiabatic;
-    }
-    else
-    {
-      ASSERT_THROW(
-          boundary_type != BoundaryType::adiabatic,
-          "Error: Adiabatic condition cannot be combined with another type.");
-
-      if (boundary == "radiative")
+      if (boundary == "adiabatic")
       {
-        boundary_type |= BoundaryType::radiative;
-      }
-      else if (boundary == "convective")
-      {
-        boundary_type |= BoundaryType::convective;
+        ASSERT_THROW(
+            boundary_type == BoundaryType::invalid,
+            "Error: Adiabatic condition cannot be combined with another type.");
+        boundary_type = BoundaryType::adiabatic;
       }
       else
       {
-        ASSERT_THROW(false, "Error: Unknown boundary type.");
+        ASSERT_THROW(
+            boundary_type != BoundaryType::adiabatic,
+            "Error: Adiabatic condition cannot be combined with another type.");
+
+        if (boundary == "radiative")
+        {
+          boundary_type |= BoundaryType::radiative;
+        }
+        else if (boundary == "convective")
+        {
+          boundary_type |= BoundaryType::convective;
+        }
+        else
+        {
+          ASSERT_THROW(false, "Error: Unknown boundary type.");
+        }
       }
+    }
+    else
+    {
+      ASSERT_THROW(false, "Error: Global boundary type can only be assigned "
+                          "when thermal physic is enabled.");
     }
   };
   while ((pos_str = boundary_type_str.find(delimiter)) != std::string::npos)

--- a/tests/data/thermoelastic_bare_plate.info
+++ b/tests/data/thermoelastic_bare_plate.info
@@ -39,6 +39,10 @@ discretization
 boundary
 {
   type adiabatic ; convective,radiative
+  boundary_4
+  {
+    type adiabatic,clamped
+  }
 }
 
 refinement

--- a/tests/test_implicit_operator.cc
+++ b/tests/test_implicit_operator.cc
@@ -39,6 +39,14 @@ BOOST_AUTO_TEST_CASE(implicit_operator)
   boost::optional<boost::property_tree::ptree const &> units_optional_database;
   adamantine::Geometry<2> geometry(communicator, geometry_database,
                                    units_optional_database);
+
+  // Create the Boundary
+  boost::property_tree::ptree boundary_database;
+  boundary_database.put("type", "adiabatic");
+  adamantine::Boundary boundary(boundary_database,
+                                geometry.get_triangulation().get_boundary_ids(),
+                                false);
+
   // Create the DoFHandler
   dealii::hp::FECollection<2> fe_collection;
   fe_collection.push_back(dealii::FE_Q<2>(2));
@@ -86,8 +94,6 @@ BOOST_AUTO_TEST_CASE(implicit_operator)
   heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
-  std::vector<adamantine::BoundaryType> boundary(
-      2, adamantine::BoundaryType::adiabatic);
   auto thermal_operator = std::make_shared<
       adamantine::ThermalOperator<2, false, 0, 2, adamantine::SolidLiquidPowder,
                                   dealii::MemorySpace::Host>>(

--- a/tests/test_material_deposition.cc
+++ b/tests/test_material_deposition.cc
@@ -1,4 +1,4 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2021 - 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2021 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -286,6 +286,13 @@ BOOST_AUTO_TEST_CASE(material_deposition)
   adamantine::Geometry<dim> geometry(communicator, geometry_database,
                                      units_optional_database);
 
+  // Create the Boundary
+  boost::property_tree::ptree boundary_database;
+  boundary_database.put("type", "adiabatic");
+  adamantine::Boundary boundary(boundary_database,
+                                geometry.get_triangulation().get_boundary_ids(),
+                                false);
+
   // MaterialProperty database
   database.put("materials.property_format", "polynomial");
   database.put("materials.initial_temperature", initial_temperature);
@@ -311,13 +318,12 @@ BOOST_AUTO_TEST_CASE(material_deposition)
   database.put("sources.n_beams", 0);
   // Time-stepping database
   database.put("time_stepping.method", "forward_euler");
-  // Boundary database
-  database.put("boundary.type", "adiabatic");
 
   // Build ThermalPhysics
   adamantine::ThermalPhysics<dim, 1, dim, adamantine::SolidLiquidPowder,
                              dealii::MemorySpace::Host, dealii::QGauss<1>>
-      thermal_physics(communicator, database, geometry, material_properties);
+      thermal_physics(communicator, database, geometry, boundary,
+                      material_properties);
   thermal_physics.setup();
   auto &dof_handler = thermal_physics.get_dof_handler();
 

--- a/tests/test_mechanical_physics.cc
+++ b/tests/test_mechanical_physics.cc
@@ -1,4 +1,4 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2022 - 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2022 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -227,13 +227,18 @@ BOOST_AUTO_TEST_CASE(elastostatic)
   adamantine::MaterialProperty<3, 4, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Host>
       material_properties(communicator, triangulation, material_database);
+  // Create the Boundary
+  boost::property_tree::ptree boundary_database;
+  boundary_database.put("boundary_4.type", "clamped");
+  adamantine::Boundary boundary(
+      boundary_database, geometry.get_triangulation().get_boundary_ids(), true);
   // Build MechanicalPhysics
   unsigned int const fe_degree = 1;
   std::vector<double> empty_vector;
   adamantine::MechanicalPhysics<3, 4, adamantine::SolidLiquidPowder,
                                 dealii::MemorySpace::Host>
-      mechanical_physics(communicator, fe_degree, geometry, material_properties,
-                         empty_vector);
+      mechanical_physics(communicator, fe_degree, geometry, boundary,
+                         material_properties, empty_vector);
   std::vector<std::shared_ptr<adamantine::BodyForce<3>>> body_forces;
   auto gravity_force = std::make_shared<adamantine::GravityForce<
       3, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>>(
@@ -300,13 +305,18 @@ BOOST_AUTO_TEST_CASE(fe_nothing)
   adamantine::MaterialProperty<3, 2, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Host>
       material_properties(communicator, triangulation, material_database);
+  // Create the Boundary
+  boost::property_tree::ptree boundary_database;
+  boundary_database.put("boundary_4.type", "clamped");
+  adamantine::Boundary boundary(
+      boundary_database, geometry.get_triangulation().get_boundary_ids(), true);
   // Build MechanicalPhysics
   unsigned int const fe_degree = 1;
   std::vector<double> empty_vector;
   adamantine::MechanicalPhysics<3, 2, adamantine::SolidLiquidPowder,
                                 dealii::MemorySpace::Host>
-      mechanical_physics(communicator, fe_degree, geometry, material_properties,
-                         empty_vector);
+      mechanical_physics(communicator, fe_degree, geometry, boundary,
+                         material_properties, empty_vector);
   std::vector<std::shared_ptr<adamantine::BodyForce<3>>> body_forces;
   auto gravity_force = std::make_shared<adamantine::GravityForce<
       3, 2, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>>(
@@ -414,6 +424,14 @@ run_eshelby(std::vector<dealii::Point<dim>> pts, unsigned int refinement_cycles)
     triangulation.execute_coarsening_and_refinement();
   }
 
+  // Create the Boundary
+  boost::property_tree::ptree boundary_database;
+  boundary_database.put("type", "adiabatic");
+  boundary_database.put("boundary_4.type", "adiabatic,clamped");
+  adamantine::Boundary boundary(boundary_database,
+                                geometry.get_triangulation().get_boundary_ids(),
+                                false);
+
   // Create the MaterialProperty
   boost::property_tree::ptree material_database;
   material_database.put("property_format", "polynomial");
@@ -453,10 +471,10 @@ run_eshelby(std::vector<dealii::Point<dim>> pts, unsigned int refinement_cycles)
   database.put("sources.beam_0.scan_path_file",
                "scan_path_test_thermal_physics.txt");
   database.put("sources.beam_0.scan_path_file_format", "segment");
-  database.put("boundary.type", "adiabatic");
   adamantine::ThermalPhysics<dim, 3, 1, adamantine::SolidLiquidPowder,
                              dealii::MemorySpace::Host, dealii::QGauss<1>>
-      thermal_physics(communicator, database, geometry, material_properties);
+      thermal_physics(communicator, database, geometry, boundary,
+                      material_properties);
   thermal_physics.setup();
 
   dealii::LinearAlgebra::distributed::Vector<double> temperature;
@@ -470,8 +488,8 @@ run_eshelby(std::vector<dealii::Point<dim>> pts, unsigned int refinement_cycles)
   std::vector<double> initial_temperature = {2.0};
   adamantine::MechanicalPhysics<3, 3, adamantine::SolidLiquidPowder,
                                 dealii::MemorySpace::Host>
-      mechanical_physics(communicator, fe_degree, geometry, material_properties,
-                         initial_temperature);
+      mechanical_physics(communicator, fe_degree, geometry, boundary,
+                         material_properties, initial_temperature);
 
   boost::property_tree::ptree post_processor_database;
   post_processor_database.put("filename_prefix", "mech_phys_test");
@@ -576,13 +594,18 @@ BOOST_AUTO_TEST_CASE(elastoplastic)
   adamantine::MaterialProperty<3, 4, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Host>
       material_properties(communicator, triangulation, material_database);
+  // Create the Boundary
+  boost::property_tree::ptree boundary_database;
+  boundary_database.put("boundary_4.type", "clamped");
+  adamantine::Boundary boundary(
+      boundary_database, geometry.get_triangulation().get_boundary_ids(), true);
   // Build MechanicalPhysics
   unsigned int const fe_degree = 1;
   std::vector<double> empty_vector;
   adamantine::MechanicalPhysics<3, 4, adamantine::SolidLiquidPowder,
                                 dealii::MemorySpace::Host>
-      mechanical_physics(communicator, fe_degree, geometry, material_properties,
-                         empty_vector);
+      mechanical_physics(communicator, fe_degree, geometry, boundary,
+                         material_properties, empty_vector);
   std::vector<std::shared_ptr<adamantine::BodyForce<3>>> body_forces;
   auto gravity_force = std::make_shared<adamantine::GravityForce<
       3, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>>(

--- a/tests/test_microstructure.cc
+++ b/tests/test_microstructure.cc
@@ -67,6 +67,13 @@ BOOST_AUTO_TEST_CASE(G_and_R)
   adamantine::Geometry<2> geometry(communicator, geometry_database,
                                    units_optional_database);
 
+  // Create the Boundary
+  boost::property_tree::ptree boundary_database;
+  boundary_database.put("type", "adiabatic");
+  adamantine::Boundary boundary(boundary_database,
+                                geometry.get_triangulation().get_boundary_ids(),
+                                false);
+
   // Build MaterialProperty
   boost::property_tree::ptree material_property_database;
   material_property_database.put("property_format", "polynomial");
@@ -106,8 +113,6 @@ BOOST_AUTO_TEST_CASE(G_and_R)
   database.put("sources.beam_0.scan_path_file",
                "scan_path_test_thermal_physics.txt");
   database.put("sources.beam_0.scan_path_file_format", "segment");
-  // Boundary database
-  database.put("boundary.type", "adiabatic");
 
   // Time-stepping database
   database.put("time_stepping.method", "rk_fourth_order");
@@ -115,7 +120,7 @@ BOOST_AUTO_TEST_CASE(G_and_R)
   // Build ThermalPhysics
   adamantine::ThermalPhysics<2, 4, 2, adamantine::SolidLiquidPowder,
                              dealii::MemorySpace::Host, dealii::QGauss<1>>
-      physics(communicator, database, geometry, material_properties);
+      physics(communicator, database, geometry, boundary, material_properties);
   physics.setup();
   dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> solution;
 

--- a/tests/test_post_processor.cc
+++ b/tests/test_post_processor.cc
@@ -38,6 +38,14 @@ BOOST_AUTO_TEST_CASE(thermal_post_processor)
   boost::optional<boost::property_tree::ptree const &> units_optional_database;
   adamantine::Geometry<2> geometry(communicator, geometry_database,
                                    units_optional_database);
+
+  // Create the Boundary
+  boost::property_tree::ptree boundary_database;
+  boundary_database.put("type", "adiabatic");
+  adamantine::Boundary boundary(boundary_database,
+                                geometry.get_triangulation().get_boundary_ids(),
+                                false);
+
   // Create the DoFHandler
   dealii::hp::FECollection<2> fe_collection;
   fe_collection.push_back(dealii::FE_Q<2>(2));
@@ -84,8 +92,6 @@ BOOST_AUTO_TEST_CASE(thermal_post_processor)
       beam_database, units_optional_database);
 
   // Initialize the ThermalOperator
-  std::vector<adamantine::BoundaryType> boundary(
-      2, adamantine::BoundaryType::adiabatic);
   adamantine::ThermalOperator<2, false, 0, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
       thermal_operator(communicator, boundary, mat_properties, heat_sources);

--- a/tests/test_thermal_operator.cc
+++ b/tests/test_thermal_operator.cc
@@ -52,6 +52,14 @@ BOOST_AUTO_TEST_CASE(thermal_operator, *utf::tolerance(1e-15))
   boost::optional<boost::property_tree::ptree const &> units_optional_database;
   adamantine::Geometry<2> geometry(communicator, geometry_database,
                                    units_optional_database);
+
+  // Create the Boundary
+  boost::property_tree::ptree boundary_database;
+  boundary_database.put("type", "adiabatic");
+  adamantine::Boundary boundary(boundary_database,
+                                geometry.get_triangulation().get_boundary_ids(),
+                                false);
+
   // Create the DoFHandler
   dealii::hp::FECollection<2> fe_collection;
   fe_collection.push_back(dealii::FE_Q<2>(2));
@@ -100,8 +108,6 @@ BOOST_AUTO_TEST_CASE(thermal_operator, *utf::tolerance(1e-15))
   heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
-  std::vector<adamantine::BoundaryType> boundary(
-      2, adamantine::BoundaryType::adiabatic);
   adamantine::ThermalOperator<2, false, 1, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
       thermal_operator(communicator, boundary, mat_properties, heat_sources);
@@ -161,6 +167,13 @@ BOOST_AUTO_TEST_CASE(spmv, *utf::tolerance(1e-12))
   boost::optional<boost::property_tree::ptree const &> units_optional_database;
   adamantine::Geometry<2> geometry(communicator, geometry_database,
                                    units_optional_database);
+  // Create the Boundary
+  boost::property_tree::ptree boundary_database;
+  boundary_database.put("type", "adiabatic");
+  adamantine::Boundary boundary(boundary_database,
+                                geometry.get_triangulation().get_boundary_ids(),
+                                false);
+
   // Create the DoFHandler
   dealii::hp::FECollection<2> fe_collection;
   fe_collection.push_back(dealii::FE_Q<2>(2));
@@ -209,8 +222,6 @@ BOOST_AUTO_TEST_CASE(spmv, *utf::tolerance(1e-12))
   heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
-  std::vector<adamantine::BoundaryType> boundary(
-      2, adamantine::BoundaryType::adiabatic);
   adamantine::ThermalOperator<2, false, 2, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
       thermal_operator(communicator, boundary, mat_properties, heat_sources);
@@ -274,6 +285,14 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic, *utf::tolerance(1e-12))
   boost::optional<boost::property_tree::ptree const &> units_optional_database;
   adamantine::Geometry<2> geometry(communicator, geometry_database,
                                    units_optional_database);
+
+  // Create the Boundary
+  boost::property_tree::ptree boundary_database;
+  boundary_database.put("type", "adiabatic");
+  adamantine::Boundary boundary(boundary_database,
+                                geometry.get_triangulation().get_boundary_ids(),
+                                false);
+
   // Create the DoFHandler
   dealii::hp::FECollection<2> fe_collection;
   fe_collection.push_back(dealii::FE_Q<2>(2));
@@ -322,8 +341,6 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic, *utf::tolerance(1e-12))
   heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
-  std::vector<adamantine::BoundaryType> boundary(
-      2, adamantine::BoundaryType::adiabatic);
   adamantine::ThermalOperator<2, false, 2, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
       thermal_operator(communicator, boundary, mat_properties, heat_sources);
@@ -421,6 +438,14 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic_angle, *utf::tolerance(1e-10))
   boost::optional<boost::property_tree::ptree const &> units_optional_database;
   adamantine::Geometry<3> geometry(communicator, geometry_database,
                                    units_optional_database);
+
+  // Create the Boundary
+  boost::property_tree::ptree boundary_database;
+  boundary_database.put("type", "adiabatic");
+  adamantine::Boundary boundary(boundary_database,
+                                geometry.get_triangulation().get_boundary_ids(),
+                                false);
+
   // Create the DoFHandler
   dealii::hp::FECollection<3> fe_collection;
   fe_collection.push_back(dealii::FE_Q<3>(2));
@@ -464,8 +489,6 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic_angle, *utf::tolerance(1e-10))
   std::vector<std::shared_ptr<adamantine::HeatSource<3>>> heat_sources;
 
   // Initialize the ThermalOperator
-  std::vector<adamantine::BoundaryType> boundary(
-      2, adamantine::BoundaryType::adiabatic);
   adamantine::ThermalOperator<3, false, 1, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
       thermal_operator(communicator, boundary, mat_properties, heat_sources);
@@ -579,6 +602,14 @@ BOOST_AUTO_TEST_CASE(spmv_rad, *utf::tolerance(1e-12))
   boost::optional<boost::property_tree::ptree const &> units_optional_database;
   adamantine::Geometry<2> geometry(communicator, geometry_database,
                                    units_optional_database);
+
+  // Create the Boundary
+  boost::property_tree::ptree boundary_database;
+  boundary_database.put("type", "radiative");
+  adamantine::Boundary boundary(boundary_database,
+                                geometry.get_triangulation().get_boundary_ids(),
+                                false);
+
   // Create the DoFHandler
   dealii::hp::FECollection<2> fe_collection;
   fe_collection.push_back(dealii::FE_Q<2>(2));
@@ -636,8 +667,6 @@ BOOST_AUTO_TEST_CASE(spmv_rad, *utf::tolerance(1e-12))
   heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
-  std::vector<adamantine::BoundaryType> boundary(
-      2, adamantine::BoundaryType::radiative);
   adamantine::ThermalOperator<2, false, 1, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
       thermal_operator(communicator, boundary, mat_properties, heat_sources);
@@ -766,6 +795,14 @@ BOOST_AUTO_TEST_CASE(spmv_conv, *utf::tolerance(1e-12))
   boost::optional<boost::property_tree::ptree const &> units_optional_database;
   adamantine::Geometry<2> geometry(communicator, geometry_database,
                                    units_optional_database);
+
+  // Create the Boundary
+  boost::property_tree::ptree boundary_database;
+  boundary_database.put("type", "convective");
+  adamantine::Boundary boundary(boundary_database,
+                                geometry.get_triangulation().get_boundary_ids(),
+                                false);
+
   // Create the DoFHandler
   dealii::hp::FECollection<2> fe_collection;
   fe_collection.push_back(dealii::FE_Q<2>(2));
@@ -823,8 +860,6 @@ BOOST_AUTO_TEST_CASE(spmv_conv, *utf::tolerance(1e-12))
   heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
-  std::vector<adamantine::BoundaryType> boundary(
-      2, adamantine::BoundaryType::convective);
   adamantine::ThermalOperator<2, false, 1, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
       thermal_operator(communicator, boundary, mat_properties, heat_sources);

--- a/tests/test_thermal_operator_device.cc
+++ b/tests/test_thermal_operator_device.cc
@@ -42,6 +42,14 @@ BOOST_AUTO_TEST_CASE(thermal_operator_dev, *utf::tolerance(1e-10))
   boost::optional<boost::property_tree::ptree const &> units_optional_database;
   adamantine::Geometry<2> geometry(communicator, geometry_database,
                                    units_optional_database);
+
+  // Create the Boundary
+  boost::property_tree::ptree boundary_database;
+  boundary_database.put("type", "adiabatic");
+  adamantine::Boundary boundary(boundary_database,
+                                geometry.get_triangulation().get_boundary_ids(),
+                                false);
+
   // Create the DoFHandler
   dealii::hp::FECollection<2> fe_collection;
   fe_collection.push_back(dealii::FE_Q<2>(2));
@@ -76,8 +84,6 @@ BOOST_AUTO_TEST_CASE(thermal_operator_dev, *utf::tolerance(1e-10))
                      mat_prop_database);
 
   // Initialize the ThermalOperator
-  std::vector<adamantine::BoundaryType> boundary(
-      2, adamantine::BoundaryType::adiabatic);
   adamantine::ThermalOperatorDevice<2, false, 0, 2,
                                     adamantine::SolidLiquidPowder,
                                     dealii::MemorySpace::Default>
@@ -137,6 +143,14 @@ BOOST_AUTO_TEST_CASE(spmv, *utf::tolerance(1e-12))
   boost::optional<boost::property_tree::ptree const &> units_optional_database;
   adamantine::Geometry<2> geometry(communicator, geometry_database,
                                    units_optional_database);
+
+  // Create the Boundary
+  boost::property_tree::ptree boundary_database;
+  boundary_database.put("type", "adiabatic");
+  adamantine::Boundary boundary(boundary_database,
+                                geometry.get_triangulation().get_boundary_ids(),
+                                false);
+
   // Create the DoFHandler
   dealii::hp::FECollection<2> fe_collection;
   fe_collection.push_back(dealii::FE_Q<2>(2));
@@ -171,8 +185,6 @@ BOOST_AUTO_TEST_CASE(spmv, *utf::tolerance(1e-12))
                      mat_prop_database);
 
   // Initialize the ThermalOperator
-  std::vector<adamantine::BoundaryType> boundary(
-      2, adamantine::BoundaryType::adiabatic);
   adamantine::ThermalOperatorDevice<2, false, 3, 2,
                                     adamantine::SolidLiquidPowder,
                                     dealii::MemorySpace::Default>
@@ -245,6 +257,14 @@ BOOST_AUTO_TEST_CASE(mf_spmv, *utf::tolerance(1.5e-12))
   boost::optional<boost::property_tree::ptree const &> units_optional_database;
   adamantine::Geometry<2> geometry(communicator, geometry_database,
                                    units_optional_database);
+
+  // Create the Boundary
+  boost::property_tree::ptree boundary_database;
+  boundary_database.put("type", "adiabatic");
+  adamantine::Boundary boundary(boundary_database,
+                                geometry.get_triangulation().get_boundary_ids(),
+                                false);
+
   // Create the DoFHandler
   dealii::hp::FECollection<2> fe_collection;
   fe_collection.push_back(dealii::FE_Q<2>(2));
@@ -297,8 +317,6 @@ BOOST_AUTO_TEST_CASE(mf_spmv, *utf::tolerance(1.5e-12))
   heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
-  std::vector<adamantine::BoundaryType> boundary(
-      2, adamantine::BoundaryType::adiabatic);
   adamantine::ThermalOperatorDevice<2, false, 4, 2,
                                     adamantine::SolidLiquidPowder,
                                     dealii::MemorySpace::Default>
@@ -380,6 +398,14 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic_angle, *utf::tolerance(1e-10))
   boost::optional<boost::property_tree::ptree const &> units_optional_database;
   adamantine::Geometry<3> geometry(communicator, geometry_database,
                                    units_optional_database);
+
+  // Create the Boundary
+  boost::property_tree::ptree boundary_database;
+  boundary_database.put("type", "adiabatic");
+  adamantine::Boundary boundary(boundary_database,
+                                geometry.get_triangulation().get_boundary_ids(),
+                                false);
+
   // Create the DoFHandler
   dealii::hp::FECollection<3> fe_collection;
   fe_collection.push_back(dealii::FE_Q<3>(2));
@@ -420,8 +446,6 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic_angle, *utf::tolerance(1e-10))
                      mat_prop_database);
 
   // Initialize the ThermalOperatorDevice
-  std::vector<adamantine::BoundaryType> boundary(
-      2, adamantine::BoundaryType::adiabatic);
   adamantine::ThermalOperatorDevice<3, false, 3, 2,
                                     adamantine::SolidLiquidPowder,
                                     dealii::MemorySpace::Default>


### PR DESCRIPTION
This PR reworks how we store boundary conditions and boundary ids. It consolidates everything into a new `Boundary` class. This PR also adds a new `clamped` boundary condition which imposes zero displacement in mechanical simulation. Before this PR, we always clamped the faces with a boundary id equals to four. Now we can clamp any boundary ids we want. Right now, user can set `clamped` bc with `boudary.type`. I am not sure if we should allow it or not because it won't do what you expect on the layer that's being printed. The top face won't be clamped but the thermal boundary condition will be applied. The current behavior is convenient but not consistent between the thermal and the mechanical parts of the simulation. What do you think @stvdwtt ? 