### PR TITLE
Remove source height variable

### DIFF
--- a/source/CubeHeatSource.cc
+++ b/source/CubeHeatSource.cc
@@ -49,8 +49,7 @@ void CubeHeatSource<dim>::update_time(double time)
 }
 
 template <int dim>
-double CubeHeatSource<dim>::value(dealii::Point<dim> const &point,
-                                  double const /*height*/) const
+double CubeHeatSource<dim>::value(dealii::Point<dim> const &point) const
 {
   if (_source_on)
   {
@@ -73,8 +72,7 @@ double CubeHeatSource<dim>::value(dealii::Point<dim> const &point,
 
 template <int dim>
 dealii::VectorizedArray<double> CubeHeatSource<dim>::value(
-    dealii::Point<dim, dealii::VectorizedArray<double>> const &points,
-    dealii::VectorizedArray<double> const & /*height*/) const
+    dealii::Point<dim, dealii::VectorizedArray<double>> const &points) const
 {
   dealii::VectorizedArray<double> mask = 0.;
 
@@ -106,12 +104,6 @@ dealii::VectorizedArray<double> CubeHeatSource<dim>::value(
   }
 
   return mask * _value;
-}
-
-template <int dim>
-double CubeHeatSource<dim>::get_current_height(double const /*time*/) const
-{
-  return _max_point[axis<dim>::z];
 }
 
 template <int dim>

--- a/source/CubeHeatSource.hh
+++ b/source/CubeHeatSource.hh
@@ -45,21 +45,14 @@ public:
   /**
    * Return the value of the source for a given point and time.
    */
-  double value(dealii::Point<dim> const &point,
-               double const /*height*/) const final;
+  double value(dealii::Point<dim> const &point) const final;
 
   /**
    * Same function as above but it uses vectorized data.
    */
   dealii::VectorizedArray<double>
-  value(dealii::Point<dim, dealii::VectorizedArray<double>> const &points,
-        dealii::VectorizedArray<double> const & /*height*/) const final;
-
-  /**
-   * Compute the current height of the where the heat source meets the material
-   * (i.e. the current scan path height).
-   */
-  double get_current_height(double const time) const final;
+  value(dealii::Point<dim, dealii::VectorizedArray<double>> const &points)
+      const final;
 
   dealii::BoundingBox<dim>
   get_bounding_box(double const time, double const scaling_factor) const final;

--- a/source/ElectronBeamHeatSource.cc
+++ b/source/ElectronBeamHeatSource.cc
@@ -37,10 +37,9 @@ void ElectronBeamHeatSource<dim>::update_time(double time)
 }
 
 template <int dim>
-double ElectronBeamHeatSource<dim>::value(dealii::Point<dim> const &point,
-                                          double const height) const
+double ElectronBeamHeatSource<dim>::value(dealii::Point<dim> const &point) const
 {
-  double const z = point[axis<dim>::z] - height;
+  double const z = point[axis<dim>::z] - _beam_center[axis<dim>::z][0];
   if ((z + this->_beam.depth) < 0.)
   {
     return 0.;
@@ -77,10 +76,9 @@ double ElectronBeamHeatSource<dim>::value(dealii::Point<dim> const &point,
 
 template <int dim>
 dealii::VectorizedArray<double> ElectronBeamHeatSource<dim>::value(
-    dealii::Point<dim, dealii::VectorizedArray<double>> const &points,
-    dealii::VectorizedArray<double> const &height) const
+    dealii::Point<dim, dealii::VectorizedArray<double>> const &points) const
 {
-  auto const z = points[axis<dim>::z] - height;
+  auto const z = points[axis<dim>::z] - _beam_center[axis<dim>::z];
   auto const z_depth = z + _depth;
   dealii::VectorizedArray<double> depth_mask;
   for (unsigned int i = 0; i < depth_mask.size(); ++i)

--- a/source/ElectronBeamHeatSource.hh
+++ b/source/ElectronBeamHeatSource.hh
@@ -47,15 +47,14 @@ public:
    * Returns the value of an electron beam heat source at a specified point and
    * time.
    */
-  double value(dealii::Point<dim> const &point,
-               double const height) const final;
+  double value(dealii::Point<dim> const &point) const final;
 
   /**
    * Same function as above but it uses vectorized data.
    */
   dealii::VectorizedArray<double>
-  value(dealii::Point<dim, dealii::VectorizedArray<double>> const &points,
-        dealii::VectorizedArray<double> const &height) const final;
+  value(dealii::Point<dim, dealii::VectorizedArray<double>> const &points)
+      const final;
 
   dealii::BoundingBox<dim>
   get_bounding_box(double const time, double const scaling_factor) const final;

--- a/source/GoldakHeatSource.cc
+++ b/source/GoldakHeatSource.cc
@@ -36,10 +36,9 @@ void GoldakHeatSource<dim>::update_time(double time)
 }
 
 template <int dim>
-double GoldakHeatSource<dim>::value(dealii::Point<dim> const &point,
-                                    double const height) const
+double GoldakHeatSource<dim>::value(dealii::Point<dim> const &point) const
 {
-  double const z = point[axis<dim>::z] - height;
+  double const z = point[axis<dim>::z] - _beam_center[axis<dim>::z][0];
   if ((z + this->_beam.depth) < 0.)
   {
     return 0.;
@@ -72,10 +71,9 @@ double GoldakHeatSource<dim>::value(dealii::Point<dim> const &point,
 
 template <int dim>
 dealii::VectorizedArray<double> GoldakHeatSource<dim>::value(
-    dealii::Point<dim, dealii::VectorizedArray<double>> const &points,
-    dealii::VectorizedArray<double> const &height) const
+    dealii::Point<dim, dealii::VectorizedArray<double>> const &points) const
 {
-  auto const z = points[axis<dim>::z] - height;
+  auto const z = points[axis<dim>::z] - _beam_center[axis<dim>::z];
   auto const z_depth = z + _depth;
   dealii::VectorizedArray<double> depth_mask;
   for (unsigned int i = 0; i < depth_mask.size(); ++i)

--- a/source/GoldakHeatSource.hh
+++ b/source/GoldakHeatSource.hh
@@ -46,15 +46,14 @@ public:
    * Returns the value of a Goldak heat source at a specified point and
    * time.
    */
-  double value(dealii::Point<dim> const &point,
-               double const height) const final;
+  double value(dealii::Point<dim> const &point) const final;
 
   /**
    * Same function as above but it uses vectorized data.
    */
   dealii::VectorizedArray<double>
-  value(dealii::Point<dim, dealii::VectorizedArray<double>> const &points,
-        dealii::VectorizedArray<double> const &height) const final;
+  value(dealii::Point<dim, dealii::VectorizedArray<double>> const &points)
+      const final;
 
   dealii::BoundingBox<dim>
   get_bounding_box(double time, double const scaling_factor) const final;

--- a/source/HeatSource.hh
+++ b/source/HeatSource.hh
@@ -74,28 +74,20 @@ public:
   virtual void update_time(double time) = 0;
 
   /**
-   * Compute the heat source at a given point at a given time given the current
-   * height of the object being manufactured.
+   * Compute the heat source at a given point at a given time
    */
-  virtual double value(dealii::Point<dim> const &points,
-                       double const height) const = 0;
+  virtual double value(dealii::Point<dim> const &points) const = 0;
 
   /**
    * Same function as above but it uses vectorized data.
    */
   virtual dealii::VectorizedArray<double>
-  value(dealii::Point<dim, dealii::VectorizedArray<double>> const &points,
-        dealii::VectorizedArray<double> const &height) const = 0;
+  value(dealii::Point<dim, dealii::VectorizedArray<double>> const &points)
+      const = 0;
   /**
    * Return the scan path for the heat source.
    */
   virtual ScanPath &get_scan_path();
-
-  /**
-   * Compute the current height of the where the heat source meets the material
-   * (i.e. the current scan path height).
-   */
-  virtual double get_current_height(double const time) const;
 
   /**
    * (Re)sets the BeamHeatSourceProperties member variable, necessary if the
@@ -125,12 +117,6 @@ template <int dim>
 inline ScanPath &HeatSource<dim>::get_scan_path()
 {
   return _scan_path;
-}
-
-template <int dim>
-inline double HeatSource<dim>::get_current_height(double const time) const
-{
-  return _scan_path.value(time)[2];
 }
 
 template <int dim>

--- a/source/ThermalOperator.hh
+++ b/source/ThermalOperator.hh
@@ -91,7 +91,7 @@ public:
       std::vector<double> const &deposition_cos,
       std::vector<double> const &deposition_sin) override;
 
-  void set_time_and_source_height(double t, double height) override;
+  void set_time(double t) override;
 
 private:
   /**
@@ -162,10 +162,6 @@ private:
    * false otherwise.
    */
   bool _adiabatic_only_bc = true;
-  /**
-   * Current height of the heat sources.
-   */
-  double _current_source_height = 0.;
   /**
    * Boundary ids associated to the domain.
    */
@@ -295,12 +291,9 @@ inline void ThermalOperator<dim, n_materials, use_table, p_order, fe_degree,
 
 template <int dim, int n_materials, bool use_table, int p_order, int fe_degree,
           typename MaterialStates, typename MemorySpaceType>
-inline void
-ThermalOperator<dim, n_materials, use_table, p_order, fe_degree, MaterialStates,
-                MemorySpaceType>::set_time_and_source_height(double t,
-                                                             double height)
+inline void ThermalOperator<dim, n_materials, use_table, p_order, fe_degree,
+                            MaterialStates, MemorySpaceType>::set_time(double t)
 {
-  _current_source_height = height;
   for (auto &beam : _heat_sources)
     beam->update_time(t);
 }

--- a/source/ThermalOperator.templates.hh
+++ b/source/ThermalOperator.templates.hh
@@ -595,9 +595,8 @@ void ThermalOperator<dim, n_materials, use_table, p_order, fe_degree,
           fe_eval.quadrature_point(q);
 
       dealii::VectorizedArray<double> quad_pt_source = 0.0;
-      dealii::VectorizedArray<double> height = _current_source_height;
       for (auto &beam : _heat_sources)
-        quad_pt_source += beam->value(q_point, height);
+        quad_pt_source += beam->value(q_point);
 
       quad_pt_source *= inv_rho_cp;
 

--- a/source/ThermalOperatorBase.hh
+++ b/source/ThermalOperatorBase.hh
@@ -81,7 +81,7 @@ public:
       std::vector<double> const &deposition_cos,
       std::vector<double> const &deposition_sin) = 0;
 
-  virtual void set_time_and_source_height(double, double) = 0;
+  virtual void set_time(double) = 0;
 };
 } // namespace adamantine
 #endif

--- a/source/ThermalOperatorDevice.hh
+++ b/source/ThermalOperatorDevice.hh
@@ -71,7 +71,7 @@ public:
       std::vector<double> const &deposition_cos,
       std::vector<double> const &deposition_sin) override;
 
-  void set_time_and_source_height(double, double) override
+  void set_time(double) override
   {
     // TODO
   }

--- a/source/ThermalPhysics.hh
+++ b/source/ThermalPhysics.hh
@@ -119,11 +119,6 @@ public:
 
   unsigned int get_fe_degree() const override;
 
-  /**
-   * Return the current height of the heat source.
-   */
-  double get_current_source_height() const;
-
 private:
   using LA_Vector =
       typename dealii::LA::distributed::Vector<double, MemorySpaceType>;
@@ -144,10 +139,6 @@ private:
    * This flag is true if the time stepping method is forward euler.
    */
   bool _forward_euler = false;
-  /**
-   * Current height of the object.
-   */
-  double _current_source_height = 0.;
   /**
    * Associated geometry.
    */
@@ -346,17 +337,6 @@ ThermalPhysics<dim, n_materials, p_order, fe_degree, MaterialStates,
                MemorySpaceType, QuadratureType>::get_fe_degree() const
 {
   return fe_degree;
-}
-
-template <int dim, int n_materials, int p_order, int fe_degree,
-          typename MaterialStates, typename MemorySpaceType,
-          typename QuadratureType>
-inline double
-ThermalPhysics<dim, n_materials, p_order, fe_degree, MaterialStates,
-               MemorySpaceType, QuadratureType>::get_current_source_height()
-    const
-{
-  return _current_source_height;
 }
 } // namespace adamantine
 

--- a/tests/test_heat_source.cc
+++ b/tests/test_heat_source.cc
@@ -33,48 +33,48 @@ BOOST_AUTO_TEST_CASE(heat_source_value_2d, *utf::tolerance(1e-12))
   double g_value = 0.0;
   double eb_value = 0.0;
 
-  dealii::Point<2> point1(0.0, 0.15);
+  dealii::Point<2> point1(0.0, 0.05);
   goldak_heat_source.update_time(1.0e-7);
-  g_value = goldak_heat_source.value(point1, 0.2);
+  g_value = goldak_heat_source.value(point1);
   BOOST_TEST(g_value == 0.0);
 
   eb_heat_source.update_time(1.0e-7);
-  eb_value = eb_heat_source.value(point1, 0.2);
+  eb_value = eb_heat_source.value(point1);
   BOOST_TEST(eb_value == 0.0);
 
   dealii::Point<2> point2(10.0, 0.0);
   goldak_heat_source.update_time(5.0e-7);
-  g_value = goldak_heat_source.value(point2, 0.2);
+  g_value = goldak_heat_source.value(point2);
   BOOST_TEST(g_value == 0.0);
 
   eb_heat_source.update_time(5.0e-7);
-  eb_value = eb_heat_source.value(point2, 0.2);
+  eb_value = eb_heat_source.value(point2);
   BOOST_TEST(eb_value == 0.0);
 
   // Check the beam center 0.001 s into the second segment
-  dealii::Point<2> point3(8.0e-4, 0.2);
+  dealii::Point<2> point3(8.0e-4, 0.1);
   goldak_heat_source.update_time(0.001001);
-  g_value = goldak_heat_source.value(point3, 0.2);
+  g_value = goldak_heat_source.value(point3);
   double pi_over_3_to_1p5 = std::pow(dealii::numbers::PI / 3.0, 1.5);
   double expected_value =
       2.0 * 0.1 * 10.0 / (0.5 * 0.5 * 0.1 * pi_over_3_to_1p5);
   BOOST_TEST(g_value == expected_value);
 
   eb_heat_source.update_time(0.001001);
-  eb_value = eb_heat_source.value(point3, 0.2);
+  eb_value = eb_heat_source.value(point3);
   expected_value = -0.1 * 10. * 1.0 * std::log(0.1) /
                    (dealii::numbers::PI * 0.5 * 0.5 * 0.1) * 1. * 1.;
   BOOST_TEST(eb_value == expected_value);
 
   // Check slightly off beam center 0.001 s into the second segment
-  dealii::Point<2> point4(7.0e-4, 0.19);
-  g_value = goldak_heat_source.value(point4, 0.2);
+  dealii::Point<2> point4(7.0e-4, 0.09);
+  g_value = goldak_heat_source.value(point4);
   expected_value = 2.0 * 0.1 * 10.0 / (0.5 * 0.5 * 0.1 * pi_over_3_to_1p5);
   expected_value *=
       std::exp(-3.0 * 1.0e-4 * 1.0e-4 / 0.25 - 3.0 * 0.01 * 0.01 / 0.1 / 0.1);
   BOOST_TEST(g_value == expected_value);
 
-  eb_value = eb_heat_source.value(point4, 0.2);
+  eb_value = eb_heat_source.value(point4);
   expected_value = -0.1 * 10. * 1.0 * std::log(0.1) /
                    (dealii::numbers::PI * 0.5 * 0.5 * 0.1) *
                    std::exp(std::log(0.1) * 1.0e-4 * 1.0e-4 / 0.25) *
@@ -83,12 +83,12 @@ BOOST_AUTO_TEST_CASE(heat_source_value_2d, *utf::tolerance(1e-12))
 
   // Checking beyond the defined time, where the expected value is zero
   goldak_heat_source.update_time(100.0);
-  g_value = goldak_heat_source.value(point4, 0.2);
+  g_value = goldak_heat_source.value(point4);
   expected_value = 0.0;
   BOOST_TEST(g_value == expected_value);
 
   eb_heat_source.update_time(100.0);
-  eb_value = eb_heat_source.value(point4, 0.2);
+  eb_value = eb_heat_source.value(point4);
   BOOST_TEST(eb_value == expected_value);
 }
 
