### PR TITLE
 Use new data structure for material dependent Views

### DIFF
--- a/source/BodyForce.cc
+++ b/source/BodyForce.cc
@@ -8,19 +8,19 @@
 
 namespace adamantine
 {
-template <int dim, int p_order, typename MaterialStates,
+template <int dim, int n_materials, int p_order, typename MaterialStates,
           typename MemorySpaceType>
-GravityForce<dim, p_order, MaterialStates, MemorySpaceType>::GravityForce(
-    MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType>
-        &material_properties)
+GravityForce<dim, n_materials, p_order, MaterialStates, MemorySpaceType>::
+    GravityForce(MaterialProperty<dim, n_materials, p_order, MaterialStates,
+                                  MemorySpaceType> &material_properties)
     : _material_properties(material_properties)
 {
 }
 
-template <int dim, int p_order, typename MaterialStates,
+template <int dim, int n_materials, int p_order, typename MaterialStates,
           typename MemorySpaceType>
 dealii::Tensor<1, dim, double>
-GravityForce<dim, p_order, MaterialStates, MemorySpaceType>::eval(
+GravityForce<dim, n_materials, p_order, MaterialStates, MemorySpaceType>::eval(
     typename dealii::Triangulation<dim>::active_cell_iterator const &cell)
 {
   // Note that the density is independent of the temperature
@@ -33,5 +33,5 @@ GravityForce<dim, p_order, MaterialStates, MemorySpaceType>::eval(
 }
 } // namespace adamantine
 
-INSTANTIATE_DIM_PORDER_MATERIALSTATES_HOST(GravityForce)
-INSTANTIATE_DIM_PORDER_MATERIALSTATES_DEVICE(GravityForce)
+INSTANTIATE_DIM_NMAT_PORDER_MATERIALSTATES_HOST(GravityForce)
+INSTANTIATE_DIM_NMAT_PORDER_MATERIALSTATES_DEVICE(GravityForce)

--- a/source/BodyForce.hh
+++ b/source/BodyForce.hh
@@ -1,4 +1,4 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2023 - 2024, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2023 - 2025, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -26,20 +26,20 @@ struct BodyForce
 };
 
 // Forward declaration
-template <int dim, int p_order, typename MaterialStates,
+template <int dim, int n_materials, int p_order, typename MaterialStates,
           typename MemorySpaceType>
 class MaterialProperty;
 
 /**
  * Gravity's body force.
  */
-template <int dim, int p_order, typename MaterialStates,
+template <int dim, int n_materials, int p_order, typename MaterialStates,
           typename MemorySpaceType>
 class GravityForce final : public BodyForce<dim>
 {
 public:
-  GravityForce(MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType>
-                   &material_properties);
+  GravityForce(MaterialProperty<dim, n_materials, p_order, MaterialStates,
+                                MemorySpaceType> &material_properties);
 
   dealii::Tensor<1, dim, double>
   eval(typename dealii::Triangulation<dim>::active_cell_iterator const &cell)
@@ -50,7 +50,7 @@ private:
    * Gravity in \f$m/s^2\f$
    */
   static double constexpr g = 9.80665;
-  MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType>
+  MaterialProperty<dim, n_materials, p_order, MaterialStates, MemorySpaceType>
       &_material_properties;
 };
 } // namespace adamantine

--- a/source/MaterialPropertyInstDev.cc
+++ b/source/MaterialPropertyInstDev.cc
@@ -5,4 +5,4 @@
 #include <MaterialProperty.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_PORDER_MATERIALSTATES_DEVICE(MaterialProperty)
+INSTANTIATE_DIM_NMAT_PORDER_MATERIALSTATES_DEVICE(MaterialProperty)

--- a/source/MaterialPropertyInstHost.cc
+++ b/source/MaterialPropertyInstHost.cc
@@ -5,4 +5,4 @@
 #include <MaterialProperty.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_PORDER_MATERIALSTATES_HOST(MaterialProperty)
+INSTANTIATE_DIM_NMAT_PORDER_MATERIALSTATES_HOST(MaterialProperty)

