### PR TITLE
Simplify instantiation macros

### DIFF
--- a/source/BodyForce.cc
+++ b/source/BodyForce.cc
@@ -1,4 +1,4 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2023 - 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2023 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -33,5 +33,5 @@ GravityForce<dim, p_order, MaterialStates, MemorySpaceType>::eval(
 }
 } // namespace adamantine
 
-INSTANTIATE_DIM_PORDER_MATERIALSTATES_HOST(TUPLE(GravityForce))
-INSTANTIATE_DIM_PORDER_MATERIALSTATES_DEVICE(TUPLE(GravityForce))
+INSTANTIATE_DIM_PORDER_MATERIALSTATES_HOST(GravityForce)
+INSTANTIATE_DIM_PORDER_MATERIALSTATES_DEVICE(GravityForce)

--- a/source/MaterialPropertyInstDev.cc
+++ b/source/MaterialPropertyInstDev.cc
@@ -1,8 +1,8 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2024 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #include <MaterialProperty.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_PORDER_MATERIALSTATES_DEVICE(TUPLE(MaterialProperty))
+INSTANTIATE_DIM_PORDER_MATERIALSTATES_DEVICE(MaterialProperty)

--- a/source/MaterialPropertyInstHost.cc
+++ b/source/MaterialPropertyInstHost.cc
@@ -1,8 +1,8 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2024 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #include <MaterialProperty.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_PORDER_MATERIALSTATES_HOST(TUPLE(MaterialProperty))
+INSTANTIATE_DIM_PORDER_MATERIALSTATES_HOST(MaterialProperty)

--- a/source/MechanicalOperator.cc
+++ b/source/MechanicalOperator.cc
@@ -347,5 +347,5 @@ void MechanicalOperator<dim, p_order, MaterialStates, MemorySpaceType>::
 }
 } // namespace adamantine
 
-INSTANTIATE_DIM_PORDER_MATERIALSTATES_HOST(TUPLE(MechanicalOperator))
-INSTANTIATE_DIM_PORDER_MATERIALSTATES_DEVICE(TUPLE(MechanicalOperator))
+INSTANTIATE_DIM_PORDER_MATERIALSTATES_HOST(MechanicalOperator)
+INSTANTIATE_DIM_PORDER_MATERIALSTATES_DEVICE(MechanicalOperator)

--- a/source/MechanicalPhysics.cc
+++ b/source/MechanicalPhysics.cc
@@ -558,5 +558,5 @@ void MechanicalPhysics<dim, p_order, MaterialStates, MemorySpaceType>::
 
 } // namespace adamantine
 
-INSTANTIATE_DIM_PORDER_MATERIALSTATES_HOST(TUPLE(MechanicalPhysics))
-INSTANTIATE_DIM_PORDER_MATERIALSTATES_DEVICE(TUPLE(MechanicalPhysics))
+INSTANTIATE_DIM_PORDER_MATERIALSTATES_HOST(MechanicalPhysics)
+INSTANTIATE_DIM_PORDER_MATERIALSTATES_DEVICE(MechanicalPhysics)

--- a/source/ThermalOperatorDeviceInstSDev.cc
+++ b/source/ThermalOperatorDeviceInstSDev.cc
@@ -1,8 +1,8 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2024 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #include <ThermalOperatorDevice.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_S_DEVICE(TUPLE(ThermalOperatorDevice))
+INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_S_DEVICE(ThermalOperatorDevice)

--- a/source/ThermalOperatorDeviceInstSLDev.cc
+++ b/source/ThermalOperatorDeviceInstSLDev.cc
@@ -1,8 +1,8 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2024 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #include <ThermalOperatorDevice.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SL_DEVICE(TUPLE(ThermalOperatorDevice))
+INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SL_DEVICE(ThermalOperatorDevice)

--- a/source/ThermalOperatorDeviceInstSLPDev.cc
+++ b/source/ThermalOperatorDeviceInstSLPDev.cc
@@ -1,9 +1,8 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2024 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #include <ThermalOperatorDevice.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SLP_DEVICE(
-    TUPLE(ThermalOperatorDevice))
+INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SLP_DEVICE(ThermalOperatorDevice)

--- a/source/ThermalOperatorInstSHost.cc
+++ b/source/ThermalOperatorInstSHost.cc
@@ -1,8 +1,8 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2024 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #include <ThermalOperator.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_S_HOST(TUPLE(ThermalOperator))
+INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_S_HOST(ThermalOperator)

--- a/source/ThermalOperatorInstSLHost.cc
+++ b/source/ThermalOperatorInstSLHost.cc
@@ -1,8 +1,8 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2024 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #include <ThermalOperator.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SL_HOST(TUPLE(ThermalOperator))
+INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SL_HOST(ThermalOperator)

