### PR TITLE
Change format of experimental log file

### DIFF
--- a/source/experimental_data_utils.cc
+++ b/source/experimental_data_utils.cc
@@ -162,8 +162,6 @@ read_frame_timestamps(boost::property_tree::ptree const &experiment_database)
   unsigned int num_cameras = last_camera_id - first_camera_id + 1;
   std::vector<std::vector<double>> time_stamps(num_cameras);
 
-  std::vector<double> first_frame_value(num_cameras);
-
   // Read and parse the file
   std::ifstream file;
   file.open(log_filename);
@@ -193,13 +191,9 @@ read_frame_timestamps(boost::property_tree::ptree const &experiment_database)
       }
       else
       {
-        if (frame == first_frame && substring.size() > 0)
-          first_frame_value[entry_index - 1] = std::stod(substring);
-
         if (frame_of_interest && substring.size() > 0)
-          time_stamps[entry_index - 1].push_back(
-              std::stod(substring) - first_frame_value[entry_index - 1] +
-              first_frame_offset);
+          time_stamps[entry_index - 1].push_back(std::stod(substring) +
+                                                 first_frame_offset);
       }
       entry_index++;
     }

--- a/tests/test_experimental_data.cc
+++ b/tests/test_experimental_data.cc
@@ -205,13 +205,13 @@ BOOST_AUTO_TEST_CASE(timestamp, *utf::tolerance(1e-12))
   BOOST_TEST(time_stamps[0].size() == 3);
   BOOST_TEST(time_stamps[1].size() == 3);
 
-  BOOST_TEST(time_stamps[0][0] == 0.1);
-  BOOST_TEST(time_stamps[0][1] == 0.1135);
-  BOOST_TEST(time_stamps[0][2] == 0.1345);
+  BOOST_TEST(time_stamps[0][0] == 0.1105);
+  BOOST_TEST(time_stamps[0][1] == 0.124);
+  BOOST_TEST(time_stamps[0][2] == 0.145);
 
-  BOOST_TEST(time_stamps[1][0] == 0.1);
-  BOOST_TEST(time_stamps[1][1] == 0.1136);
-  BOOST_TEST(time_stamps[1][2] == 0.1348);
+  BOOST_TEST(time_stamps[1][0] == 0.1106);
+  BOOST_TEST(time_stamps[1][1] == 0.1242);
+  BOOST_TEST(time_stamps[1][2] == 0.1454);
 }
 
 BOOST_AUTO_TEST_CASE(project_ray_data_on_mesh, *utf::tolerance(1e-12))


### PR DESCRIPTION
I propose to change the way the build time log files work. Currently, we subtract the time of the first frame to all the following frames. This is very confusing and I don't know why we do that. @stvdwtt You wrote that code https://github.com/adamantine-sim/adamantine/pull/119 do you remember why we do this? 

Would this change break your workflow @stvdwtt @AshGannon ?