--- a/source/MechanicalOperator.cc
+++ b/source/MechanicalOperator.cc
@@ -27,26 +27,28 @@
 
 namespace adamantine
 {
-template <int dim, int p_order, typename MaterialStates,
+template <int dim, int n_materials, int p_order, typename MaterialStates,
           typename MemorySpaceType>
-MechanicalOperator<dim, p_order, MaterialStates, MemorySpaceType>::
-    MechanicalOperator(MPI_Comm const &communicator,
-                       MaterialProperty<dim, p_order, MaterialStates,
-                                        MemorySpaceType> &material_properties,
-                       std::vector<double> const &reference_temperatures)
+MechanicalOperator<dim, n_materials, p_order, MaterialStates, MemorySpaceType>::
+    MechanicalOperator(
+        MPI_Comm const &communicator,
+        MaterialProperty<dim, n_materials, p_order, MaterialStates,
+                         MemorySpaceType> &material_properties,
+        std::vector<double> const &reference_temperatures)
     : _communicator(communicator),
       _reference_temperatures(reference_temperatures),
       _material_properties(material_properties)
 {
 }
 
-template <int dim, int p_order, typename MaterialStates,
+template <int dim, int n_materials, int p_order, typename MaterialStates,
           typename MemorySpaceType>
-void MechanicalOperator<dim, p_order, MaterialStates, MemorySpaceType>::reinit(
-    dealii::DoFHandler<dim> const &dof_handler,
-    dealii::AffineConstraints<double> const &affine_constraints,
-    dealii::hp::QCollection<dim> const &q_collection,
-    std::vector<std::shared_ptr<BodyForce<dim>>> const &body_forces)
+void MechanicalOperator<dim, n_materials, p_order, MaterialStates,
+                        MemorySpaceType>::
+    reinit(dealii::DoFHandler<dim> const &dof_handler,
+           dealii::AffineConstraints<double> const &affine_constraints,
+           dealii::hp::QCollection<dim> const &q_collection,
+           std::vector<std::shared_ptr<BodyForce<dim>>> const &body_forces)
 {
   _dof_handler = &dof_handler;
   _affine_constraints = &affine_constraints;
@@ -54,9 +56,10 @@ void MechanicalOperator<dim, p_order, MaterialStates, MemorySpaceType>::reinit(
   assemble_system(body_forces);
 }
 
-template <int dim, int p_order, typename MaterialStates,
+template <int dim, int n_materials, int p_order, typename MaterialStates,
           typename MemorySpaceType>
-void MechanicalOperator<dim, p_order, MaterialStates, MemorySpaceType>::
+void MechanicalOperator<dim, n_materials, p_order, MaterialStates,
+                        MemorySpaceType>::
     update_temperature(
         dealii::DoFHandler<dim> const &thermal_dof_handler,
         dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> const
@@ -68,9 +71,10 @@ void MechanicalOperator<dim, p_order, MaterialStates, MemorySpaceType>::
   _has_melted = has_melted;
 }
 
-template <int dim, int p_order, typename MaterialStates,
+template <int dim, int n_materials, int p_order, typename MaterialStates,
           typename MemorySpaceType>
-void MechanicalOperator<dim, p_order, MaterialStates, MemorySpaceType>::
+void MechanicalOperator<dim, n_materials, p_order, MaterialStates,
+                        MemorySpaceType>::
     assemble_system(
         std::vector<std::shared_ptr<BodyForce<dim>>> const &body_forces)
 {
@@ -305,5 +309,5 @@ void MechanicalOperator<dim, p_order, MaterialStates, MemorySpaceType>::
 }
 } // namespace adamantine
 
-INSTANTIATE_DIM_PORDER_MATERIALSTATES_HOST(MechanicalOperator)
-INSTANTIATE_DIM_PORDER_MATERIALSTATES_DEVICE(MechanicalOperator)
+INSTANTIATE_DIM_NMAT_PORDER_MATERIALSTATES_HOST(MechanicalOperator)
+INSTANTIATE_DIM_NMAT_PORDER_MATERIALSTATES_DEVICE(MechanicalOperator)

--- a/source/MechanicalOperator.hh
+++ b/source/MechanicalOperator.hh
@@ -25,7 +25,7 @@ namespace adamantine
  * The class is templated on the MemorySpace because it use MaterialProperty
  * which itself is templated on the MemorySpace but the operator is CPU only.
  */
-template <int dim, int p_order, typename MaterialStates,
+template <int dim, int n_materials, int p_order, typename MaterialStates,
           typename MemorySpaceType>
 class MechanicalOperator
 {
@@ -35,7 +35,7 @@ public:
    * mechanical only. Otherwise, we solve a thermo-mechanical problem.
    */
   MechanicalOperator(MPI_Comm const &communicator,
-                     MaterialProperty<dim, p_order, MaterialStates,
+                     MaterialProperty<dim, n_materials, p_order, MaterialStates,
                                       MemorySpaceType> &material_properties,
                      std::vector<double> const &reference_temperatures);
 
@@ -80,7 +80,7 @@ private:
   /**
    * Reference to the MaterialProperty from MechanicalPhysics.
    */
-  MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType>
+  MaterialProperty<dim, n_materials, p_order, MaterialStates, MemorySpaceType>
       &_material_properties;
   /**
    * Non-owning pointer to the DoFHandler from MechanicalPhysics
@@ -120,19 +120,20 @@ private:
   std::vector<bool> _has_melted;
 };
 
-template <int dim, int p_order, typename MaterialStates,
+template <int dim, int n_materials, int p_order, typename MaterialStates,
           typename MemorySpaceType>
 inline dealii::LA::distributed::Vector<double,
                                        dealii::MemorySpace::Host> const &
-MechanicalOperator<dim, p_order, MaterialStates, MemorySpaceType>::rhs() const
+MechanicalOperator<dim, n_materials, p_order, MaterialStates,
+                   MemorySpaceType>::rhs() const
 {
   return _system_rhs;
 }
 
-template <int dim, int p_order, typename MaterialStates,
+template <int dim, int n_materials, int p_order, typename MaterialStates,
           typename MemorySpaceType>
 inline dealii::TrilinosWrappers::SparseMatrix const &
-MechanicalOperator<dim, p_order, MaterialStates,
+MechanicalOperator<dim, n_materials, p_order, MaterialStates,
                    MemorySpaceType>::system_matrix() const
 {
   return _system_matrix;

--- a/source/MechanicalPhysics.hh
+++ b/source/MechanicalPhysics.hh
@@ -18,7 +18,7 @@
 
 namespace adamantine
 {
-template <int dim, int p_order, typename MaterialStates,
+template <int dim, int n_materials, int p_order, typename MaterialStates,
           typename MemorySpaceType>
 class MechanicalPhysics
 {
@@ -28,7 +28,7 @@ public:
    */
   MechanicalPhysics(MPI_Comm const &communicator, unsigned int const fe_degree,
                     Geometry<dim> &geometry, Boundary const &boundary,
-                    MaterialProperty<dim, p_order, MaterialStates,
+                    MaterialProperty<dim, n_materials, p_order, MaterialStates,
                                      MemorySpaceType> &material_properties,
                     std::vector<double> const &initial_temperatures);
 
@@ -103,7 +103,7 @@ private:
   /**
    * Associated MaterialProperty.
    */
-  MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType>
+  MaterialProperty<dim, n_materials, p_order, MaterialStates, MemorySpaceType>
       &_material_properties;
   /**
    * Associated FECollection.
@@ -124,8 +124,8 @@ private:
   /**
    * Pointer to the MechanicalOperator
    */
-  std::unique_ptr<
-      MechanicalOperator<dim, p_order, MaterialStates, MemorySpaceType>>
+  std::unique_ptr<MechanicalOperator<dim, n_materials, p_order, MaterialStates,
+                                     MemorySpaceType>>
       _mechanical_operator;
   /**
    * Whether to include a gravitional body force in the calculation.
@@ -176,28 +176,28 @@ private:
   std::vector<std::vector<double>> _data_to_transfer;
 };
 
-template <int dim, int p_order, typename MaterialStates,
+template <int dim, int n_materials, int p_order, typename MaterialStates,
           typename MemorySpaceType>
 inline dealii::DoFHandler<dim> &
-MechanicalPhysics<dim, p_order, MaterialStates,
+MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
                   MemorySpaceType>::get_dof_handler()
 {
   return _dof_handler;
 }
 
-template <int dim, int p_order, typename MaterialStates,
+template <int dim, int n_materials, int p_order, typename MaterialStates,
           typename MemorySpaceType>
 inline dealii::AffineConstraints<double> &
-MechanicalPhysics<dim, p_order, MaterialStates,
+MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
                   MemorySpaceType>::get_affine_constraints()
 {
   return _affine_constraints;
 }
 
-template <int dim, int p_order, typename MaterialStates,
+template <int dim, int n_materials, int p_order, typename MaterialStates,
           typename MemorySpaceType>
 inline std::vector<std::vector<dealii::SymmetricTensor<2, dim>>> &
-MechanicalPhysics<dim, p_order, MaterialStates,
+MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
                   MemorySpaceType>::get_stress_tensor()
 {
   return _stress;

--- a/source/Microstructure.hh
+++ b/source/Microstructure.hh
@@ -51,10 +51,11 @@ public:
    * - Cooling Rate (K/s) = |dT/dt|
    * - Interface Velocity: R (m/s) = cooling rate / G
    */
-  template <int p_order, typename MaterialStates, typename MemorySpaceType>
+  template <int n_materials, int p_order, typename MaterialStates,
+            typename MemorySpaceType>
   void compute_G_and_R(
-      MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType> const
-          &material_properties,
+      MaterialProperty<dim, n_materials, p_order, MaterialStates,
+                       MemorySpaceType> const &material_properties,
       dealii::DoFHandler<dim> const &dof_handler,
       dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> const
           &temperature,
@@ -81,10 +82,11 @@ private:
 };
 
 template <int dim>
-template <int p_order, typename MaterialStates, typename MemorySpaceType>
+template <int n_materials, int p_order, typename MaterialStates,
+          typename MemorySpaceType>
 void Microstructure<dim>::compute_G_and_R(
-    MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType> const
-        &material_properties,
+    MaterialProperty<dim, n_materials, p_order, MaterialStates,
+                     MemorySpaceType> const &material_properties,
     dealii::DoFHandler<dim> const &dof_handler,
     dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> const
         &temperature,

--- a/source/ThermalOperator.hh
+++ b/source/ThermalOperator.hh
@@ -21,15 +21,15 @@ namespace adamantine
  * This class is the operator associated with the heat equation, i.e., vmult
  * performs \f$ dst = -\nabla k \nabla src \f$.
  */
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
 class ThermalOperator final : public ThermalOperatorBase<dim, MemorySpaceType>
 {
 public:
   ThermalOperator(
       MPI_Comm const &communicator, Boundary const &boundary,
-      MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType>
-          &material_properties,
+      MaterialProperty<dim, n_materials, p_order, MaterialStates,
+                       MemorySpaceType> &material_properties,
       std::vector<std::shared_ptr<HeatSource<dim>>> const &heat_sources);
 
   /**
@@ -181,7 +181,7 @@ private:
   /**
    * Material properties associated with the domain.
    */
-  MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType>
+  MaterialProperty<dim, n_materials, p_order, MaterialStates, MemorySpaceType>
       &_material_properties;
   /**
    * Vector of heat sources.
@@ -247,56 +247,56 @@ private:
   dealii::Table<2, dealii::VectorizedArray<double>> _deposition_sin;
 };
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
 inline dealii::types::global_dof_index
-ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
+ThermalOperator<dim, n_materials, use_table, p_order, fe_degree, MaterialStates,
                 MemorySpaceType>::m() const
 {
   return _matrix_free.get_vector_partitioner()->size();
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
 inline dealii::types::global_dof_index
-ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
+ThermalOperator<dim, n_materials, use_table, p_order, fe_degree, MaterialStates,
                 MemorySpaceType>::n() const
 {
   return _matrix_free.get_vector_partitioner()->size();
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
 inline std::shared_ptr<dealii::LA::distributed::Vector<double, MemorySpaceType>>
-ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
+ThermalOperator<dim, n_materials, use_table, p_order, fe_degree, MaterialStates,
                 MemorySpaceType>::get_inverse_mass_matrix() const
 {
   return _inverse_mass_matrix;
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
 inline dealii::MatrixFree<dim, double> const &
-ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
+ThermalOperator<dim, n_materials, use_table, p_order, fe_degree, MaterialStates,
                 MemorySpaceType>::get_matrix_free() const
 {
   return _matrix_free;
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
-inline void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
-                            MemorySpaceType>::
+inline void ThermalOperator<dim, n_materials, use_table, p_order, fe_degree,
+                            MaterialStates, MemorySpaceType>::
     initialize_dof_vector(
         dealii::LA::distributed::Vector<double, MemorySpaceType> &vector) const
 {
   _matrix_free.initialize_dof_vector(vector);
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
 inline void
-ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
+ThermalOperator<dim, n_materials, use_table, p_order, fe_degree, MaterialStates,
                 MemorySpaceType>::set_time_and_source_height(double t,
                                                              double height)
 {

--- a/source/ThermalOperator.templates.hh
+++ b/source/ThermalOperator.templates.hh
@@ -23,14 +23,14 @@
 namespace adamantine
 {
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
-ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
+ThermalOperator<dim, n_materials, use_table, p_order, fe_degree, MaterialStates,
                 MemorySpaceType>::
     ThermalOperator(
         MPI_Comm const &communicator, Boundary const &boundary,
-        MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType>
-            &material_properties,
+        MaterialProperty<dim, n_materials, p_order, MaterialStates,
+                         MemorySpaceType> &material_properties,
         std::vector<std::shared_ptr<HeatSource<dim>>> const &heat_sources)
     : _communicator(communicator), _boundary(boundary),
       _material_properties(material_properties), _heat_sources(heat_sources),
@@ -52,10 +52,10 @@ ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
       dealii::update_values | dealii::update_JxW_values;
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
-void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
-                     MemorySpaceType>::
+void ThermalOperator<dim, n_materials, use_table, p_order, fe_degree,
+                     MaterialStates, MemorySpaceType>::
     reinit(dealii::DoFHandler<dim> const &dof_handler,
            dealii::AffineConstraints<double> const &affine_constraints,
            dealii::hp::QCollection<1> const &q_collection)
@@ -77,10 +77,10 @@ void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
     }
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
-void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
-                     MemorySpaceType>::
+void ThermalOperator<dim, n_materials, use_table, p_order, fe_degree,
+                     MaterialStates, MemorySpaceType>::
     cell_local_mass(
         dealii::MatrixFree<dim, double> const &data,
         dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
@@ -114,10 +114,10 @@ void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
   }
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
-void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
-                     MemorySpaceType>::
+void ThermalOperator<dim, n_materials, use_table, p_order, fe_degree,
+                     MaterialStates, MemorySpaceType>::
     compute_inverse_mass_matrix(
         dealii::DoFHandler<dim> const &dof_handler,
         dealii::AffineConstraints<double> const &affine_constraints)
@@ -162,20 +162,20 @@ void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
   }
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
-void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
-                     MemorySpaceType>::clear()
+void ThermalOperator<dim, n_materials, use_table, p_order, fe_degree,
+                     MaterialStates, MemorySpaceType>::clear()
 {
   _cell_it_to_mf_cell_map.clear();
   _matrix_free.clear();
   _inverse_mass_matrix->reinit(0);
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
-void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
-                     MemorySpaceType>::
+void ThermalOperator<dim, n_materials, use_table, p_order, fe_degree,
+                     MaterialStates, MemorySpaceType>::
     vmult(dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
           dealii::LA::distributed::Vector<double, MemorySpaceType> const &src)
         const
@@ -184,10 +184,10 @@ void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
   vmult_add(dst, src);
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
-void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
-                     MemorySpaceType>::
+void ThermalOperator<dim, n_materials, use_table, p_order, fe_degree,
+                     MaterialStates, MemorySpaceType>::
     vmult_add(dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
               dealii::LA::distributed::Vector<double, MemorySpaceType> const
                   &src) const
@@ -223,10 +223,10 @@ void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
     dst.local_element(dof) += scaling * src.local_element(dof);
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
-void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
-                     MemorySpaceType>::
+void ThermalOperator<dim, n_materials, use_table, p_order, fe_degree,
+                     MaterialStates, MemorySpaceType>::
     update_state_ratios(
         [[maybe_unused]] unsigned int cell, [[maybe_unused]] unsigned int q,
         [[maybe_unused]] dealii::VectorizedArray<double> temperature,
@@ -315,10 +315,10 @@ void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
   }
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
-void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
-                     MemorySpaceType>::
+void ThermalOperator<dim, n_materials, use_table, p_order, fe_degree,
+                     MaterialStates, MemorySpaceType>::
     update_face_state_ratios(
         [[maybe_unused]] unsigned int face, [[maybe_unused]] unsigned int q,
         [[maybe_unused]] dealii::VectorizedArray<double> temperature,
@@ -411,10 +411,10 @@ void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
   }
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
 dealii::VectorizedArray<double>
-ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
+ThermalOperator<dim, n_materials, use_table, p_order, fe_degree, MaterialStates,
                 MemorySpaceType>::
     get_inv_rho_cp(
         std::array<dealii::types::material_id,
@@ -475,10 +475,10 @@ ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
   return 1.0 / (density * specific_heat);
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
-void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
-                     MemorySpaceType>::
+void ThermalOperator<dim, n_materials, use_table, p_order, fe_degree,
+                     MaterialStates, MemorySpaceType>::
     cell_local_apply(
         dealii::MatrixFree<dim, double> const &data,
         dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
@@ -610,10 +610,10 @@ void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
   }
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
-void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
-                     MemorySpaceType>::
+void ThermalOperator<dim, n_materials, use_table, p_order, fe_degree,
+                     MaterialStates, MemorySpaceType>::
     face_local_apply(
         dealii::MatrixFree<dim, double> const &data,
         dealii::LA::distributed::Vector<double, MemorySpaceType> &dst,
@@ -744,9 +744,10 @@ void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
   }
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
-void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
+void ThermalOperator<dim, n_materials, use_table, p_order, fe_degree,
+                     MaterialStates,
                      MemorySpaceType>::get_state_from_material_properties()
 {
   unsigned int const n_cells = _matrix_free.n_cell_batches();
@@ -876,9 +877,10 @@ void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
   }
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
-void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
+void ThermalOperator<dim, n_materials, use_table, p_order, fe_degree,
+                     MaterialStates,
                      MemorySpaceType>::set_state_to_material_properties()
 {
   _material_properties.set_state(_liquid_ratio, _powder_ratio,
@@ -886,10 +888,10 @@ void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
                                  _matrix_free.get_dof_handler());
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
-void ThermalOperator<dim, use_table, p_order, fe_degree, MaterialStates,
-                     MemorySpaceType>::
+void ThermalOperator<dim, n_materials, use_table, p_order, fe_degree,
+                     MaterialStates, MemorySpaceType>::
     set_material_deposition_orientation(
         std::vector<double> const &deposition_cos,
         std::vector<double> const &deposition_sin)

--- a/source/ThermalOperatorDevice.hh
+++ b/source/ThermalOperatorDevice.hh
@@ -14,15 +14,16 @@
 
 namespace adamantine
 {
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
 class ThermalOperatorDevice final
     : public ThermalOperatorBase<dim, MemorySpaceType>
 {
 public:
-  ThermalOperatorDevice(MPI_Comm const &communicator, Boundary const &boundary,
-                        MaterialProperty<dim, p_order, MaterialStates,
-                                         MemorySpaceType> &material_properties);
+  ThermalOperatorDevice(
+      MPI_Comm const &communicator, Boundary const &boundary,
+      MaterialProperty<dim, n_materials, p_order, MaterialStates,
+                       MemorySpaceType> &material_properties);
 
   void reinit(dealii::DoFHandler<dim> const &dof_handler,
               dealii::AffineConstraints<double> const &affine_constraints,
@@ -108,7 +109,7 @@ private:
   /**
    * Material properties associated with the domain.
    */
-  MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType>
+  MaterialProperty<dim, n_materials, p_order, MaterialStates, MemorySpaceType>
       &_material_properties;
   dealii::CUDAWrappers::MatrixFree<dim, double> _matrix_free;
   Kokkos::View<double *, kokkos_default> _liquid_ratio;
@@ -126,47 +127,49 @@ private:
       _inv_rho_cp_cells;
 };
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
 inline dealii::types::global_dof_index
-ThermalOperatorDevice<dim, use_table, p_order, fe_degree, MaterialStates,
-                      MemorySpaceType>::m() const
+ThermalOperatorDevice<dim, n_materials, use_table, p_order, fe_degree,
+                      MaterialStates, MemorySpaceType>::m() const
 {
   return _m;
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
 inline dealii::types::global_dof_index
-ThermalOperatorDevice<dim, use_table, p_order, fe_degree, MaterialStates,
-                      MemorySpaceType>::n() const
+ThermalOperatorDevice<dim, n_materials, use_table, p_order, fe_degree,
+                      MaterialStates, MemorySpaceType>::n() const
 {
   // Operator must be square
   return _m;
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
 inline std::shared_ptr<dealii::LA::distributed::Vector<double, MemorySpaceType>>
-ThermalOperatorDevice<dim, use_table, p_order, fe_degree, MaterialStates,
+ThermalOperatorDevice<dim, n_materials, use_table, p_order, fe_degree,
+                      MaterialStates,
                       MemorySpaceType>::get_inverse_mass_matrix() const
 {
   return _inverse_mass_matrix;
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
 inline dealii::CUDAWrappers::MatrixFree<dim, double> const &
-ThermalOperatorDevice<dim, use_table, p_order, fe_degree, MaterialStates,
-                      MemorySpaceType>::get_matrix_free() const
+ThermalOperatorDevice<dim, n_materials, use_table, p_order, fe_degree,
+                      MaterialStates, MemorySpaceType>::get_matrix_free() const
 {
   return _matrix_free;
 }
 
-template <int dim, bool use_table, int p_order, int fe_degree,
+template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
-inline double ThermalOperatorDevice<dim, use_table, p_order, fe_degree,
-                                    MaterialStates, MemorySpaceType>::
+inline double
+ThermalOperatorDevice<dim, n_materials, use_table, p_order, fe_degree,
+                      MaterialStates, MemorySpaceType>::
     get_inv_rho_cp(typename dealii::DoFHandler<dim>::cell_iterator const &cell,
                    unsigned int) const
 {

--- a/source/ThermalOperatorDeviceInstSDev.cc
+++ b/source/ThermalOperatorDeviceInstSDev.cc
@@ -5,4 +5,4 @@
 #include <ThermalOperatorDevice.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_S_DEVICE(ThermalOperatorDevice)
+INSTANTIATE_DIM_NMAT_USETABLE_PORDER_FEDEGREE_S_DEVICE(ThermalOperatorDevice)

--- a/source/ThermalOperatorDeviceInstSLDev.cc
+++ b/source/ThermalOperatorDeviceInstSLDev.cc
@@ -5,4 +5,4 @@
 #include <ThermalOperatorDevice.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SL_DEVICE(ThermalOperatorDevice)
+INSTANTIATE_DIM_NMAT_USETABLE_PORDER_FEDEGREE_SL_DEVICE(ThermalOperatorDevice)

--- a/source/ThermalOperatorDeviceInstSLPDev.cc
+++ b/source/ThermalOperatorDeviceInstSLPDev.cc
@@ -5,4 +5,4 @@
 #include <ThermalOperatorDevice.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SLP_DEVICE(ThermalOperatorDevice)
+INSTANTIATE_DIM_NMAT_USETABLE_PORDER_FEDEGREE_SLP_DEVICE(ThermalOperatorDevice)

--- a/source/ThermalOperatorInstSHost.cc
+++ b/source/ThermalOperatorInstSHost.cc
@@ -5,4 +5,4 @@
 #include <ThermalOperator.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_S_HOST(ThermalOperator)
+INSTANTIATE_DIM_NMAT_USETABLE_PORDER_FEDEGREE_S_HOST(ThermalOperator)

--- a/source/ThermalOperatorInstSLHost.cc
+++ b/source/ThermalOperatorInstSLHost.cc
@@ -5,4 +5,4 @@
 #include <ThermalOperator.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SL_HOST(ThermalOperator)
+INSTANTIATE_DIM_NMAT_USETABLE_PORDER_FEDEGREE_SL_HOST(ThermalOperator)

--- a/source/ThermalOperatorInstSLPHost.cc
+++ b/source/ThermalOperatorInstSLPHost.cc
@@ -5,4 +5,4 @@
 #include <ThermalOperator.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SLP_HOST(ThermalOperator)
+INSTANTIATE_DIM_NMAT_USETABLE_PORDER_FEDEGREE_SLP_HOST(ThermalOperator)

--- a/source/ThermalPhysics.hh
+++ b/source/ThermalPhysics.hh
@@ -27,8 +27,9 @@ namespace adamantine
  * This class takes care of building the linear operator and the
  * right-hand-side. Also used to evolve the system in time.
  */
-template <int dim, int p_order, int fe_degree, typename MaterialStates,
-          typename MemorySpaceType, typename QuadratureType>
+template <int dim, int n_materials, int p_order, int fe_degree,
+          typename MaterialStates, typename MemorySpaceType,
+          typename QuadratureType>
 class ThermalPhysics : public ThermalPhysicsInterface<dim, MemorySpaceType>
 {
 public:
@@ -38,8 +39,8 @@ public:
   ThermalPhysics(MPI_Comm const &communicator,
                  boost::property_tree::ptree const &database,
                  Geometry<dim> &geometry, Boundary const &boundary,
-                 MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType>
-                     &material_properties);
+                 MaterialProperty<dim, n_materials, p_order, MaterialStates,
+                                  MemorySpaceType> &material_properties);
 
   void setup() override;
 
@@ -193,7 +194,7 @@ private:
   /**
    * Associated material properties.
    */
-  MaterialProperty<dim, p_order, MaterialStates, MemorySpaceType>
+  MaterialProperty<dim, n_materials, p_order, MaterialStates, MemorySpaceType>
       &_material_properties;
   /**
    * Vector of heat sources.
@@ -228,19 +229,22 @@ private:
   std::vector<std::vector<double>> _data_to_transfer;
 };
 
-template <int dim, int p_order, int fe_degree, typename MaterialStates,
-          typename MemorySpaceType, typename QuadratureType>
+template <int dim, int n_materials, int p_order, int fe_degree,
+          typename MaterialStates, typename MemorySpaceType,
+          typename QuadratureType>
 inline void
-ThermalPhysics<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
+ThermalPhysics<dim, n_materials, p_order, fe_degree, MaterialStates,
+               MemorySpaceType,
                QuadratureType>::update_material_deposition_orientation()
 {
   _thermal_operator->set_material_deposition_orientation(_deposition_cos,
                                                          _deposition_sin);
 }
 
-template <int dim, int p_order, int fe_degree, typename MaterialStates,
-          typename MemorySpaceType, typename QuadratureType>
-inline void ThermalPhysics<dim, p_order, fe_degree, MaterialStates,
+template <int dim, int n_materials, int p_order, int fe_degree,
+          typename MaterialStates, typename MemorySpaceType,
+          typename QuadratureType>
+inline void ThermalPhysics<dim, n_materials, p_order, fe_degree, MaterialStates,
                            MemorySpaceType, QuadratureType>::
     set_material_deposition_orientation(
         std::vector<double> const &deposition_cos,
@@ -251,93 +255,106 @@ inline void ThermalPhysics<dim, p_order, fe_degree, MaterialStates,
   update_material_deposition_orientation();
 }
 
-template <int dim, int p_order, int fe_degree, typename MaterialStates,
-          typename MemorySpaceType, typename QuadratureType>
+template <int dim, int n_materials, int p_order, int fe_degree,
+          typename MaterialStates, typename MemorySpaceType,
+          typename QuadratureType>
 inline double
-ThermalPhysics<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
+ThermalPhysics<dim, n_materials, p_order, fe_degree, MaterialStates,
+               MemorySpaceType,
                QuadratureType>::get_deposition_cos(unsigned int const i) const
 {
   return _deposition_cos[i];
 }
 
-template <int dim, int p_order, int fe_degree, typename MaterialStates,
-          typename MemorySpaceType, typename QuadratureType>
+template <int dim, int n_materials, int p_order, int fe_degree,
+          typename MaterialStates, typename MemorySpaceType,
+          typename QuadratureType>
 inline double
-ThermalPhysics<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
+ThermalPhysics<dim, n_materials, p_order, fe_degree, MaterialStates,
+               MemorySpaceType,
                QuadratureType>::get_deposition_sin(unsigned int const i) const
 {
   return _deposition_sin[i];
 }
 
-template <int dim, int p_order, int fe_degree, typename MaterialStates,
-          typename MemorySpaceType, typename QuadratureType>
+template <int dim, int n_materials, int p_order, int fe_degree,
+          typename MaterialStates, typename MemorySpaceType,
+          typename QuadratureType>
 inline std::vector<bool>
-ThermalPhysics<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
-               QuadratureType>::get_has_melted_vector() const
+ThermalPhysics<dim, n_materials, p_order, fe_degree, MaterialStates,
+               MemorySpaceType, QuadratureType>::get_has_melted_vector() const
 {
   return _has_melted;
 }
 
-template <int dim, int p_order, int fe_degree, typename MaterialStates,
-          typename MemorySpaceType, typename QuadratureType>
-inline void
-ThermalPhysics<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
-               QuadratureType>::set_has_melted_vector(std::vector<bool> const
-                                                          &has_melted)
+template <int dim, int n_materials, int p_order, int fe_degree,
+          typename MaterialStates, typename MemorySpaceType,
+          typename QuadratureType>
+inline void ThermalPhysics<
+    dim, n_materials, p_order, fe_degree, MaterialStates, MemorySpaceType,
+    QuadratureType>::set_has_melted_vector(std::vector<bool> const &has_melted)
 {
   _has_melted = has_melted;
 }
 
-template <int dim, int p_order, int fe_degree, typename MaterialStates,
-          typename MemorySpaceType, typename QuadratureType>
+template <int dim, int n_materials, int p_order, int fe_degree,
+          typename MaterialStates, typename MemorySpaceType,
+          typename QuadratureType>
 inline bool
-ThermalPhysics<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
+ThermalPhysics<dim, n_materials, p_order, fe_degree, MaterialStates,
+               MemorySpaceType,
                QuadratureType>::get_has_melted(unsigned int const i) const
 {
   return _has_melted[i];
 }
 
-template <int dim, int p_order, int fe_degree, typename MaterialStates,
-          typename MemorySpaceType, typename QuadratureType>
+template <int dim, int n_materials, int p_order, int fe_degree,
+          typename MaterialStates, typename MemorySpaceType,
+          typename QuadratureType>
 inline dealii::DoFHandler<dim> &
-ThermalPhysics<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
-               QuadratureType>::get_dof_handler()
+ThermalPhysics<dim, n_materials, p_order, fe_degree, MaterialStates,
+               MemorySpaceType, QuadratureType>::get_dof_handler()
 {
   return _dof_handler;
 }
 
-template <int dim, int p_order, int fe_degree, typename MaterialStates,
-          typename MemorySpaceType, typename QuadratureType>
+template <int dim, int n_materials, int p_order, int fe_degree,
+          typename MaterialStates, typename MemorySpaceType,
+          typename QuadratureType>
 inline dealii::AffineConstraints<double> &
-ThermalPhysics<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
-               QuadratureType>::get_affine_constraints()
+ThermalPhysics<dim, n_materials, p_order, fe_degree, MaterialStates,
+               MemorySpaceType, QuadratureType>::get_affine_constraints()
 {
   return _affine_constraints;
 }
 
-template <int dim, int p_order, int fe_degree, typename MaterialStates,
-          typename MemorySpaceType, typename QuadratureType>
+template <int dim, int n_materials, int p_order, int fe_degree,
+          typename MaterialStates, typename MemorySpaceType,
+          typename QuadratureType>
 inline std::vector<std::shared_ptr<HeatSource<dim>>> &
-ThermalPhysics<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
-               QuadratureType>::get_heat_sources()
+ThermalPhysics<dim, n_materials, p_order, fe_degree, MaterialStates,
+               MemorySpaceType, QuadratureType>::get_heat_sources()
 {
   return _heat_sources;
 }
 
-template <int dim, int p_order, int fe_degree, typename MaterialStates,
-          typename MemorySpaceType, typename QuadratureType>
+template <int dim, int n_materials, int p_order, int fe_degree,
+          typename MaterialStates, typename MemorySpaceType,
+          typename QuadratureType>
 inline unsigned int
-ThermalPhysics<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
-               QuadratureType>::get_fe_degree() const
+ThermalPhysics<dim, n_materials, p_order, fe_degree, MaterialStates,
+               MemorySpaceType, QuadratureType>::get_fe_degree() const
 {
   return fe_degree;
 }
 
-template <int dim, int p_order, int fe_degree, typename MaterialStates,
-          typename MemorySpaceType, typename QuadratureType>
+template <int dim, int n_materials, int p_order, int fe_degree,
+          typename MaterialStates, typename MemorySpaceType,
+          typename QuadratureType>
 inline double
-ThermalPhysics<dim, p_order, fe_degree, MaterialStates, MemorySpaceType,
-               QuadratureType>::get_current_source_height() const
+ThermalPhysics<dim, n_materials, p_order, fe_degree, MaterialStates,
+               MemorySpaceType, QuadratureType>::get_current_source_height()
+    const
 {
   return _current_source_height;
 }

--- a/source/ThermalPhysicsInstSDev.cc
+++ b/source/ThermalPhysicsInstSDev.cc
@@ -5,4 +5,4 @@
 #include <ThermalPhysics.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_PORDER_FEDEGREE_S_QUAD_DEVICE(ThermalPhysics)
+INSTANTIATE_DIM_NMAT_PORDER_FEDEGREE_S_QUAD_DEVICE(ThermalPhysics)

--- a/source/ThermalPhysicsInstSHost.cc
+++ b/source/ThermalPhysicsInstSHost.cc
@@ -5,4 +5,4 @@
 #include <ThermalPhysics.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_PORDER_FEDEGREE_S_QUAD_HOST(ThermalPhysics)
+INSTANTIATE_DIM_NMAT_PORDER_FEDEGREE_S_QUAD_HOST(ThermalPhysics)

--- a/source/ThermalPhysicsInstSLDev.cc
+++ b/source/ThermalPhysicsInstSLDev.cc
@@ -5,4 +5,4 @@
 #include <ThermalPhysics.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_PORDER_FEDEGREE_SL_QUAD_DEVICE(ThermalPhysics)
+INSTANTIATE_DIM_NMAT_PORDER_FEDEGREE_SL_QUAD_DEVICE(ThermalPhysics)

--- a/source/ThermalPhysicsInstSLHost.cc
+++ b/source/ThermalPhysicsInstSLHost.cc
@@ -5,4 +5,4 @@
 #include <ThermalPhysics.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_PORDER_FEDEGREE_SL_QUAD_HOST(ThermalPhysics)
+INSTANTIATE_DIM_NMAT_PORDER_FEDEGREE_SL_QUAD_HOST(ThermalPhysics)

--- a/source/ThermalPhysicsInstSLPDev.cc
+++ b/source/ThermalPhysicsInstSLPDev.cc
@@ -5,4 +5,4 @@
 #include <ThermalPhysics.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_PORDER_FEDEGREE_SLP_QUAD_DEVICE(ThermalPhysics)
+INSTANTIATE_DIM_NMAT_PORDER_FEDEGREE_SLP_QUAD_DEVICE(ThermalPhysics)

--- a/source/ThermalPhysicsInstSLPHost.cc
+++ b/source/ThermalPhysicsInstSLPHost.cc
@@ -5,4 +5,4 @@
 #include <ThermalPhysics.templates.hh>
 #include <instantiation.hh>
 
-INSTANTIATE_DIM_PORDER_FEDEGREE_SLP_QUAD_HOST(ThermalPhysics)
+INSTANTIATE_DIM_NMAT_PORDER_FEDEGREE_SLP_QUAD_HOST(ThermalPhysics)

--- a/source/instantiation.hh
+++ b/source/instantiation.hh
@@ -7,233 +7,291 @@
 // clang-format off
 #define ADAMANTINE_DIM (2)(3)
 #define ADAMANTINE_USE_TABLE (true)(false)
+#define ADAMANTINE_N_MATERIALS (-1)(1)
 #define ADAMANTINE_P_ORDER (0)(1)(2)(3)(4)
 #define ADAMANTINE_FE_DEGREE (1)(2)(3)(4)(5)
 #define ADAMANTINE_MATERIAL_STATE (adamantine::Solid)(adamantine::SolidLiquid)(adamantine::SolidLiquidPowder)
 #define ADAMANTINE_QUADRATURE_TYPE (dealii::QGauss<1>)(dealii::QGaussLobatto<1>)
-
-// Instantiation of the class for:
-//   - dim = 2 and 3
-#define ADAMANTINE_D(z, SEQ) \
-  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ)>;
-#define INSTANTIATE_DIM(NAME) \
-  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D,((NAME))(ADAMANTINE_DIM))
-
-// Instantiation of the class for:
-//   - dim = 2 and 3
-//   - p_order = 0 to 4
-//   - material_state = Solid, SolidLiquid, and SolidLiquidPowder
-//   - memory_space = Host
-#define ADAMANTINE_D_P_M_HOST(z, SEQ) \
-  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
-  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), dealii::MemorySpace::Host>;
-#define INSTANTIATE_DIM_PORDER_MATERIALSTATES_HOST(NAME) \
-  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_P_M_HOST,\
-                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_P_ORDER)\
-                                (ADAMANTINE_MATERIAL_STATE))
-
-// Instantiation of the class for:
-//   - dim = 2 and 3
-//   - p_order = 0 to 4
-//   - material_state = Solid, SolidLiquid, and SolidLiquidPowder
-//   - memory_space = Default
-#define ADAMANTINE_D_P_M_DEV(z, SEQ) \
-  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
-  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), dealii::MemorySpace::Default>;
-#define INSTANTIATE_DIM_PORDER_MATERIALSTATES_DEVICE(NAME) \
-  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_P_M_DEV,\
-                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_P_ORDER)\
-                                (ADAMANTINE_MATERIAL_STATE))
-
-// Instantiation of the class for:
-//   - dim = 2 and 3
-//   - use_table = true or false
-//   - p_order = 0 to 4
-//   - fe_degree = 1 to 5
-//   - material_state = Solid
-//   - memory_space = Host
-#define ADAMANTINE_D_U_P_F_S_HOST(z, SEQ) \
-  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
-  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),\
-  adamantine::Solid, dealii::MemorySpace::Host>;
-#define INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_S_HOST(NAME) \
-  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_U_P_F_S_HOST,\
-                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_USE_TABLE)\
-                                (ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE))
-
-// Instantiation of the class for:
-//   - dim = 2 and 3
-//   - use_table = true or false
-//   - p_order = 0 to 4
-//   - fe_degree = 1 to 5
-//   - material_state = SolidLiquid
-//   - memory_space = Host
-#define ADAMANTINE_D_U_P_F_SL_HOST(z, SEQ) \
-  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
-  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),\
-  adamantine::SolidLiquid, dealii::MemorySpace::Host>;
-#define INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SL_HOST(NAME) \
-  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_U_P_F_SL_HOST,\
-                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_USE_TABLE)\
-                                (ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE))
-
-// Instantiation of the class for:
-//   - dim = 2 and 3
-//   - use_table = true or false
-//   - p_order = 0 to 4
-//   - fe_degree = 1 to 5
-//   - material_state = SolidLiquidPowder
-//   - memory_space = Host
-#define ADAMANTINE_D_U_P_F_SLP_HOST(z, SEQ) \
-  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
-  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),\
-  adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>;
-#define INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SLP_HOST(NAME) \
-  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_U_P_F_SLP_HOST,\
-                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_USE_TABLE)\
-                                (ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE))
-
-// Instantiation of the class for:
-//   - dim = 2 and 3
-//   - use_table = true or false
-//   - p_order = 0 to 4
-//   - fe_degree = 1 to 5
-//   - material_state = Solid
-//   - memory_space = Default
-#define ADAMANTINE_D_U_P_F_S_DEV(z, SEQ) \
-  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
-  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),\
-  adamantine::Solid, dealii::MemorySpace::Default>;
-#define INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_S_DEVICE(NAME) \
-  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_U_P_F_S_DEV,\
-                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_USE_TABLE)\
-                                (ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE))
-
-// Instantiation of the class for:
-//   - dim = 2 and 3
-//   - use_table = true or false
-//   - p_order = 0 to 4
-//   - fe_degree = 1 to 5
-//   - material_state = SolidLiquid
-//   - memory_space = Default
-#define ADAMANTINE_D_U_P_F_SL_DEV(z, SEQ) \
-  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
-  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),\
-  adamantine::SolidLiquid, dealii::MemorySpace::Default>;
-#define INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SL_DEVICE(NAME) \
-  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_U_P_F_SL_DEV,\
-                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_USE_TABLE)\
-                                (ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE))
-
-// Instantiation of the class for:
-//   - dim = 2 and 3
-//   - use_table = true or false
-//   - p_order = 0 to 4
-//   - fe_degree = 1 to 5
-//   - material_state = SolidLiquidPowder
-//   - memory_space = Default
-#define ADAMANTINE_D_U_P_F_SLP_DEV(z, SEQ) \
-  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
-  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),\
-  adamantine::SolidLiquidPowder, dealii::MemorySpace::Default>;
-#define INSTANTIATE_DIM_USETABLE_PORDER_FEDEGREE_SLP_DEVICE(NAME) \
-  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_U_P_F_SLP_DEV,\
-                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_USE_TABLE)\
-                                (ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE))
-
-// Instantiation of the class for:
-//   - dim = 2 and 3
-//   - p_order = 0 to 4
-//   - fe_degree = 1 to 5
-//   - material_state = Solid
-//   - memory_space = Host
-//   - QuadratureType = dealii::QGauss<1> and dealii::QGaussLobatto<1>
-#define ADAMANTINE_D_P_F_S_Q_HOST(z, SEQ) \
-  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
-  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), adamantine::Solid,\
-  dealii::MemorySpace::Host, BOOST_PP_SEQ_ELEM(4, SEQ)>;
-#define INSTANTIATE_DIM_PORDER_FEDEGREE_S_QUAD_HOST(NAME) \
-  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_P_F_S_Q_HOST,\
-                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_P_ORDER)\
-                                (ADAMANTINE_FE_DEGREE)(ADAMANTINE_QUADRATURE_TYPE))
-
-// Instantiation of the class for:
-//   - dim = 2 and 3
-//   - p_order = 0 to 4
-//   - fe_degree = 1 to 5
-//   - material_state = SolidLiquid
-//   - memory_space = Host
-//   - QuadratureType = dealii::QGauss<1> and dealii::QGaussLobatto<1>
-#define ADAMANTINE_D_P_F_SL_Q_HOST(z, SEQ) \
-  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
-  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), adamantine::SolidLiquid,\
-  dealii::MemorySpace::Host, BOOST_PP_SEQ_ELEM(4, SEQ)>;
-#define INSTANTIATE_DIM_PORDER_FEDEGREE_SL_QUAD_HOST(NAME) \
-  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_P_F_SL_Q_HOST,\
-                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_P_ORDER)\
-                                (ADAMANTINE_FE_DEGREE)(ADAMANTINE_QUADRATURE_TYPE))
-
-// Instantiation of the class for:
-//   - dim = 2 and 3
-//   - p_order = 0 to 4
-//   - fe_degree = 1 to 5
-//   - material_state = SolidLiquidPowder
-//   - memory_space = Host
-//   - QuadratureType = dealii::QGauss<1> and dealii::QGaussLobatto<1>
-#define ADAMANTINE_D_P_F_SLP_Q_HOST(z, SEQ) \
-  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
-  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), adamantine::SolidLiquidPowder,\
-  dealii::MemorySpace::Host, BOOST_PP_SEQ_ELEM(4, SEQ)>;
-#define INSTANTIATE_DIM_PORDER_FEDEGREE_SLP_QUAD_HOST(NAME) \
-  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_P_F_SLP_Q_HOST,\
-                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_P_ORDER)\
-                                (ADAMANTINE_FE_DEGREE)(ADAMANTINE_QUADRATURE_TYPE))
-
-// Instantiation of the class for:
-//   - dim = 2 and 3
-//   - p_order = 0 to 4
-//   - fe_degree = 1 to 5
-//   - material_state = Solid
-//   - memory_space = Default
-//   - QuadratureType = dealii::QGauss<1> and dealii::QGaussLobatto<1>
-#define ADAMANTINE_D_P_F_S_Q_DEV(z, SEQ) \
-  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
-  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), adamantine::Solid,\
-  dealii::MemorySpace::Default, BOOST_PP_SEQ_ELEM(4, SEQ)>;
-#define INSTANTIATE_DIM_PORDER_FEDEGREE_S_QUAD_DEVICE(NAME) \
-  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_P_F_S_Q_DEV,\
-                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_P_ORDER)\
-                                (ADAMANTINE_FE_DEGREE)(ADAMANTINE_QUADRATURE_TYPE))
-
-// Instantiation of the class for:
-//   - dim = 2 and 3
-//   - p_order = 0 to 4
-//   - fe_degree = 1 to 5
-//   - material_state = SolidLiquid
-//   - memory_space = Default
-//   - QuadratureType = dealii::QGauss<1> and dealii::QGaussLobatto<1>
-#define ADAMANTINE_D_P_F_SL_Q_DEV(z, SEQ) \
-  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
-  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), adamantine::SolidLiquid,\
-  dealii::MemorySpace::Default, BOOST_PP_SEQ_ELEM(4, SEQ)>;
-#define INSTANTIATE_DIM_PORDER_FEDEGREE_SL_QUAD_DEVICE(NAME) \
-  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_P_F_SL_Q_DEV,\
-                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_P_ORDER)\
-                                (ADAMANTINE_FE_DEGREE)(ADAMANTINE_QUADRATURE_TYPE))
-
-// Instantiation of the class for:
-//   - dim = 2 and 3
-//   - p_order = 0 to 4
-//   - fe_degree = 1 to 5
-//   - material_state = SolidLiquidPowder
-//   - memory_space = Default
-//   - QuadratureType = dealii::QGauss<1> and dealii::QGaussLobatto<1>
-#define ADAMANTINE_D_P_F_SLP_Q_DEV(z, SEQ) \
-  template class adamantine::BOOST_PP_SEQ_ELEM(0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ),\
-  BOOST_PP_SEQ_ELEM(2, SEQ), BOOST_PP_SEQ_ELEM(3, SEQ), adamantine::SolidLiquidPowder,\
-  dealii::MemorySpace::Default, BOOST_PP_SEQ_ELEM(4, SEQ)>;
-#define INSTANTIATE_DIM_PORDER_FEDEGREE_SLP_QUAD_DEVICE(NAME) \
-  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D_P_F_SLP_Q_DEV,\
-                                ((NAME))(ADAMANTINE_DIM)(ADAMANTINE_P_ORDER)\
-                                (ADAMANTINE_FE_DEGREE)(ADAMANTINE_QUADRATURE_TYPE))
 // clang-format on
+
+// Instantiation of the class for:
+//   - dim = 2 and 3
+#define ADAMANTINE_D(z, SEQ)                                                   \
+  template class adamantine::BOOST_PP_SEQ_ELEM(                                \
+      0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ)>;
+#define INSTANTIATE_DIM(NAME)                                                  \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(ADAMANTINE_D, ((NAME))(ADAMANTINE_DIM))
+
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - n_materials = -1 and 1
+//   - p_order = 0 to 4
+//   - material_state = Solid, SolidLiquid, and SolidLiquidPowder
+//   - memory_space = Host
+#define ADAMANTINE_D_N_P_M_HOST(z, SEQ)                                        \
+  template class adamantine::BOOST_PP_SEQ_ELEM(                                \
+      0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ), BOOST_PP_SEQ_ELEM(2, SEQ),            \
+              BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),            \
+              dealii::MemorySpace::Host>;
+#define INSTANTIATE_DIM_NMAT_PORDER_MATERIALSTATES_HOST(NAME)                  \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(                                               \
+      ADAMANTINE_D_N_P_M_HOST,                                                 \
+      ((NAME))(                                                                \
+          ADAMANTINE_DIM)(ADAMANTINE_N_MATERIALS)(ADAMANTINE_P_ORDER)(ADAMANTINE_MATERIAL_STATE))
+
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - n_materials = -1 and 1
+//   - p_order = 0 to 4
+//   - material_state = Solid, SolidLiquid, and SolidLiquidPowder
+//   - memory_space = Default
+#define ADAMANTINE_D_N_P_M_DEV(z, SEQ)                                         \
+  template class adamantine::BOOST_PP_SEQ_ELEM(                                \
+      0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ), BOOST_PP_SEQ_ELEM(2, SEQ),            \
+              BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),            \
+              dealii::MemorySpace::Default>;
+#define INSTANTIATE_DIM_NMAT_PORDER_MATERIALSTATES_DEVICE(NAME)                \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(                                               \
+      ADAMANTINE_D_N_P_M_DEV,                                                  \
+      ((NAME))(                                                                \
+          ADAMANTINE_DIM)(ADAMANTINE_N_MATERIALS)(ADAMANTINE_P_ORDER)(ADAMANTINE_MATERIAL_STATE))
+
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - n_materials = -1 and 1
+//   - use_table = true and false
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = Solid
+//   - memory_space = Host
+#define ADAMANTINE_D_N_U_P_F_S_HOST(z, SEQ)                                    \
+  template class adamantine::BOOST_PP_SEQ_ELEM(                                \
+      0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ), BOOST_PP_SEQ_ELEM(2, SEQ),            \
+              BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),            \
+              BOOST_PP_SEQ_ELEM(5, SEQ), adamantine::Solid,                    \
+              dealii::MemorySpace::Host>;
+#define INSTANTIATE_DIM_NMAT_USETABLE_PORDER_FEDEGREE_S_HOST(NAME)             \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(                                               \
+      ADAMANTINE_D_N_U_P_F_S_HOST,                                             \
+      ((NAME))(                                                                \
+          ADAMANTINE_DIM)(ADAMANTINE_N_MATERIALS)(ADAMANTINE_USE_TABLE)(ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE))
+
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - n_material = -1 and 1
+//   - use_table = true and false
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = SolidLiquid
+//   - memory_space = Host
+#define ADAMANTINE_D_N_U_P_F_SL_HOST(z, SEQ)                                   \
+  template class adamantine::BOOST_PP_SEQ_ELEM(                                \
+      0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ), BOOST_PP_SEQ_ELEM(2, SEQ),            \
+              BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),            \
+              BOOST_PP_SEQ_ELEM(5, SEQ), adamantine::SolidLiquid,              \
+              dealii::MemorySpace::Host>;
+#define INSTANTIATE_DIM_NMAT_USETABLE_PORDER_FEDEGREE_SL_HOST(NAME)            \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(                                               \
+      ADAMANTINE_D_N_U_P_F_SL_HOST,                                            \
+      ((NAME))(                                                                \
+          ADAMANTINE_DIM)(ADAMANTINE_N_MATERIALS)(ADAMANTINE_USE_TABLE)(ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE))
+
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - n_materials = -1 and 1
+//   - use_table = true and false
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = SolidLiquidPowder
+//   - memory_space = Host
+#define ADAMANTINE_D_N_U_P_F_SLP_HOST(z, SEQ)                                  \
+  template class adamantine::BOOST_PP_SEQ_ELEM(                                \
+      0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ), BOOST_PP_SEQ_ELEM(2, SEQ),            \
+              BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),            \
+              BOOST_PP_SEQ_ELEM(5, SEQ), adamantine::SolidLiquidPowder,        \
+              dealii::MemorySpace::Host>;
+#define INSTANTIATE_DIM_NMAT_USETABLE_PORDER_FEDEGREE_SLP_HOST(NAME)           \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(                                               \
+      ADAMANTINE_D_N_U_P_F_SLP_HOST,                                           \
+      ((NAME))(                                                                \
+          ADAMANTINE_DIM)(ADAMANTINE_N_MATERIALS)(ADAMANTINE_USE_TABLE)(ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE))
+
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - n_materials = -1 and 1
+//   - use_table = true and false
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = Solid
+//   - memory_space = Default
+#define ADAMANTINE_D_N_U_P_F_S_DEV(z, SEQ)                                     \
+  template class adamantine::BOOST_PP_SEQ_ELEM(                                \
+      0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ), BOOST_PP_SEQ_ELEM(2, SEQ),            \
+              BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),            \
+              BOOST_PP_SEQ_ELEM(5, SEQ), adamantine::Solid,                    \
+              dealii::MemorySpace::Default>;
+#define INSTANTIATE_DIM_NMAT_USETABLE_PORDER_FEDEGREE_S_DEVICE(NAME)           \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(                                               \
+      ADAMANTINE_D_N_U_P_F_S_DEV,                                              \
+      ((NAME))(                                                                \
+          ADAMANTINE_DIM)(ADAMANTINE_N_MATERIALS)(ADAMANTINE_USE_TABLE)(ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE))
+
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - n_materials = -1 and 1
+//   - use_table = true and false
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = SolidLiquid
+//   - memory_space = Default
+#define ADAMANTINE_D_N_U_P_F_SL_DEV(z, SEQ)                                    \
+  template class adamantine::BOOST_PP_SEQ_ELEM(                                \
+      0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ), BOOST_PP_SEQ_ELEM(2, SEQ),            \
+              BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),            \
+              BOOST_PP_SEQ_ELEM(5, SEQ), adamantine::SolidLiquid,              \
+              dealii::MemorySpace::Default>;
+#define INSTANTIATE_DIM_NMAT_USETABLE_PORDER_FEDEGREE_SL_DEVICE(NAME)          \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(                                               \
+      ADAMANTINE_D_N_U_P_F_SL_DEV,                                             \
+      ((NAME))(                                                                \
+          ADAMANTINE_DIM)(ADAMANTINE_N_MATERIALS)(ADAMANTINE_USE_TABLE)(ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE))
+
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - n_materials = -1 and 1
+//   - use_table = true and false
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = SolidLiquidPowder
+//   - memory_space = Default
+#define ADAMANTINE_D_N_U_P_F_SLP_DEV(z, SEQ)                                   \
+  template class adamantine::BOOST_PP_SEQ_ELEM(                                \
+      0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ), BOOST_PP_SEQ_ELEM(2, SEQ),            \
+              BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),            \
+              BOOST_PP_SEQ_ELEM(5, SEQ), adamantine::SolidLiquidPowder,        \
+              dealii::MemorySpace::Default>;
+#define INSTANTIATE_DIM_NMAT_USETABLE_PORDER_FEDEGREE_SLP_DEVICE(NAME)         \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(                                               \
+      ADAMANTINE_D_N_U_P_F_SLP_DEV,                                            \
+      ((NAME))(                                                                \
+          ADAMANTINE_DIM)(ADAMANTINE_N_MATERIALS)(ADAMANTINE_USE_TABLE)(ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE))
+
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - n_materials = -1 and 1
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = Solid
+//   - memory_space = Host
+//   - QuadratureType = dealii::QGauss<1> and dealii::QGaussLobatto<1>
+#define ADAMANTINE_D_N_P_F_S_Q_HOST(z, SEQ)                                    \
+  template class adamantine::BOOST_PP_SEQ_ELEM(                                \
+      0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ), BOOST_PP_SEQ_ELEM(2, SEQ),            \
+              BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),            \
+              adamantine::Solid, dealii::MemorySpace::Host,                    \
+              BOOST_PP_SEQ_ELEM(5, SEQ)>;
+#define INSTANTIATE_DIM_NMAT_PORDER_FEDEGREE_S_QUAD_HOST(NAME)                 \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(                                               \
+      ADAMANTINE_D_N_P_F_S_Q_HOST,                                             \
+      ((NAME))(                                                                \
+          ADAMANTINE_DIM)(ADAMANTINE_N_MATERIALS)(ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE)(ADAMANTINE_QUADRATURE_TYPE))
+
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - n_materials = -1 and 1
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = SolidLiquid
+//   - memory_space = Host
+//   - QuadratureType = dealii::QGauss<1> and dealii::QGaussLobatto<1>
+#define ADAMANTINE_D_N_P_F_SL_Q_HOST(z, SEQ)                                   \
+  template class adamantine::BOOST_PP_SEQ_ELEM(                                \
+      0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ), BOOST_PP_SEQ_ELEM(2, SEQ),            \
+              BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),            \
+              adamantine::SolidLiquid, dealii::MemorySpace::Host,              \
+              BOOST_PP_SEQ_ELEM(5, SEQ)>;
+#define INSTANTIATE_DIM_NMAT_PORDER_FEDEGREE_SL_QUAD_HOST(NAME)                \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(                                               \
+      ADAMANTINE_D_N_P_F_SL_Q_HOST,                                            \
+      ((NAME))(                                                                \
+          ADAMANTINE_DIM)(ADAMANTINE_N_MATERIALS)(ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE)(ADAMANTINE_QUADRATURE_TYPE))
+
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - n_materials = -1 and 1
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = SolidLiquidPowder
+//   - memory_space = Host
+//   - QuadratureType = dealii::QGauss<1> and dealii::QGaussLobatto<1>
+#define ADAMANTINE_D_N_P_F_SLP_Q_HOST(z, SEQ)                                  \
+  template class adamantine::BOOST_PP_SEQ_ELEM(                                \
+      0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ), BOOST_PP_SEQ_ELEM(2, SEQ),            \
+              BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),            \
+              adamantine::SolidLiquidPowder, dealii::MemorySpace::Host,        \
+              BOOST_PP_SEQ_ELEM(5, SEQ)>;
+#define INSTANTIATE_DIM_NMAT_PORDER_FEDEGREE_SLP_QUAD_HOST(NAME)               \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(                                               \
+      ADAMANTINE_D_N_P_F_SLP_Q_HOST,                                           \
+      ((NAME))(                                                                \
+          ADAMANTINE_DIM)(ADAMANTINE_N_MATERIALS)(ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE)(ADAMANTINE_QUADRATURE_TYPE))
+
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - n_materials = -1 and 1
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = Solid
+//   - memory_space = Default
+//   - QuadratureType = dealii::QGauss<1> and dealii::QGaussLobatto<1>
+#define ADAMANTINE_D_N_P_F_S_Q_DEV(z, SEQ)                                     \
+  template class adamantine::BOOST_PP_SEQ_ELEM(                                \
+      0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ), BOOST_PP_SEQ_ELEM(2, SEQ),            \
+              BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),            \
+              adamantine::Solid, dealii::MemorySpace::Default,                 \
+              BOOST_PP_SEQ_ELEM(5, SEQ)>;
+#define INSTANTIATE_DIM_NMAT_PORDER_FEDEGREE_S_QUAD_DEVICE(NAME)               \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(                                               \
+      ADAMANTINE_D_N_P_F_S_Q_DEV,                                              \
+      ((NAME))(                                                                \
+          ADAMANTINE_DIM)(ADAMANTINE_N_MATERIALS)(ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE)(ADAMANTINE_QUADRATURE_TYPE))
+
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - n_materials = -1 and 1
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = SolidLiquid
+//   - memory_space = Default
+//   - QuadratureType = dealii::QGauss<1> and dealii::QGaussLobatto<1>
+#define ADAMANTINE_D_N_P_F_SL_Q_DEV(z, SEQ)                                    \
+  template class adamantine::BOOST_PP_SEQ_ELEM(                                \
+      0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ), BOOST_PP_SEQ_ELEM(2, SEQ),            \
+              BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),            \
+              adamantine::SolidLiquid, dealii::MemorySpace::Default,           \
+              BOOST_PP_SEQ_ELEM(5, SEQ)>;
+#define INSTANTIATE_DIM_NMAT_PORDER_FEDEGREE_SL_QUAD_DEVICE(NAME)              \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(                                               \
+      ADAMANTINE_D_N_P_F_SL_Q_DEV,                                             \
+      ((NAME))(                                                                \
+          ADAMANTINE_DIM)(ADAMANTINE_N_MATERIALS)(ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE)(ADAMANTINE_QUADRATURE_TYPE))
+
+// Instantiation of the class for:
+//   - dim = 2 and 3
+//   - n_materials = -1 and 1
+//   - p_order = 0 to 4
+//   - fe_degree = 1 to 5
+//   - material_state = SolidLiquidPowder
+//   - memory_space = Default
+//   - QuadratureType = dealii::QGauss<1> and dealii::QGaussLobatto<1>
+#define ADAMANTINE_D_N_P_F_SLP_Q_DEV(z, SEQ)                                   \
+  template class adamantine::BOOST_PP_SEQ_ELEM(                                \
+      0, SEQ)<BOOST_PP_SEQ_ELEM(1, SEQ), BOOST_PP_SEQ_ELEM(2, SEQ),            \
+              BOOST_PP_SEQ_ELEM(3, SEQ), BOOST_PP_SEQ_ELEM(4, SEQ),            \
+              adamantine::SolidLiquidPowder, dealii::MemorySpace::Default,     \
+              BOOST_PP_SEQ_ELEM(5, SEQ)>;
+#define INSTANTIATE_DIM_NMAT_PORDER_FEDEGREE_SLP_QUAD_DEVICE(NAME)             \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(                                               \
+      ADAMANTINE_D_N_P_F_SLP_Q_DEV,                                            \
+      ((NAME))(                                                                \
+          ADAMANTINE_DIM)(ADAMANTINE_N_MATERIALS)(ADAMANTINE_P_ORDER)(ADAMANTINE_FE_DEGREE)(ADAMANTINE_QUADRATURE_TYPE))

--- a/tests/test_integration_2d.cc
+++ b/tests/test_integration_2d.cc
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(integration_2D, *utf::tolerance(0.1))
   boost::property_tree::info_parser::read_info(filename, database);
 
   auto [temperature, displacement] =
-      run<2, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
+      run<2, 1, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
           communicator, database, timers);
 
   std::ifstream gold_file("integration_2d_gold.txt");
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(integration_2D_ensemble, *utf::tolerance(0.1))
   boost::property_tree::info_parser::read_info(filename, database);
 
   auto result_ensemble =
-      run_ensemble<2, 3, adamantine::SolidLiquidPowder,
+      run_ensemble<2, -1, 3, adamantine::SolidLiquidPowder,
                    dealii::MemorySpace::Host>(communicator, database, timers);
 
   for (auto &result_member : result_ensemble)
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(integration_2D_units, *utf::tolerance(0.1))
   boost::property_tree::info_parser::read_info(filename, database);
 
   auto [temperature, displacement] =
-      run<2, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
+      run<2, 1, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
           communicator, database, timers);
 
   std::ifstream gold_file("integration_2d_gold.txt");

--- a/tests/test_integration_2d_device.cc
+++ b/tests/test_integration_2d_device.cc
@@ -31,8 +31,8 @@ BOOST_AUTO_TEST_CASE(intregation_2D_device, *utf::tolerance(0.1))
   boost::property_tree::info_parser::read_info(filename, database);
 
   auto [temperature, displacement] =
-      run<2, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Default>(
-          communicator, database, timers);
+      run<2, -1, 4, adamantine::SolidLiquidPowder,
+          dealii::MemorySpace::Default>(communicator, database, timers);
 
   std::ifstream gold_file("integration_2d_gold.txt");
   for (unsigned int i = 0; i < temperature.locally_owned_size(); ++i)

--- a/tests/test_integration_3d.cc
+++ b/tests/test_integration_3d.cc
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(integration_3D, *utf::tolerance(0.1))
   boost::property_tree::info_parser::read_info(filename, database);
 
   auto [temperature, displacement] =
-      run<3, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
+      run<3, -1, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
           communicator, database, timers);
 
   int num_ranks = 0;
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(integration_3D_short, *utf::tolerance(0.1))
   boost::property_tree::info_parser::read_info(filename, database);
 
   auto [temperature, displacement] =
-      run<3, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
+      run<3, 1, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
           communicator, database, timers);
 
   int num_ranks = 0;
@@ -198,12 +198,12 @@ BOOST_AUTO_TEST_CASE(integration_3D_checkpoint_restart, *utf::tolerance(1e-10))
   database.put("checkpoint.overwrite_files", true);
   database.put("checkpoint.time_steps_between_checkpoint", 80);
   auto [temperature_1, displacement_1] =
-      run<3, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
+      run<3, -1, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
           communicator, database, timers);
   // Restart of the simulation
   database.put("restart.filename_prefix", checkpoint_filename);
   auto [temperature_2, displacement_2] =
-      run<3, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
+      run<3, -1, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
           communicator, database, timers);
 
   // Compare the temperatures. When using more than one processor, the
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE(hourglass, *utf::tolerance(0.1))
     boost::property_tree::ptree database;
     boost::property_tree::info_parser::read_info(filename, database);
 
-    run<3, 1, adamantine::SolidLiquid, dealii::MemorySpace::Host>(
+    run<3, 1, 1, adamantine::SolidLiquid, dealii::MemorySpace::Host>(
         communicator, database, timers);
   }
 }

--- a/tests/test_integration_3d_amr.cc
+++ b/tests/test_integration_3d_amr.cc
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(integration_3D_amr, *utf::tolerance(0.1))
   boost::property_tree::info_parser::read_info(filename, database);
 
   auto [temperature, displacement] =
-      run<3, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
+      run<3, -1, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
           communicator, database, timers);
 
   double min_val = std::numeric_limits<double>::max();
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(integration_3D_amr_refine_coarsen, *utf::tolerance(0.1))
   boost::property_tree::info_parser::read_info(filename, database);
 
   auto [temperature, displacement] =
-      run<3, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
+      run<3, 1, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
           communicator, database, timers);
 
   auto global_size = temperature.size();

--- a/tests/test_integration_3d_amr_device.cc
+++ b/tests/test_integration_3d_amr_device.cc
@@ -31,8 +31,8 @@ BOOST_AUTO_TEST_CASE(integration_3D_amr_device, *utf::tolerance(0.1))
   boost::property_tree::info_parser::read_info(filename, database);
 
   auto [temperature, displacement] =
-      run<3, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Default>(
-          communicator, database, timers);
+      run<3, -1, 4, adamantine::SolidLiquidPowder,
+          dealii::MemorySpace::Default>(communicator, database, timers);
 
   double min_val = std::numeric_limits<double>::max();
   double max_val = std::numeric_limits<double>::min();

--- a/tests/test_integration_3d_device.cc
+++ b/tests/test_integration_3d_device.cc
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(integration_3D_device, *utf::tolerance(0.1))
   boost::property_tree::info_parser::read_info(filename, database);
 
   auto [temperature, displacement] =
-      run<3, 3, adamantine::SolidLiquidPowder, dealii::MemorySpace::Default>(
+      run<3, 1, 3, adamantine::SolidLiquidPowder, dealii::MemorySpace::Default>(
           communicator, database, timers);
 
   std::ifstream gold_file("integration_3d_gold.txt");
@@ -63,12 +63,12 @@ BOOST_AUTO_TEST_CASE(integration_3D_checkpoint_restart_device)
   database.put("checkpoint.overwrite_files", true);
   database.put("checkpoint.time_steps_between_checkpoint", 80);
   auto [temperature_1, displacement_1] =
-      run<3, 3, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
+      run<3, 1, 3, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
           communicator, database, timers);
   // Restart of the simulation
   database.put("restart.filename_prefix", checkpoint_filename);
   auto [temperature_2, displacement_2] =
-      run<3, 3, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
+      run<3, 1, 3, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
           communicator, database, timers);
 
   // Compare the temperatures. When using more than one processor, the

--- a/tests/test_integration_da.cc
+++ b/tests/test_integration_da.cc
@@ -30,7 +30,7 @@ double integration_da(MPI_Comm communicator, bool l2_norm)
 
   // Run the simulation
   auto result =
-      run_ensemble<3, 1, adamantine::SolidLiquidPowder,
+      run_ensemble<3, 1, 1, adamantine::SolidLiquidPowder,
                    dealii::MemorySpace::Host>(communicator, database, timers);
 
   if (l2_norm)
@@ -100,7 +100,7 @@ double integration_da_point_cloud_add_mat(MPI_Comm communicator, bool l2_norm)
 
   // Run the simulation
   auto result =
-      run_ensemble<3, 1, adamantine::SolidLiquidPowder,
+      run_ensemble<3, 1, 1, adamantine::SolidLiquidPowder,
                    dealii::MemorySpace::Host>(communicator, database, timers);
 
   if (l2_norm)
@@ -183,7 +183,7 @@ double integration_da_ray_add_mat(MPI_Comm communicator, bool l2_norm)
 
   // Run the simulation
   auto result =
-      run_ensemble<3, 1, adamantine::SolidLiquidPowder,
+      run_ensemble<3, -1, 1, adamantine::SolidLiquidPowder,
                    dealii::MemorySpace::Host>(communicator, database, timers);
 
   if (l2_norm)

--- a/tests/test_integration_da_augmented.cc
+++ b/tests/test_integration_da_augmented.cc
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(integration_3D_data_assimilation_augmented,
 
   // Run the simulation
   auto result =
-      run_ensemble<3, 3, adamantine::SolidLiquidPowder,
+      run_ensemble<3, -1, 3, adamantine::SolidLiquidPowder,
                    dealii::MemorySpace::Host>(communicator, database, timers);
 
   // Three ensemble members expected

--- a/tests/test_integration_thermoelastic.cc
+++ b/tests/test_integration_thermoelastic.cc
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(integration_thermoelastic, *utf::tolerance(1.0e-5))
   database.put("materials.material_0.solid.thermal_expansion_coef", 17.2e-3);
 
   auto [temperature, displacement] =
-      run<3, 3, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
+      run<3, -1, 3, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
           communicator, database, timers);
 
   // For now doing a simple regression test. Without a dof handler, it's hard to
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(integration_thermoelastic_add_material,
   database.put("materials.material_0.solid.thermal_expansion_coef", 17.2e-3);
 
   auto [temperature, displacement] =
-      run<3, 2, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
+      run<3, 1, 2, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>(
           communicator, database, timers);
 
   // For now doing a simple regression test. Without a dof handler, it's hard to

--- a/tests/test_material_deposition.cc
+++ b/tests/test_material_deposition.cc
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE(material_deposition)
   // Build MaterialProperty
   boost::property_tree::ptree material_property_database =
       database.get_child("materials");
-  adamantine::MaterialProperty<dim, 1, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<dim, 1, 1, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Host>
       material_properties(communicator, geometry.get_triangulation(),
                           material_property_database);
@@ -319,7 +319,7 @@ BOOST_AUTO_TEST_CASE(material_deposition)
   database.put("time_stepping.method", "forward_euler");
 
   // Build ThermalPhysics
-  adamantine::ThermalPhysics<dim, 1, dim, adamantine::SolidLiquidPowder,
+  adamantine::ThermalPhysics<dim, 1, 1, dim, adamantine::SolidLiquidPowder,
                              dealii::MemorySpace::Host, dealii::QGauss<1>>
       thermal_physics(communicator, database, geometry, boundary,
                       material_properties);

--- a/tests/test_material_property.hh
+++ b/tests/test_material_property.hh
@@ -53,7 +53,7 @@ void material_property()
   database.put("material_0.liquidus", "100");
   database.put("material_0.solid.lame_first_parameter", 2.);
   database.put("material_0.solid.lame_second_parameter", 3.);
-  adamantine::MaterialProperty<2, 2, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<2, 1, 2, adamantine::SolidLiquidPowder,
                                MemorySpaceType>
       mat_prop(communicator, triangulation, database);
   // Evaluate the material property at the given temperature
@@ -134,7 +134,7 @@ void ratios()
   database.put("material_0.solidus", "50");
   database.put("material_0.liquidus", "100");
   database.put("material_0.latent_heat", "1000");
-  adamantine::MaterialProperty<2, 0, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<2, 1, 0, adamantine::SolidLiquidPowder,
                                MemorySpaceType>
       mat_prop(communicator, triangulation, database);
   dealii::LinearAlgebra::distributed::Vector<double, MemorySpaceType>
@@ -297,7 +297,7 @@ void material_property_table()
   // Create the MaterialProperty
   boost::property_tree::ptree material_database =
       database.get_child("materials");
-  adamantine::MaterialProperty<2, 0, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<2, -1, 0, adamantine::SolidLiquidPowder,
                                MemorySpaceType>
       mat_prop(communicator, triangulation, material_database);
   // Evaluate the material property at the given temperature
@@ -401,7 +401,7 @@ void material_property_polynomials()
   // Create the MaterialProperty
   boost::property_tree::ptree material_database =
       database.get_child("materials");
-  adamantine::MaterialProperty<2, 4, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<2, -1, 4, adamantine::SolidLiquidPowder,
                                MemorySpaceType>
       mat_prop(communicator, triangulation, material_database);
   // Evaluate the material property at the given temperature

--- a/tests/test_mechanical_operator.cc
+++ b/tests/test_mechanical_operator.cc
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(elastostatic, *utf::tolerance(1e-12))
   double const lame_second = 3.;
   material_database.put("material_0.solid.lame_first_parameter", lame_first);
   material_database.put("material_0.solid.lame_second_parameter", lame_second);
-  adamantine::MaterialProperty<dim, 4, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<dim, 1, 4, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Host>
       material_properties(communicator, triangulation, material_database);
   // Create the DoFHandler
@@ -101,12 +101,12 @@ BOOST_AUTO_TEST_CASE(elastostatic, *utf::tolerance(1e-12))
 
   std::vector<double> empty_vector;
 
-  adamantine::MechanicalOperator<dim, 4, adamantine::SolidLiquidPowder,
+  adamantine::MechanicalOperator<dim, 1, 4, adamantine::SolidLiquidPowder,
                                  dealii::MemorySpace::Host>
       mechanical_operator(communicator, material_properties, empty_vector);
   std::vector<std::shared_ptr<adamantine::BodyForce<dim>>> body_forces;
   auto gravity_force = std::make_shared<adamantine::GravityForce<
-      dim, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>>(
+      dim, 1, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>>(
       material_properties);
   body_forces.push_back(gravity_force);
   mechanical_operator.reinit(dof_handler, affine_constraints, q_collection,
@@ -266,7 +266,7 @@ BOOST_AUTO_TEST_CASE(thermoelastic, *utf::tolerance(1e-12))
   double const lame_second = 3.;
   material_database.put("material_0.solid.lame_first_parameter", lame_first);
   material_database.put("material_0.solid.lame_second_parameter", lame_second);
-  adamantine::MaterialProperty<dim, 4, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<dim, -1, 4, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Host>
       material_properties(communicator, triangulation, material_database);
   // Create the thermal DoFHandler
@@ -304,7 +304,7 @@ BOOST_AUTO_TEST_CASE(thermoelastic, *utf::tolerance(1e-12))
   temperature = 1.;
   // Create the MechanicalOperator
   std::vector<double> reference_temperatures = {0.0, 0.0};
-  adamantine::MechanicalOperator<dim, 4, adamantine::SolidLiquidPowder,
+  adamantine::MechanicalOperator<dim, -1, 4, adamantine::SolidLiquidPowder,
                                  dealii::MemorySpace::Host>
       mechanical_operator(communicator, material_properties,
                           reference_temperatures);
@@ -313,7 +313,7 @@ BOOST_AUTO_TEST_CASE(thermoelastic, *utf::tolerance(1e-12))
                                          has_melted);
   std::vector<std::shared_ptr<adamantine::BodyForce<dim>>> body_forces;
   auto gravity_force = std::make_shared<adamantine::GravityForce<
-      dim, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>>(
+      dim, -1, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>>(
       material_properties);
   body_forces.push_back(gravity_force);
   mechanical_operator.reinit(mechanical_dof_handler,

--- a/tests/test_mechanical_physics.cc
+++ b/tests/test_mechanical_physics.cc
@@ -224,7 +224,7 @@ BOOST_AUTO_TEST_CASE(elastostatic)
   material_database.put("material_0.solid.density", 1.);
   material_database.put("material_0.solid.lame_first_parameter", 2.);
   material_database.put("material_0.solid.lame_second_parameter", 3.);
-  adamantine::MaterialProperty<3, 4, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<3, 1, 4, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Host>
       material_properties(communicator, triangulation, material_database);
   // Create the Boundary
@@ -235,13 +235,13 @@ BOOST_AUTO_TEST_CASE(elastostatic)
   // Build MechanicalPhysics
   unsigned int const fe_degree = 1;
   std::vector<double> empty_vector;
-  adamantine::MechanicalPhysics<3, 4, adamantine::SolidLiquidPowder,
+  adamantine::MechanicalPhysics<3, 1, 4, adamantine::SolidLiquidPowder,
                                 dealii::MemorySpace::Host>
       mechanical_physics(communicator, fe_degree, geometry, boundary,
                          material_properties, empty_vector);
   std::vector<std::shared_ptr<adamantine::BodyForce<3>>> body_forces;
   auto gravity_force = std::make_shared<adamantine::GravityForce<
-      3, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>>(
+      3, 1, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>>(
       material_properties);
   body_forces.push_back(gravity_force);
   mechanical_physics.setup_dofs(body_forces);
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(fe_nothing)
   material_database.put("material_0.solid.density", 1.);
   material_database.put("material_0.solid.lame_first_parameter", 2.);
   material_database.put("material_0.solid.lame_second_parameter", 3.);
-  adamantine::MaterialProperty<3, 2, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<3, 1, 2, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Host>
       material_properties(communicator, triangulation, material_database);
   // Create the Boundary
@@ -313,13 +313,13 @@ BOOST_AUTO_TEST_CASE(fe_nothing)
   // Build MechanicalPhysics
   unsigned int const fe_degree = 1;
   std::vector<double> empty_vector;
-  adamantine::MechanicalPhysics<3, 2, adamantine::SolidLiquidPowder,
+  adamantine::MechanicalPhysics<3, 1, 2, adamantine::SolidLiquidPowder,
                                 dealii::MemorySpace::Host>
       mechanical_physics(communicator, fe_degree, geometry, boundary,
                          material_properties, empty_vector);
   std::vector<std::shared_ptr<adamantine::BodyForce<3>>> body_forces;
   auto gravity_force = std::make_shared<adamantine::GravityForce<
-      3, 2, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>>(
+      3, 1, 2, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>>(
       material_properties);
   body_forces.push_back(gravity_force);
   mechanical_physics.setup_dofs(body_forces);
@@ -447,7 +447,7 @@ run_eshelby(std::vector<dealii::Point<dim>> pts, unsigned int refinement_cycles)
 
   double const alpha = 0.01;
   material_database.put("material_0.solid.thermal_expansion_coef", alpha);
-  adamantine::MaterialProperty<dim, 3, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<dim, -1, 3, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Host>
       material_properties(communicator, triangulation, material_database);
 
@@ -470,7 +470,7 @@ run_eshelby(std::vector<dealii::Point<dim>> pts, unsigned int refinement_cycles)
   database.put("sources.beam_0.scan_path_file",
                "scan_path_test_thermal_physics.txt");
   database.put("sources.beam_0.scan_path_file_format", "segment");
-  adamantine::ThermalPhysics<dim, 3, 1, adamantine::SolidLiquidPowder,
+  adamantine::ThermalPhysics<dim, -1, 3, 1, adamantine::SolidLiquidPowder,
                              dealii::MemorySpace::Host, dealii::QGauss<1>>
       thermal_physics(communicator, database, geometry, boundary,
                       material_properties);
@@ -485,7 +485,7 @@ run_eshelby(std::vector<dealii::Point<dim>> pts, unsigned int refinement_cycles)
   // Build MechanicalPhysics
   unsigned int const fe_degree = 1;
   std::vector<double> initial_temperature = {2.0};
-  adamantine::MechanicalPhysics<3, 3, adamantine::SolidLiquidPowder,
+  adamantine::MechanicalPhysics<3, -1, 3, adamantine::SolidLiquidPowder,
                                 dealii::MemorySpace::Host>
       mechanical_physics(communicator, fe_degree, geometry, boundary,
                          material_properties, initial_temperature);
@@ -590,7 +590,7 @@ BOOST_AUTO_TEST_CASE(elastoplastic)
   material_database.put("material_0.solid.plastic_modulus", 1.5);
   material_database.put("material_0.solid.isotropic_hardening", 0.5);
   material_database.put("material_0.solid.elastic_limit", 0.1);
-  adamantine::MaterialProperty<3, 4, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<3, 1, 4, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Host>
       material_properties(communicator, triangulation, material_database);
   // Create the Boundary
@@ -601,13 +601,13 @@ BOOST_AUTO_TEST_CASE(elastoplastic)
   // Build MechanicalPhysics
   unsigned int const fe_degree = 1;
   std::vector<double> empty_vector;
-  adamantine::MechanicalPhysics<3, 4, adamantine::SolidLiquidPowder,
+  adamantine::MechanicalPhysics<3, 1, 4, adamantine::SolidLiquidPowder,
                                 dealii::MemorySpace::Host>
       mechanical_physics(communicator, fe_degree, geometry, boundary,
                          material_properties, empty_vector);
   std::vector<std::shared_ptr<adamantine::BodyForce<3>>> body_forces;
   auto gravity_force = std::make_shared<adamantine::GravityForce<
-      3, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>>(
+      3, 1, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>>(
       material_properties);
   body_forces.push_back(gravity_force);
   mechanical_physics.setup_dofs(body_forces);

--- a/tests/test_microstructure.cc
+++ b/tests/test_microstructure.cc
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(G_and_R)
   material_property_database.put("material_0.liquid.thermal_conductivity_z",
                                  1.);
   material_property_database.put("material_0.liquidus", 100.);
-  adamantine::MaterialProperty<2, 4, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<2, 1, 4, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Host>
       material_properties(communicator, geometry.get_triangulation(),
                           material_property_database);
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(G_and_R)
   database.put("time_stepping.method", "rk_fourth_order");
 
   // Build ThermalPhysics
-  adamantine::ThermalPhysics<2, 4, 2, adamantine::SolidLiquidPowder,
+  adamantine::ThermalPhysics<2, 1, 4, 2, adamantine::SolidLiquidPowder,
                              dealii::MemorySpace::Host, dealii::QGauss<1>>
       physics(communicator, database, geometry, boundary, material_properties);
   physics.setup();

--- a/tests/test_post_processor.cc
+++ b/tests/test_post_processor.cc
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(thermal_post_processor)
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 10.);
-  adamantine::MaterialProperty<2, 0, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<2, 1, 0, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Host>
       mat_properties(communicator, geometry.get_triangulation(),
                      mat_prop_database);
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(thermal_post_processor)
       beam_database, units_optional_database);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperator<2, false, 0, 2, adamantine::SolidLiquidPowder,
+  adamantine::ThermalOperator<2, 1, false, 0, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
       thermal_operator(communicator, boundary, mat_properties, heat_sources);
   std::vector<double> deposition_cos(
@@ -198,14 +198,14 @@ BOOST_AUTO_TEST_CASE(mechanical_post_processor)
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 10.);
   mat_prop_database.put("material_0.solid.lame_first_parameter", 2.);
   mat_prop_database.put("material_0.solid.lame_second_parameter", 3.);
-  adamantine::MaterialProperty<dim, 0, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<dim, 1, 0, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Host>
       mat_properties(communicator, geometry.get_triangulation(),
                      mat_prop_database);
 
   std::vector<double> empty_vector;
 
-  adamantine::MechanicalOperator<dim, 0, adamantine::SolidLiquidPowder,
+  adamantine::MechanicalOperator<dim, 1, 0, adamantine::SolidLiquidPowder,
                                  dealii::MemorySpace::Host>
       mechanical_operator(communicator, mat_properties, empty_vector);
   mechanical_operator.reinit(dof_handler, affine_constraints, q_collection);

--- a/tests/test_thermal_operator.cc
+++ b/tests/test_thermal_operator.cc
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(thermal_operator, *utf::tolerance(1e-15))
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 10.);
-  adamantine::MaterialProperty<2, 1, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<2, 1, 1, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Host>
       mat_properties(communicator, geometry.get_triangulation(),
                      mat_prop_database);
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(thermal_operator, *utf::tolerance(1e-15))
   heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperator<2, false, 1, 2, adamantine::SolidLiquidPowder,
+  adamantine::ThermalOperator<2, 1, false, 1, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
       thermal_operator(communicator, boundary, mat_properties, heat_sources);
   std::vector<double> deposition_cos(
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(spmv, *utf::tolerance(1e-12))
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 1.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 1.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 1.);
-  adamantine::MaterialProperty<2, 2, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<2, -1, 2, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Host>
       mat_properties(communicator, geometry.get_triangulation(),
                      mat_prop_database);
@@ -213,7 +213,7 @@ BOOST_AUTO_TEST_CASE(spmv, *utf::tolerance(1e-12))
   heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperator<2, false, 2, 2, adamantine::SolidLiquidPowder,
+  adamantine::ThermalOperator<2, -1, false, 2, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
       thermal_operator(communicator, boundary, mat_properties, heat_sources);
   std::vector<double> deposition_cos(
@@ -311,7 +311,7 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic, *utf::tolerance(1e-12))
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 0.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 1.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 0.);
-  adamantine::MaterialProperty<2, 2, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<2, 1, 2, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Host>
       mat_properties(communicator, geometry.get_triangulation(),
                      mat_prop_database);
@@ -331,7 +331,7 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic, *utf::tolerance(1e-12))
   heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperator<2, false, 2, 2, adamantine::SolidLiquidPowder,
+  adamantine::ThermalOperator<2, 1, false, 2, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
       thermal_operator(communicator, boundary, mat_properties, heat_sources);
   std::vector<double> deposition_cos(
@@ -469,7 +469,7 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic_angle, *utf::tolerance(1e-10))
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", th_cond_x);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_y", th_cond_y);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", th_cond_z);
-  adamantine::MaterialProperty<3, 1, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<3, 1, 1, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Host>
       mat_properties(communicator, geometry.get_triangulation(),
                      mat_prop_database);
@@ -478,7 +478,7 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic_angle, *utf::tolerance(1e-10))
   std::vector<std::shared_ptr<adamantine::HeatSource<3>>> heat_sources;
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperator<3, false, 1, 2, adamantine::SolidLiquidPowder,
+  adamantine::ThermalOperator<3, 1, false, 1, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
       thermal_operator(communicator, boundary, mat_properties, heat_sources);
   double constexpr deposition_angle = M_PI / 6.;
@@ -635,7 +635,7 @@ BOOST_AUTO_TEST_CASE(spmv_rad, *utf::tolerance(1e-12))
   mat_prop_database.put("material_0.liquid.convection_heat_transfer_coef", 1.);
   mat_prop_database.put("material_0.radiation_temperature_infty", 0.0);
   mat_prop_database.put("material_0.convection_temperature_infty", 0.0);
-  adamantine::MaterialProperty<2, 1, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<2, -1, 1, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Host>
       mat_properties(communicator, geometry.get_triangulation(),
                      mat_prop_database);
@@ -655,7 +655,7 @@ BOOST_AUTO_TEST_CASE(spmv_rad, *utf::tolerance(1e-12))
   heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperator<2, false, 1, 2, adamantine::SolidLiquidPowder,
+  adamantine::ThermalOperator<2, -1, false, 1, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
       thermal_operator(communicator, boundary, mat_properties, heat_sources);
   std::vector<double> deposition_cos(
@@ -827,7 +827,7 @@ BOOST_AUTO_TEST_CASE(spmv_conv, *utf::tolerance(1e-12))
   mat_prop_database.put("material_0.liquid.convection_heat_transfer_coef", 1.);
   mat_prop_database.put("material_0.radiation_temperature_infty", 0.0);
   mat_prop_database.put("material_0.convection_temperature_infty", 0.0);
-  adamantine::MaterialProperty<2, 1, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<2, 1, 1, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Host>
       mat_properties(communicator, geometry.get_triangulation(),
                      mat_prop_database);
@@ -847,7 +847,7 @@ BOOST_AUTO_TEST_CASE(spmv_conv, *utf::tolerance(1e-12))
   heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperator<2, false, 1, 2, adamantine::SolidLiquidPowder,
+  adamantine::ThermalOperator<2, 1, false, 1, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
       thermal_operator(communicator, boundary, mat_properties, heat_sources);
   std::vector<double> deposition_cos(

--- a/tests/test_thermal_operator_device.cc
+++ b/tests/test_thermal_operator_device.cc
@@ -77,13 +77,13 @@ BOOST_AUTO_TEST_CASE(thermal_operator_dev, *utf::tolerance(1e-10))
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 10.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 10.);
-  adamantine::MaterialProperty<2, 0, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<2, 1, 0, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Default>
       mat_properties(communicator, geometry.get_triangulation(),
                      mat_prop_database);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperatorDevice<2, false, 0, 2,
+  adamantine::ThermalOperatorDevice<2, 1, false, 0, 2,
                                     adamantine::SolidLiquidPowder,
                                     dealii::MemorySpace::Default>
       thermal_operator_dev(communicator, boundary, mat_properties);
@@ -170,13 +170,13 @@ BOOST_AUTO_TEST_CASE(spmv, *utf::tolerance(1e-12))
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 1.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 1.);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 1.);
-  adamantine::MaterialProperty<2, 3, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<2, 1, 3, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Default>
       mat_properties(communicator, geometry.get_triangulation(),
                      mat_prop_database);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperatorDevice<2, false, 3, 2,
+  adamantine::ThermalOperatorDevice<2, 1, false, 3, 2,
                                     adamantine::SolidLiquidPowder,
                                     dealii::MemorySpace::Default>
       thermal_operator_dev(communicator, boundary, mat_properties);
@@ -283,11 +283,11 @@ BOOST_AUTO_TEST_CASE(mf_spmv, *utf::tolerance(1.5e-12))
   mat_prop_database.put("material_0.powder.thermal_conductivity_z", 0.266);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", 0.266);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", 0.266);
-  adamantine::MaterialProperty<2, 4, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<2, -1, 4, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Host>
       mat_properties_host(communicator, geometry.get_triangulation(),
                           mat_prop_database);
-  adamantine::MaterialProperty<2, 4, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<2, -1, 4, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Default>
       mat_properties(communicator, geometry.get_triangulation(),
                      mat_prop_database);
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(mf_spmv, *utf::tolerance(1.5e-12))
   heat_sources[0]->update_time(0.);
 
   // Initialize the ThermalOperator
-  adamantine::ThermalOperatorDevice<2, false, 4, 2,
+  adamantine::ThermalOperatorDevice<2, -1, false, 4, 2,
                                     adamantine::SolidLiquidPowder,
                                     dealii::MemorySpace::Default>
       thermal_operator_dev(communicator, boundary, mat_properties);
@@ -323,7 +323,7 @@ BOOST_AUTO_TEST_CASE(mf_spmv, *utf::tolerance(1.5e-12))
   thermal_operator_dev.get_state_from_material_properties();
   BOOST_TEST(thermal_operator_dev.m() == thermal_operator_dev.n());
 
-  adamantine::ThermalOperator<2, false, 4, 2, adamantine::SolidLiquidPowder,
+  adamantine::ThermalOperator<2, -1, false, 4, 2, adamantine::SolidLiquidPowder,
                               dealii::MemorySpace::Host>
       thermal_operator_host(communicator, boundary, mat_properties_host,
                             heat_sources);
@@ -429,13 +429,13 @@ BOOST_AUTO_TEST_CASE(spmv_anisotropic_angle, *utf::tolerance(1e-10))
   mat_prop_database.put("material_0.liquid.thermal_conductivity_x", th_cond_x);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_y", th_cond_y);
   mat_prop_database.put("material_0.liquid.thermal_conductivity_z", th_cond_z);
-  adamantine::MaterialProperty<3, 3, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<3, -1, 3, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Default>
       mat_properties(communicator, geometry.get_triangulation(),
                      mat_prop_database);
 
   // Initialize the ThermalOperatorDevice
-  adamantine::ThermalOperatorDevice<3, false, 3, 2,
+  adamantine::ThermalOperatorDevice<3, -1, false, 3, 2,
                                     adamantine::SolidLiquidPowder,
                                     dealii::MemorySpace::Default>
       thermal_operator_dev(communicator, boundary, mat_properties);

--- a/tests/test_thermal_physics.hh
+++ b/tests/test_thermal_physics.hh
@@ -116,7 +116,7 @@ void thermal_2d(boost::property_tree::ptree &database, double time_step)
   material_property_database.put("material_0.liquid.thermal_conductivity_z",
                                  1.);
   // Build MaterialProperty
-  adamantine::MaterialProperty<2, 2, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<2, 1, 2, adamantine::SolidLiquidPowder,
                                MemorySpaceType>
       material_properties(communicator, geometry.get_triangulation(),
                           material_property_database);
@@ -132,7 +132,7 @@ void thermal_2d(boost::property_tree::ptree &database, double time_step)
   database.put("sources.beam_0.scan_path_file_format", "segment");
 
   // Build ThermalPhysics
-  adamantine::ThermalPhysics<2, 2, 2, adamantine::SolidLiquidPowder,
+  adamantine::ThermalPhysics<2, 1, 2, 2, adamantine::SolidLiquidPowder,
                              MemorySpaceType, dealii::QGauss<1>>
       physics(communicator, database, geometry, boundary, material_properties);
   physics.setup();
@@ -197,7 +197,7 @@ void thermal_2d_manufactured_solution()
   material_property_database.put("material_0.liquid.thermal_conductivity_z",
                                  1.);
   // Build MaterialProperty
-  adamantine::MaterialProperty<2, 1, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<2, 1, 1, adamantine::SolidLiquidPowder,
                                MemorySpaceType>
       material_properties(communicator, geometry.get_triangulation(),
                           material_property_database);
@@ -218,7 +218,7 @@ void thermal_2d_manufactured_solution()
   // Time-stepping database
   database.put("time_stepping.method", "rk_fourth_order");
   // Build ThermalPhysics
-  adamantine::ThermalPhysics<2, 1, 2, adamantine::SolidLiquidPowder,
+  adamantine::ThermalPhysics<2, 1, 1, 2, adamantine::SolidLiquidPowder,
                              MemorySpaceType, dealii::QGauss<1>>
       physics(communicator, database, geometry, boundary, material_properties);
   physics.setup();
@@ -263,7 +263,7 @@ void initial_temperature()
 
   // Build MaterialProperty
   auto material_property_database = basic_material_properies_database();
-  adamantine::MaterialProperty<2, 4, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<2, -1, 4, adamantine::SolidLiquidPowder,
                                MemorySpaceType>
       material_properties(communicator, geometry.get_triangulation(),
                           material_property_database);
@@ -277,7 +277,7 @@ void initial_temperature()
       geometry.get_triangulation().get_boundary_ids());
 
   // Build ThermalPhysics
-  adamantine::ThermalPhysics<2, 4, 2, adamantine::SolidLiquidPowder,
+  adamantine::ThermalPhysics<2, -1, 4, 2, adamantine::SolidLiquidPowder,
                              MemorySpaceType, dealii::QGauss<1>>
       physics(communicator, database, geometry, boundary, material_properties);
   physics.setup();
@@ -329,7 +329,7 @@ void energy_conservation()
   material_property_database.put("material_0.liquid.thermal_conductivity_z",
                                  2.);
   // Build MaterialProperty
-  adamantine::MaterialProperty<2, 0, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<2, 1, 0, adamantine::SolidLiquidPowder,
                                MemorySpaceType>
       material_properties(communicator, geometry.get_triangulation(),
                           material_property_database);
@@ -347,7 +347,7 @@ void energy_conservation()
   // Time-stepping database
   database.put("time_stepping.method", "forward_euler");
   // Build ThermalPhysics
-  adamantine::ThermalPhysics<2, 0, 2, adamantine::SolidLiquidPowder,
+  adamantine::ThermalPhysics<2, 1, 0, 2, adamantine::SolidLiquidPowder,
                              MemorySpaceType, dealii::QGauss<1>>
       physics(communicator, database, geometry, boundary, material_properties);
   physics.setup();
@@ -456,7 +456,7 @@ void radiation_bcs()
   material_property_database.put("material_0.convection_temperature_infty",
                                  0.0);
   // Build MaterialProperty
-  adamantine::MaterialProperty<2, 1, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<2, 1, 1, adamantine::SolidLiquidPowder,
                                MemorySpaceType>
       material_properties(communicator, geometry.get_triangulation(),
                           material_property_database);
@@ -466,7 +466,7 @@ void radiation_bcs()
   // Time-stepping database
   database.put("time_stepping.method", "forward_euler");
   // Build ThermalPhysics
-  adamantine::ThermalPhysics<2, 1, 2, adamantine::SolidLiquidPowder,
+  adamantine::ThermalPhysics<2, 1, 1, 2, adamantine::SolidLiquidPowder,
                              dealii::MemorySpace::Host, dealii::QGauss<1>>
       physics(communicator, database, geometry, boundary, material_properties);
   physics.setup();
@@ -569,7 +569,7 @@ void convection_bcs()
   material_property_database.put("material_0.convection_temperature_infty",
                                  300.0);
   // Build MaterialProperty
-  adamantine::MaterialProperty<3, 0, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<3, -1, 0, adamantine::SolidLiquidPowder,
                                MemorySpaceType>
       material_properties(communicator, geometry.get_triangulation(),
                           material_property_database);
@@ -579,7 +579,7 @@ void convection_bcs()
   // Time-stepping database
   database.put("time_stepping.method", "forward_euler");
   // Build ThermalPhysics
-  adamantine::ThermalPhysics<3, 0, 2, adamantine::SolidLiquidPowder,
+  adamantine::ThermalPhysics<3, -1, 0, 2, adamantine::SolidLiquidPowder,
                              MemorySpaceType, dealii::QGauss<1>>
       physics(communicator, database, geometry, boundary, material_properties);
   physics.setup();
@@ -639,7 +639,7 @@ void reference_temperature()
 
   // Build MaterialProperty
   auto material_property_database = basic_material_properies_database();
-  adamantine::MaterialProperty<2, 4, adamantine::SolidLiquidPowder,
+  adamantine::MaterialProperty<2, -1, 4, adamantine::SolidLiquidPowder,
                                MemorySpaceType>
       material_properties(communicator, geometry.get_triangulation(),
                           material_property_database);
@@ -653,7 +653,7 @@ void reference_temperature()
       geometry.get_triangulation().get_boundary_ids());
 
   // Build ThermalPhysics
-  adamantine::ThermalPhysics<2, 4, 2, adamantine::SolidLiquidPowder,
+  adamantine::ThermalPhysics<2, -1, 4, 2, adamantine::SolidLiquidPowder,
                              MemorySpaceType, dealii::QGauss<1>>
       physics(communicator, database, geometry, boundary, material_properties);
   physics.setup();


### PR DESCRIPTION
The vast majority of the cases we are running only use a single material. This PR creates a special case when we use only one material to use Kokkos::Views with all the dimensions set at compile time. In a followup PR, we will take advantage of this.