--- a/source/ThermalOperatorInstSLPHost.cc
+++ b/source/ThermalOperatorInstSLPHost.cc
@@ -1,8 +1,8 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2024 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #include <ThermalOperator.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SLP_HOST(TUPLE(ThermalOperator))
+INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SLP_HOST(ThermalOperator)

--- a/source/ThermalPhysicsInstSDev.cc
+++ b/source/ThermalPhysicsInstSDev.cc
@@ -1,8 +1,8 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2024 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #include <ThermalPhysics.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_PORDER_FEDEGREE_S_QUAD_DEVICE(TUPLE(ThermalPhysics))
+INSTANTIATE_DIM_PORDER_FEDEGREE_S_QUAD_DEVICE(ThermalPhysics)

--- a/source/ThermalPhysicsInstSHost.cc
+++ b/source/ThermalPhysicsInstSHost.cc
@@ -1,8 +1,8 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2024 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #include <ThermalPhysics.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_PORDER_FEDEGREE_S_QUAD_HOST(TUPLE(ThermalPhysics))
+INSTANTIATE_DIM_PORDER_FEDEGREE_S_QUAD_HOST(ThermalPhysics)

--- a/source/ThermalPhysicsInstSLDev.cc
+++ b/source/ThermalPhysicsInstSLDev.cc
@@ -1,8 +1,8 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2024 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #include <ThermalPhysics.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_PORDER_FEDEGREE_SL_QUAD_DEVICE(TUPLE(ThermalPhysics))
+INSTANTIATE_DIM_PORDER_FEDEGREE_SL_QUAD_DEVICE(ThermalPhysics)

--- a/source/ThermalPhysicsInstSLHost.cc
+++ b/source/ThermalPhysicsInstSLHost.cc
@@ -1,8 +1,8 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2024 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #include <ThermalPhysics.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_PORDER_FEDEGREE_SL_QUAD_HOST(TUPLE(ThermalPhysics))
+INSTANTIATE_DIM_PORDER_FEDEGREE_SL_QUAD_HOST(ThermalPhysics)

--- a/source/ThermalPhysicsInstSLPDev.cc
+++ b/source/ThermalPhysicsInstSLPDev.cc
@@ -1,8 +1,8 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2024 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #include <ThermalPhysics.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_PORDER_FEDEGREE_SLP_QUAD_DEVICE(TUPLE(ThermalPhysics))
+INSTANTIATE_DIM_PORDER_FEDEGREE_SLP_QUAD_DEVICE(ThermalPhysics)

--- a/source/ThermalPhysicsInstSLPHost.cc
+++ b/source/ThermalPhysicsInstSLPHost.cc
@@ -1,8 +1,8 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2024 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
 #include <ThermalPhysics.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_PORDER_FEDEGREE_SLP_QUAD_HOST(TUPLE(ThermalPhysics))
+INSTANTIATE_DIM_PORDER_FEDEGREE_SLP_QUAD_HOST(ThermalPhysics)

--- a/source/instantiation.hh
+++ b/source/instantiation.hh
@@ -1,230 +1,239 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
-#include <boost/preprocessor/repeat_from_to.hpp>
-#include <boost/preprocessor/seq/for_each.hpp>
-#include <boost/preprocessor/tuple/replace.hpp>
+#include <boost/preprocessor/seq/for_each_product.hpp>
 
 // clang-format off
+#define ADAMANTINE_DIM (2)(3)
+#define ADAMANTINE_USE_TABLE (true)(false)
+#define ADAMANTINE_P_ORDER (0)(1)(2)(3)(4)
+#define ADAMANTINE_FE_DEGREE (1)(2)(3)(4)(5)
+#define ADAMANTINE_MATERIAL_STATE (adamantine::Solid)(adamantine::SolidLiquid)(adamantine::SolidLiquidPowder)
+#define ADAMANTINE_QUADRATURE_TYPE (dealii::QGauss<1>)(dealii::QGaussLobatto<1>)
+
 // Instantiation of the class for:
 //   - dim = 2 and 3