@@ -114,18 +114,17 @@ BOOST_AUTO_TEST_CASE(heat_source_vectorized_value_2d, *utf::tolerance(1e-12))
   {
     // Put the first point in the first lane
     points[0][0] = 8.0e-4;
-    points[1][0] = 0.2;
+    points[1][0] = 0.1;
     // Put the second point in the second lane
     points[0][1] = 7.0e-4;
-    points[1][1] = 0.19;
+    points[1][1] = 0.09;
     // Fill the other lanes with points outside of the domain
     for (unsigned int i = 2; i < n_lanes; ++i)
     {
       points[0][i] = -1e10;
       points[1][i] = -1e10;
     }
-    auto const values =
-        goldak_heat_source.value(points, dealii::make_vectorized_array(0.2));
+    auto const values = goldak_heat_source.value(points);
 
     double const pi_over_3_to_1p5 = std::pow(dealii::numbers::PI / 3.0, 1.5);
 
@@ -149,9 +148,8 @@ BOOST_AUTO_TEST_CASE(heat_source_vectorized_value_2d, *utf::tolerance(1e-12))
     // Check the first point
     // Only one lane is available
     points[0][0] = 8.0e-4;
-    points[1][0] = 0.2;
-    auto values =
-        goldak_heat_source.value(points, dealii::make_vectorized_array(0.2));
+    points[1][0] = 0.1;
+    auto values = goldak_heat_source.value(points);
 
     double const pi_over_3_to_1p5 = std::pow(dealii::numbers::PI / 3.0, 1.5);
 
@@ -161,9 +159,8 @@ BOOST_AUTO_TEST_CASE(heat_source_vectorized_value_2d, *utf::tolerance(1e-12))
 
     // Check the second point
     points[0][0] = 7.0e-4;
-    points[1][0] = 0.19;
-    values =
-        goldak_heat_source.value(points, dealii::make_vectorized_array(0.2));
+    points[1][0] = 0.09;
+    values = goldak_heat_source.value(points);
     double expected_value_1 =
         2.0 * 0.1 * 10.0 / (0.5 * 0.5 * 0.1 * pi_over_3_to_1p5);
     expected_value_1 *=
@@ -177,8 +174,7 @@ BOOST_AUTO_TEST_CASE(heat_source_vectorized_value_2d, *utf::tolerance(1e-12))
   if (n_lanes > 1)
   {
     // points is correctly initialized. We can just check the values
-    auto const values =
-        eb_heat_source.value(points, dealii::make_vectorized_array(0.2));
+    auto const values = eb_heat_source.value(points);
 
     double const expected_value_0 = -0.1 * 10. * 1.0 * std::log(0.1) /
                                     (dealii::numbers::PI * 0.5 * 0.5 * 0.1);
@@ -201,9 +197,8 @@ BOOST_AUTO_TEST_CASE(heat_source_vectorized_value_2d, *utf::tolerance(1e-12))
     // Check the first point
     // Only one lane is available
     points[0][0] = 8.0e-4;
-    points[1][0] = 0.2;
-    auto values =
-        eb_heat_source.value(points, dealii::make_vectorized_array(0.2));
+    points[1][0] = 0.1;
+    auto values = eb_heat_source.value(points);
 
     double const expected_value_0 = -0.1 * 10. * 1.0 * std::log(0.1) /
                                     (dealii::numbers::PI * 0.5 * 0.5 * 0.1);
@@ -211,8 +206,8 @@ BOOST_AUTO_TEST_CASE(heat_source_vectorized_value_2d, *utf::tolerance(1e-12))
 
     // Check the second point
     points[0][0] = 7.0e-4;
-    points[1][0] = 0.19;
-    values = eb_heat_source.value(points, dealii::make_vectorized_array(0.2));
+    points[1][0] = 0.09;
+    values = eb_heat_source.value(points);
     double const expected_value_1 =
         -0.1 * 10. * 1.0 * std::log(0.1) /
         (dealii::numbers::PI * 0.5 * 0.5 * 0.1) *
@@ -240,47 +235,47 @@ BOOST_AUTO_TEST_CASE(heat_source_value_3d, *utf::tolerance(1e-12))
   double g_value = 0.0;
   double eb_value = 0.0;
 
-  dealii::Point<3> point1(0.0, 0.0, 0.15);
+  dealii::Point<3> point1(0.0, 0.0, 0.05);
   goldak_heat_source.update_time(1.0e-7);
-  g_value = goldak_heat_source.value(point1, 0.2);
+  g_value = goldak_heat_source.value(point1);
   BOOST_TEST(g_value == 0.0);
 
   eb_heat_source.update_time(1.0e-7);
-  eb_value = eb_heat_source.value(point1, 0.2);
+  eb_value = eb_heat_source.value(point1);
   BOOST_TEST(eb_value == 0.0);
 
   dealii::Point<3> point2(10.0, 0.0, 0.0);
   goldak_heat_source.update_time(5.0e-7);
-  g_value = goldak_heat_source.value(point2, 0.2);
+  g_value = goldak_heat_source.value(point2);
   BOOST_TEST(g_value == 0.0);
 
   eb_heat_source.update_time(5.0e-7);
-  eb_value = eb_heat_source.value(point2, 0.2);
+  eb_value = eb_heat_source.value(point2);
   BOOST_TEST(eb_value == 0.0);
 
   // Check the beam center 0.001 s into the second segment
-  dealii::Point<3> point3(8e-4, 0.1, 0.2);
+  dealii::Point<3> point3(8e-4, 0.1, 0.1);
   goldak_heat_source.update_time(0.001001);
-  g_value = goldak_heat_source.value(point3, 0.2);
+  g_value = goldak_heat_source.value(point3);
   double pi_over_3_to_1p5 = std::pow(dealii::numbers::PI / 3.0, 1.5);
   double expected_value = 2.0 * 0.1 * 10.0 / 0.5 / 0.5 / 0.1 / pi_over_3_to_1p5;
   BOOST_TEST(g_value == expected_value);
 
   eb_heat_source.update_time(0.001001);
-  eb_value = eb_heat_source.value(point3, 0.2);
+  eb_value = eb_heat_source.value(point3);
   expected_value = -0.1 * 10. * 1.0 * std::log(0.1) /
                    (dealii::numbers::PI * 0.5 * 0.5 * 0.1) * 1. * 1.;
   BOOST_TEST(eb_value == expected_value);
 
   // Check slightly off beam center 0.001 s into the second segment
-  dealii::Point<3> point4(7.0e-4, 0.1, 0.19);
-  g_value = goldak_heat_source.value(point4, 0.2);
+  dealii::Point<3> point4(7.0e-4, 0.1, 0.09);
+  g_value = goldak_heat_source.value(point4);
   expected_value = 2.0 * 0.1 * 10.0 / (0.5 * 0.5 * 0.1 * pi_over_3_to_1p5);
   expected_value *=
       std::exp(-3.0 * 1.0e-4 * 1.0e-4 / 0.25 - 3.0 * 0.01 * 0.01 / 0.1 / 0.1);
   BOOST_TEST(g_value == expected_value);
 
-  eb_value = eb_heat_source.value(point4, 0.2);
+  eb_value = eb_heat_source.value(point4);
   expected_value = -0.1 * 10. * 1.0 * std::log(0.1) /
                    (dealii::numbers::PI * 0.5 * 0.5 * 0.1) *
                    std::exp(std::log(0.1) * 1.0e-4 * 1.0e-4 / 0.25) *
@@ -311,11 +306,11 @@ BOOST_AUTO_TEST_CASE(heat_source_vectorized_value_3d, *utf::tolerance(1e-12))
     // Put the first point in the first lane
     points[0][0] = 8.0e-4;
     points[1][0] = 0.1;
-    points[2][0] = 0.2;
+    points[2][0] = 0.1;
     // Put the second point in the second lane
     points[0][1] = 7.0e-4;
     points[1][1] = 0.1;
-    points[2][1] = 0.19;
+    points[2][1] = 0.09;
     // Fill the other lanes with points outside of the domain
     for (unsigned int i = 2; i < n_lanes; ++i)
     {
@@ -323,8 +318,7 @@ BOOST_AUTO_TEST_CASE(heat_source_vectorized_value_3d, *utf::tolerance(1e-12))
       points[1][i] = -1e10;
       points[2][i] = -1e10;
     }
-    auto const values =
-        goldak_heat_source.value(points, dealii::make_vectorized_array(0.2));
+    auto const values = goldak_heat_source.value(points);
 
     double const pi_over_3_to_1p5 = std::pow(dealii::numbers::PI / 3.0, 1.5);
 
@@ -349,9 +343,8 @@ BOOST_AUTO_TEST_CASE(heat_source_vectorized_value_3d, *utf::tolerance(1e-12))
     // Only one lane is available
     points[0][0] = 8.0e-4;
     points[1][0] = 0.1;
-    points[2][0] = 0.2;
-    auto values =
-        goldak_heat_source.value(points, dealii::make_vectorized_array(0.2));
+    points[2][0] = 0.1;
+    auto values = goldak_heat_source.value(points);
     double const pi_over_3_to_1p5 = std::pow(dealii::numbers::PI / 3.0, 1.5);
 
     double const expected_value_0 =
@@ -361,9 +354,8 @@ BOOST_AUTO_TEST_CASE(heat_source_vectorized_value_3d, *utf::tolerance(1e-12))
     // Check the second point
     points[0][0] = 7.0e-4;
     points[1][0] = 0.1;
-    points[2][0] = 0.19;
-    values =
-        goldak_heat_source.value(points, dealii::make_vectorized_array(0.2));
+    points[2][0] = 0.09;
+    values = goldak_heat_source.value(points);
     double expected_value_1 =
         2.0 * 0.1 * 10.0 / (0.5 * 0.5 * 0.1 * pi_over_3_to_1p5);
     expected_value_1 *=
@@ -377,8 +369,7 @@ BOOST_AUTO_TEST_CASE(heat_source_vectorized_value_3d, *utf::tolerance(1e-12))
   if (n_lanes > 1)
   {
     // points is correctly initialized. We can just check the values
-    auto const values =
-        eb_heat_source.value(points, dealii::make_vectorized_array(0.2));
+    auto const values = eb_heat_source.value(points);
 
     double const expected_value_0 = -0.1 * 10. * 1.0 * std::log(0.1) /
                                     (dealii::numbers::PI * 0.5 * 0.5 * 0.1);
@@ -402,9 +393,8 @@ BOOST_AUTO_TEST_CASE(heat_source_vectorized_value_3d, *utf::tolerance(1e-12))
     // Only one lane is available
     points[0][0] = 8.0e-4;
     points[1][0] = 0.1;
-    points[2][0] = 0.2;
-    auto values =
-        eb_heat_source.value(points, dealii::make_vectorized_array(0.2));
+    points[2][0] = 0.1;
+    auto values = eb_heat_source.value(points);
 
     double const expected_value_0 = -0.1 * 10. * 1.0 * std::log(0.1) /
                                     (dealii::numbers::PI * 0.5 * 0.5 * 0.1);
@@ -413,8 +403,8 @@ BOOST_AUTO_TEST_CASE(heat_source_vectorized_value_3d, *utf::tolerance(1e-12))
     // Check the second point
     points[0][0] = 7.0e-4;
     points[1][0] = 0.1;
-    points[2][0] = 0.19;
-    values = eb_heat_source.value(points, dealii::make_vectorized_array(0.2));
+    points[2][0] = 0.09;
+    values = eb_heat_source.value(points);
     double const expected_value_1 =
         -0.1 * 10. * 1.0 * std::log(0.1) /
         (dealii::numbers::PI * 0.5 * 0.5 * 0.1) *
@@ -422,45 +412,6 @@ BOOST_AUTO_TEST_CASE(heat_source_vectorized_value_3d, *utf::tolerance(1e-12))
         (-3.0 * 0.01 * 0.01 / 0.1 / 0.1 + 2.0 * 0.01 / 0.1 + 1.0);
     BOOST_TEST(values[0] == expected_value_1);
   }
-}
-
-BOOST_AUTO_TEST_CASE(heat_source_height, *utf::tolerance(1e-12))
-{
-  boost::property_tree::ptree database;
-
-  database.put("depth", 0.1);
-  database.put("absorption_efficiency", 0.1);
-  database.put("diameter", 1.0);
-  database.put("max_power", 10.);
-  database.put("scan_path_file", "scan_path_layers.txt");
-  database.put("scan_path_file_format", "segment");
-  boost::optional<boost::property_tree::ptree const &> units_optional_database;
-  GoldakHeatSource<2> goldak_heat_source(database, units_optional_database);
-  ElectronBeamHeatSource<2> eb_heat_source(database, units_optional_database);
-
-  double g_height = 0.0;
-  double eb_height = 0.0;
-
-  // Check the height for the first segment
-  g_height = goldak_heat_source.get_current_height(1.0e-7);
-  BOOST_TEST(g_height == 0.);
-
-  eb_height = eb_heat_source.get_current_height(1.0e-7);
-  BOOST_TEST(eb_height == 0.);
-
-  // Check the height for the second segment
-  g_height = goldak_heat_source.get_current_height(0.001001);
-  BOOST_TEST(g_height == 0.);
-
-  eb_height = eb_heat_source.get_current_height(0.001001);
-  BOOST_TEST(eb_height == 0.);
-
-  // Check the height for the third segment
-  g_height = goldak_heat_source.get_current_height(0.003);
-  BOOST_TEST(g_height == 0.001);
-
-  eb_height = eb_heat_source.get_current_height(0.003);
-  BOOST_TEST(eb_height == 0.001);
 }
 
 } // namespace adamantine

--- a/tests/test_thermal_physics.hh
+++ b/tests/test_thermal_physics.hh
@@ -232,9 +232,6 @@ void thermal_2d_manufactured_solution()
 
   BOOST_TEST(time == 0.1);
 
-  BOOST_TEST(physics.get_current_source_height() == 0.0,
-             tt::tolerance(tolerance));
-
   if (std::is_same<MemorySpaceType, dealii::MemorySpace::Host>::value)
   {
     for (unsigned int i = 0; i < solution.locally_owned_size(); ++i)


### PR DESCRIPTION
This variable is not necessary. We already assume that the top of the object follows the scan path. This is necessary to support 5-axis deposition.