-#define INST_DIM(z, dim, class_name) template class adamantine::class_name<dim>;
-#define INSTANTIATE_DIM(class_name) BOOST_PP_REPEAT_FROM_TO(2, 4, INST_DIM, class_name)
-
-#define INST_DIM_DEVICE(z, dim, class_name) template class adamantine::class_name<dim, dealii::MemorySpace::Default>;
-#define INSTANTIATE_DIM_DEVICE(class_name) BOOST_PP_REPEAT_FROM_TO(2, 4, INST_DIM_DEVICE, class_name)
-
-#define INST_DIM_HOST(z, dim, class_name) template class adamantine::class_name<dim, dealii::MemorySpace::Host>;
-#define INSTANTIATE_DIM_HOST(class_name) BOOST_PP_REPEAT_FROM_TO(2, 4, INST_DIM_HOST, class_name)
-
-#define TUPLE_N (0, 0, 0, 0)
-#define TUPLE(class_name) BOOST_PP_TUPLE_REPLACE(TUPLE_N, 0, class_name)
-
-#define USE_TABLE (true)(false)
-#define MATERIAL_STATE (adamantine::Solid)(adamantine::SolidLiquid)(adamantine::SolidLiquidPowder)
-#define QUADRATURE_TYPE (dealii::QGauss<1>)(dealii::QGaussLobatto<1>)
+#define ADAMANTINE_D(z, SEQ) \
+  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ)>;
+#define INSTANTIATE_DIM(NAME) \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D,((NAME))(ADAMANTINE_DIM))
 
 // Instantiation of the class for:
 //   - dim = 2 and 3
 //   - p_order = 0 to 4
 //   - material_state = Solid, SolidLiquid, and SolidLiquidPowder
-#define M_MATERIAL_STATE_HOST_1(z, TUPLE_2, material_state) \
-  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_2)<BOOST_PP_TUPLE_ELEM(1, TUPLE_2),\
-  BOOST_PP_TUPLE_ELEM(2, TUPLE_2), material_state, dealii::MemorySpace::Host>;
-#define M_P_ORDER_HOST_1(z, p_order, TUPLE_1) \
-  BOOST_PP_SEQ_FOR_EACH(M_MATERIAL_STATE_HOST_1, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 2, p_order),\
-                        MATERIAL_STATE)
-#define M_DIM_HOST_1(z, dim, TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_HOST_1, BOOST_PP_TUPLE_REPLACE(TUPLE_0, 1, dim))
-#define INSTANTIATE_DIM_PORDER_MATERIALSTATES_HOST(TUPLE_0) BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_HOST_1, TUPLE_0)
+//   - memory_space = Host
+#define ADAMANTINE_D_P_M_HOST(z, SEQ) \
+  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
+  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), dealii::MemorySpace::Host>;
+#define INSTANTIATE_DIM_PORDER_MATERIALSTATES_HOST(NAME) \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_P_M_HOST,\
+                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_P_ORDER)\
+                                (ADAMANTINE_MATERIAL_STATE))
 
-#define M_MATERIAL_STATE_DEVICE_1(z, TUPLE_2, material_state) \
-  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_2)<BOOST_PP_TUPLE_ELEM(1, TUPLE_2),\
-  BOOST_PP_TUPLE_ELEM(2, TUPLE_2), material_state, dealii::MemorySpace::Default>;
-#define M_P_ORDER_DEVICE_1(z, p_order, TUPLE_1) \
-  BOOST_PP_SEQ_FOR_EACH(M_MATERIAL_STATE_DEVICE_1, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 2, p_order),\
-                        MATERIAL_STATE)
-#define M_DIM_DEVICE_1(z, dim, TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_DEVICE_1, BOOST_PP_TUPLE_REPLACE(TUPLE_0, 1, dim))
-#define INSTANTIATE_DIM_PORDER_MATERIALSTATES_DEVICE(TUPLE_0) BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_DEVICE_1, TUPLE_0)
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - p_order = 0 to 4
+//   - material_state = Solid, SolidLiquid, and SolidLiquidPowder
+//   - memory_space = Default
+#define ADAMANTINE_D_P_M_DEV(z, SEQ) \
+  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
+  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), dealii::MemorySpace::Default>;
+#define INSTANTIATE_DIM_PORDER_MATERIALSTATES_DEVICE(NAME) \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_P_M_DEV,\
+                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_P_ORDER)\
+                                (ADAMANTINE_MATERIAL_STATE))
 
 // Instantiation of the class for:
 //   - dim = 2 and 3
 //   - use_table = true or false
 //   - p_order = 0 to 4
 //   - fe_degree = 1 to 5
-//   - material_state = Solid, SolidLiquid, and SolidLiquidPowder
-// We would like to use BOOST_PP_SEQ_FOR_EACH for the material_state but it does
-// not work. It's unclear why but it seems that we are reaching the maximum
-// number of nested for loop macros. Instead we create a macro for each material
-// state
-#define M_FE_DEGREE_S_HOST_2(z, fe_degree, TUPLE_4) \
-  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_4)<BOOST_PP_TUPLE_ELEM(1, TUPLE_4),\
-  BOOST_PP_TUPLE_ELEM(2, TUPLE_4), BOOST_PP_TUPLE_ELEM(3, TUPLE_4),\
-  fe_degree, adamantine::Solid, dealii::MemorySpace::Host>;
-#define M_P_ORDER_S_HOST_2(z, p_order, TUPLE_3) \
-  BOOST_PP_REPEAT_FROM_TO(1, 6, M_FE_DEGREE_S_HOST_2, BOOST_PP_TUPLE_REPLACE(TUPLE_3, 3, p_order))
-#define M_USE_TABLE_S_HOST_2(z, TUPLE_2, use_table) \
-  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_S_HOST_2, BOOST_PP_TUPLE_REPLACE(TUPLE_2, 2, use_table))
-#define M_DIM_S_HOST_2(z, dim, TUPLE_1) \
-  BOOST_PP_SEQ_FOR_EACH(M_USE_TABLE_S_HOST_2, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 1, dim), USE_TABLE)
-#define INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_S_HOST(TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_S_HOST_2, TUPLE_0)
+//   - material_state = Solid
+//   - memory_space = Host
+#define ADAMANTINE_D_U_P_F_S_HOST(z, SEQ) \
+  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
+  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),\
+  adamantine::Solid, dealii::MemorySpace::Host>;
+#define INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_S_HOST(NAME) \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_U_P_F_S_HOST,\
+                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_USE_TABLE)\
+                                (ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE))
 
-#define M_FE_DEGREE_SL_HOST_2(z, fe_degree, TUPLE_4) \
-  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_4)<BOOST_PP_TUPLE_ELEM(1, TUPLE_4),\
-  BOOST_PP_TUPLE_ELEM(2, TUPLE_4), BOOST_PP_TUPLE_ELEM(3, TUPLE_4),\
-  fe_degree, adamantine::SolidLiquid, dealii::MemorySpace::Host>;
-#define M_P_ORDER_SL_HOST_2(z, p_order, TUPLE_3) \
-  BOOST_PP_REPEAT_FROM_TO(1, 6, M_FE_DEGREE_SL_HOST_2, BOOST_PP_TUPLE_REPLACE(TUPLE_3, 3, p_order))
-#define M_USE_TABLE_SL_HOST_2(z, TUPLE_2, use_table) \
-  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_SL_HOST_2, BOOST_PP_TUPLE_REPLACE(TUPLE_2, 2, use_table))
-#define M_DIM_SL_HOST_2(z, dim, TUPLE_1) \
-  BOOST_PP_SEQ_FOR_EACH(M_USE_TABLE_SL_HOST_2, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 1, dim), USE_TABLE)
-#define INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SL_HOST(TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_SL_HOST_2, TUPLE_0)
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - use_table = true or false
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = SolidLiquid
+//   - memory_space = Host
+#define ADAMANTINE_D_U_P_F_SL_HOST(z, SEQ) \
+  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
+  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),\
+  adamantine::SolidLiquid, dealii::MemorySpace::Host>;
+#define INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SL_HOST(NAME) \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_U_P_F_SL_HOST,\
+                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_USE_TABLE)\
+                                (ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE))
 
-#define M_FE_DEGREE_SLP_HOST_2(z, fe_degree, TUPLE_4) \
-  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_4)<BOOST_PP_TUPLE_ELEM(1, TUPLE_4),\
-  BOOST_PP_TUPLE_ELEM(2, TUPLE_4), BOOST_PP_TUPLE_ELEM(3, TUPLE_4),\
-  fe_degree, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>;
-#define M_P_ORDER_SLP_HOST_2(z, p_order, TUPLE_3) \
-  BOOST_PP_REPEAT_FROM_TO(1, 6, M_FE_DEGREE_SLP_HOST_2, BOOST_PP_TUPLE_REPLACE(TUPLE_3, 3, p_order))
-#define M_USE_TABLE_SLP_HOST_2(z, TUPLE_2, use_table) \
-  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_SLP_HOST_2, BOOST_PP_TUPLE_REPLACE(TUPLE_2, 2, use_table))
-#define M_DIM_SLP_HOST_2(z, dim, TUPLE_1) \
-  BOOST_PP_SEQ_FOR_EACH(M_USE_TABLE_SLP_HOST_2, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 1, dim), USE_TABLE)
-#define INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SLP_HOST(TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_SLP_HOST_2, TUPLE_0)
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - use_table = true or false
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = SolidLiquidPowder
+//   - memory_space = Host
+#define ADAMANTINE_D_U_P_F_SLP_HOST(z, SEQ) \
+  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
+  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),\
+  adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>;
+#define INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SLP_HOST(NAME) \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_U_P_F_SLP_HOST,\
+                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_USE_TABLE)\
+                                (ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE))
 
-#define M_FE_DEGREE_S_DEVICE_2(z, fe_degree, TUPLE_4) \
-  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_4)<BOOST_PP_TUPLE_ELEM(1, TUPLE_4),\
-  BOOST_PP_TUPLE_ELEM(2, TUPLE_4), BOOST_PP_TUPLE_ELEM(3, TUPLE_4),\
-  fe_degree, adamantine::Solid, dealii::MemorySpace::Default>;
-#define M_P_ORDER_S_DEVICE_2(z, p_order, TUPLE_3) \
-  BOOST_PP_REPEAT_FROM_TO(1, 6, M_FE_DEGREE_S_DEVICE_2, BOOST_PP_TUPLE_REPLACE(TUPLE_3, 3, p_order))
-#define M_USE_TABLE_S_DEVICE_2(z, TUPLE_2, use_table) \
-  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_S_DEVICE_2, BOOST_PP_TUPLE_REPLACE(TUPLE_2, 2, use_table))
-#define M_DIM_S_DEVICE_2(z, dim, TUPLE_1) \
-  BOOST_PP_SEQ_FOR_EACH(M_USE_TABLE_S_DEVICE_2, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 1, dim), USE_TABLE)
-#define INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_S_DEVICE(TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_S_DEVICE_2, TUPLE_0)
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - use_table = true or false
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = Solid
+//   - memory_space = Default
+#define ADAMANTINE_D_U_P_F_S_DEV(z, SEQ) \
+  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
+  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),\
+  adamantine::Solid, dealii::MemorySpace::Default>;
+#define INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_S_DEVICE(NAME) \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_U_P_F_S_DEV,\
+                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_USE_TABLE)\
+                                (ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE))
 
-#define M_FE_DEGREE_SL_DEVICE_2(z, fe_degree, TUPLE_4) \
-  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_4)<BOOST_PP_TUPLE_ELEM(1, TUPLE_4),\
-  BOOST_PP_TUPLE_ELEM(2, TUPLE_4), BOOST_PP_TUPLE_ELEM(3, TUPLE_4),\
-  fe_degree, adamantine::SolidLiquid, dealii::MemorySpace::Default>;
-#define M_P_ORDER_SL_DEVICE_2(z, p_order, TUPLE_3) \
-  BOOST_PP_REPEAT_FROM_TO(1, 6, M_FE_DEGREE_SL_DEVICE_2, BOOST_PP_TUPLE_REPLACE(TUPLE_3, 3, p_order))
-#define M_USE_TABLE_SL_DEVICE_2(z, TUPLE_2, use_table) \
-  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_SL_DEVICE_2, BOOST_PP_TUPLE_REPLACE(TUPLE_2, 2, use_table))
-#define M_DIM_SL_DEVICE_2(z, dim, TUPLE_1) \
-  BOOST_PP_SEQ_FOR_EACH(M_USE_TABLE_SL_DEVICE_2, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 1, dim), USE_TABLE)
-#define INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SL_DEVICE(TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_SL_DEVICE_2, TUPLE_0)
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - use_table = true or false
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = SolidLiquid
+//   - memory_space = Default
+#define ADAMANTINE_D_U_P_F_SL_DEV(z, SEQ) \
+  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
+  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),\
+  adamantine::SolidLiquid, dealii::MemorySpace::Default>;
+#define INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SL_DEVICE(NAME) \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_U_P_F_SL_DEV,\
+                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_USE_TABLE)\
+                                (ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE))
 
-#define M_FE_DEGREE_SLP_DEVICE_2(z, fe_degree, TUPLE_4) \
-  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_4)<BOOST_PP_TUPLE_ELEM(1, TUPLE_4),\
-  BOOST_PP_TUPLE_ELEM(2, TUPLE_4), BOOST_PP_TUPLE_ELEM(3, TUPLE_4),\
-  fe_degree, adamantine::SolidLiquidPowder, dealii::MemorySpace::Default>;
-#define M_P_ORDER_SLP_DEVICE_2(z, p_order, TUPLE_3) \
-  BOOST_PP_REPEAT_FROM_TO(1, 6, M_FE_DEGREE_SLP_DEVICE_2, BOOST_PP_TUPLE_REPLACE(TUPLE_3, 3, p_order))
-#define M_USE_TABLE_SLP_DEVICE_2(z, TUPLE_2, use_table) \
-  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_SLP_DEVICE_2, BOOST_PP_TUPLE_REPLACE(TUPLE_2, 2, use_table))
-#define M_DIM_SLP_DEVICE_2(z, dim, TUPLE_1) \
-  BOOST_PP_SEQ_FOR_EACH(M_USE_TABLE_SLP_DEVICE_2, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 1, dim), USE_TABLE)
-#define INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SLP_DEVICE(TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_SLP_DEVICE_2, TUPLE_0)
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - use_table = true or false
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = SolidLiquidPowder
+//   - memory_space = Default
+#define ADAMANTINE_D_U_P_F_SLP_DEV(z, SEQ) \
+  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
+  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),\
+  adamantine::SolidLiquidPowder, dealii::MemorySpace::Default>;
+#define INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SLP_DEVICE(NAME) \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_U_P_F_SLP_DEV,\
+                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_USE_TABLE)\
+                                (ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE))
 
 // Instantiation of the class for:
 //   - dim = 2 and 3
 //   - p_order = 0 to 4
 //   - fe_degree = 1 to 5
-//   - material_state = Solid, SolidLiquid, and SolidLiquidPowder
+//   - material_state = Solid
+//   - memory_space = Host
 //   - QuadratureType = dealii::QGauss<1> and dealii::QGaussLobatto<1>
-#define M_QUADRATURE_TYPE_S_HOST_3(z, TUPLE_3, quadrature)\
-  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_3)<BOOST_PP_TUPLE_ELEM(1, TUPLE_3),\
-  BOOST_PP_TUPLE_ELEM(2, TUPLE_3), BOOST_PP_TUPLE_ELEM(3, TUPLE_3), \
-  adamantine::Solid, dealii::MemorySpace::Host, quadrature>;
-#define M_FE_DEGREE_S_HOST_3(z, fe_degree, TUPLE_2) \
-  BOOST_PP_SEQ_FOR_EACH(M_QUADRATURE_TYPE_S_HOST_3, \
-                        BOOST_PP_TUPLE_REPLACE(TUPLE_2, 3, fe_degree), QUADRATURE_TYPE)
-#define M_P_ORDER_S_HOST_3(z, p_order, TUPLE_1) \
-  BOOST_PP_REPEAT_FROM_TO(1, 6, M_FE_DEGREE_S_HOST_3, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 2, p_order))
-#define M_DIM_S_HOST_3(z, dim, TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_S_HOST_3, BOOST_PP_TUPLE_REPLACE(TUPLE_0, 1, dim))
-#define INSTANTIATE_DIM_PORDER_FEDEGREE_S_QUAD_HOST(TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_S_HOST_3, TUPLE_0)
+#define ADAMANTINE_D_P_F_S_Q_HOST(z, SEQ) \
+  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
+  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), adamantine::Solid,\
+  dealii::MemorySpace::Host, BOOST_PP_SEQ_ELEM(4, SEQ)>;
+#define INSTANTIATE_DIM_PORDER_FEDEGREE_S_QUAD_HOST(NAME) \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_P_F_S_Q_HOST,\
+                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_P_ORDER)\
+                                (ADAMANTINE_FE_DEGREE)(ADAMANTINE_QUADRATURE_TYPE))
 
-#define M_QUADRATURE_TYPE_SL_HOST_3(z, TUPLE_3, quadrature)\
-  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_3)<BOOST_PP_TUPLE_ELEM(1, TUPLE_3),\
-  BOOST_PP_TUPLE_ELEM(2, TUPLE_3), BOOST_PP_TUPLE_ELEM(3, TUPLE_3), \
-  adamantine::SolidLiquid, dealii::MemorySpace::Host, quadrature>;
-#define M_FE_DEGREE_SL_HOST_3(z, fe_degree, TUPLE_2) \
-  BOOST_PP_SEQ_FOR_EACH(M_QUADRATURE_TYPE_SL_HOST_3, \
-                        BOOST_PP_TUPLE_REPLACE(TUPLE_2, 3, fe_degree), QUADRATURE_TYPE)
-#define M_P_ORDER_SL_HOST_3(z, p_order, TUPLE_1) \
-  BOOST_PP_REPEAT_FROM_TO(1, 6, M_FE_DEGREE_SL_HOST_3, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 2, p_order))
-#define M_DIM_SL_HOST_3(z, dim, TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_SL_HOST_3, BOOST_PP_TUPLE_REPLACE(TUPLE_0, 1, dim))
-#define INSTANTIATE_DIM_PORDER_FEDEGREE_SL_QUAD_HOST(TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_SL_HOST_3, TUPLE_0)
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = SolidLiquid
+//   - memory_space = Host
+//   - QuadratureType = dealii::QGauss<1> and dealii::QGaussLobatto<1>
+#define ADAMANTINE_D_P_F_SL_Q_HOST(z, SEQ) \
+  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
+  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), adamantine::SolidLiquid,\
+  dealii::MemorySpace::Host, BOOST_PP_SEQ_ELEM(4, SEQ)>;
+#define INSTANTIATE_DIM_PORDER_FEDEGREE_SL_QUAD_HOST(NAME) \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_P_F_SL_Q_HOST,\
+                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_P_ORDER)\
+                                (ADAMANTINE_FE_DEGREE)(ADAMANTINE_QUADRATURE_TYPE))
 
-#define M_QUADRATURE_TYPE_SLP_HOST_3(z, TUPLE_3, quadrature)\
-  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_3)<BOOST_PP_TUPLE_ELEM(1, TUPLE_3),\
-  BOOST_PP_TUPLE_ELEM(2, TUPLE_3), BOOST_PP_TUPLE_ELEM(3, TUPLE_3), \
-  adamantine::SolidLiquidPowder, dealii::MemorySpace::Host, quadrature>;
-#define M_FE_DEGREE_SLP_HOST_3(z, fe_degree, TUPLE_2) \
-  BOOST_PP_SEQ_FOR_EACH(M_QUADRATURE_TYPE_SLP_HOST_3, \
-                        BOOST_PP_TUPLE_REPLACE(TUPLE_2, 3, fe_degree), QUADRATURE_TYPE)
-#define M_P_ORDER_SLP_HOST_3(z, p_order, TUPLE_1) \
-  BOOST_PP_REPEAT_FROM_TO(1, 6, M_FE_DEGREE_SLP_HOST_3, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 2, p_order))
-#define M_DIM_SLP_HOST_3(z, dim, TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_SLP_HOST_3, BOOST_PP_TUPLE_REPLACE(TUPLE_0, 1, dim))
-#define INSTANTIATE_DIM_PORDER_FEDEGREE_SLP_QUAD_HOST(TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_SLP_HOST_3, TUPLE_0)
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = SolidLiquidPowder
+//   - memory_space = Host
+//   - QuadratureType = dealii::QGauss<1> and dealii::QGaussLobatto<1>
+#define ADAMANTINE_D_P_F_SLP_Q_HOST(z, SEQ) \
+  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
+  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), adamantine::SolidLiquidPowder,\
+  dealii::MemorySpace::Host, BOOST_PP_SEQ_ELEM(4, SEQ)>;
+#define INSTANTIATE_DIM_PORDER_FEDEGREE_SLP_QUAD_HOST(NAME) \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_P_F_SLP_Q_HOST,\
+                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_P_ORDER)\
+                                (ADAMANTINE_FE_DEGREE)(ADAMANTINE_QUADRATURE_TYPE))
 
-#define M_QUADRATURE_TYPE_S_DEVICE_3(z, TUPLE_3, quadrature)\
-  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_3)<BOOST_PP_TUPLE_ELEM(1, TUPLE_3),\
-  BOOST_PP_TUPLE_ELEM(2, TUPLE_3), BOOST_PP_TUPLE_ELEM(3, TUPLE_3), \
-  adamantine::Solid, dealii::MemorySpace::Default, quadrature>;
-#define M_FE_DEGREE_S_DEVICE_3(z, fe_degree, TUPLE_2) \
-  BOOST_PP_SEQ_FOR_EACH(M_QUADRATURE_TYPE_S_DEVICE_3, \
-                        BOOST_PP_TUPLE_REPLACE(TUPLE_2, 3, fe_degree), QUADRATURE_TYPE)
-#define M_P_ORDER_S_DEVICE_3(z, p_order, TUPLE_1) \
-  BOOST_PP_REPEAT_FROM_TO(1, 6, M_FE_DEGREE_S_DEVICE_3, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 2, p_order))
-#define M_DIM_S_DEVICE_3(z, dim, TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_S_DEVICE_3, BOOST_PP_TUPLE_REPLACE(TUPLE_0, 1, dim))
-#define INSTANTIATE_DIM_PORDER_FEDEGREE_S_QUAD_DEVICE(TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_S_DEVICE_3, TUPLE_0)
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = Solid
+//   - memory_space = Default
+//   - QuadratureType = dealii::QGauss<1> and dealii::QGaussLobatto<1>
+#define ADAMANTINE_D_P_F_S_Q_DEV(z, SEQ) \
+  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
+  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), adamantine::Solid,\
+  dealii::MemorySpace::Default, BOOST_PP_SEQ_ELEM(4, SEQ)>;
+#define INSTANTIATE_DIM_PORDER_FEDEGREE_S_QUAD_DEVICE(NAME) \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_P_F_S_Q_DEV,\
+                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_P_ORDER)\
+                                (ADAMANTINE_FE_DEGREE)(ADAMANTINE_QUADRATURE_TYPE))
 
-#define M_QUADRATURE_TYPE_SL_DEVICE_3(z, TUPLE_3, quadrature)\
-  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_3)<BOOST_PP_TUPLE_ELEM(1, TUPLE_3),\
-  BOOST_PP_TUPLE_ELEM(2, TUPLE_3), BOOST_PP_TUPLE_ELEM(3, TUPLE_3), \
-  adamantine::SolidLiquid, dealii::MemorySpace::Default, quadrature>;
-#define M_FE_DEGREE_SL_DEVICE_3(z, fe_degree, TUPLE_2) \
-  BOOST_PP_SEQ_FOR_EACH(M_QUADRATURE_TYPE_SL_DEVICE_3, \
-                        BOOST_PP_TUPLE_REPLACE(TUPLE_2, 3, fe_degree), QUADRATURE_TYPE)
-#define M_P_ORDER_SL_DEVICE_3(z, p_order, TUPLE_1) \
-  BOOST_PP_REPEAT_FROM_TO(1, 6, M_FE_DEGREE_SL_DEVICE_3, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 2, p_order))
-#define M_DIM_SL_DEVICE_3(z, dim, TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_SL_DEVICE_3, BOOST_PP_TUPLE_REPLACE(TUPLE_0, 1, dim))
-#define INSTANTIATE_DIM_PORDER_FEDEGREE_SL_QUAD_DEVICE(TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_SL_DEVICE_3, TUPLE_0)
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = SolidLiquid
+//   - memory_space = Default
+//   - QuadratureType = dealii::QGauss<1> and dealii::QGaussLobatto<1>
+#define ADAMANTINE_D_P_F_SL_Q_DEV(z, SEQ) \
+  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
+  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), adamantine::SolidLiquid,\
+  dealii::MemorySpace::Default, BOOST_PP_SEQ_ELEM(4, SEQ)>;
+#define INSTANTIATE_DIM_PORDER_FEDEGREE_SL_QUAD_DEVICE(NAME) \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_P_F_SL_Q_DEV,\
+                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_P_ORDER)\
+                                (ADAMANTINE_FE_DEGREE)(ADAMANTINE_QUADRATURE_TYPE))
 
-#define M_QUADRATURE_TYPE_SLP_DEVICE_3(z, TUPLE_3, quadrature)\
-  template class adamantine::BOOST_PP_TUPLE_ELEM(0, TUPLE_3)<BOOST_PP_TUPLE_ELEM(1, TUPLE_3),\
-  BOOST_PP_TUPLE_ELEM(2, TUPLE_3), BOOST_PP_TUPLE_ELEM(3, TUPLE_3), \
-  adamantine::SolidLiquidPowder, dealii::MemorySpace::Default, quadrature>;
-#define M_FE_DEGREE_SLP_DEVICE_3(z, fe_degree, TUPLE_2) \
-  BOOST_PP_SEQ_FOR_EACH(M_QUADRATURE_TYPE_SLP_DEVICE_3, \
-                        BOOST_PP_TUPLE_REPLACE(TUPLE_2, 3, fe_degree), QUADRATURE_TYPE)
-#define M_P_ORDER_SLP_DEVICE_3(z, p_order, TUPLE_1) \
-  BOOST_PP_REPEAT_FROM_TO(1, 6, M_FE_DEGREE_SLP_DEVICE_3, BOOST_PP_TUPLE_REPLACE(TUPLE_1, 2, p_order))
-#define M_DIM_SLP_DEVICE_3(z, dim, TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(0, 5, M_P_ORDER_SLP_DEVICE_3, BOOST_PP_TUPLE_REPLACE(TUPLE_0, 1, dim))
-#define INSTANTIATE_DIM_PORDER_FEDEGREE_SLP_QUAD_DEVICE(TUPLE_0) \
-  BOOST_PP_REPEAT_FROM_TO(2, 4, M_DIM_SLP_DEVICE_3, TUPLE_0)
-
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = SolidLiquidPowder
+//   - memory_space = Default
+//   - QuadratureType = dealii::QGauss<1> and dealii::QGaussLobatto<1>
+#define ADAMANTINE_D_P_F_SLP_Q_DEV(z, SEQ) \
+  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
+  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), adamantine::SolidLiquidPowder,\
+  dealii::MemorySpace::Default, BOOST_PP_SEQ_ELEM(4, SEQ)>;
+#define INSTANTIATE_DIM_PORDER_FEDEGREE_SLP_QUAD_DEVICE(NAME) \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_P_F_SLP_Q_DEV,\
+                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_P_ORDER)\
+                                (ADAMANTINE_FE_DEGREE)(ADAMANTINE_QUADRATURE_TYPE))
 // clang-format on


### PR DESCRIPTION
This PR reworks the instantiation macros. Instead of creating nested loops, we can use `BOOST_PP_SEQ_FOR_EACH_PRODUCT` which repeats a macro for each cartesian product of several seqs.