### PR TITLE
Use Tpetra instead of Epetra

### DIFF
--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -33,7 +33,7 @@
 #include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/grid/filtered_iterator.h>
 #include <deal.II/grid/grid_refinement.h>
-#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#if DEAL_II_VERSION_GTE(9, 7, 0) && defined(DEAL_II_TRILINOS_WITH_TPETRA)
 #include <deal.II/lac/trilinos_tpetra_sparse_matrix.h>
 #else
 #include <deal.II/lac/trilinos_sparse_matrix.h>

--- a/source/DataAssimilator.cc
+++ b/source/DataAssimilator.cc
@@ -15,7 +15,7 @@
 #include <deal.II/lac/la_parallel_block_vector.h>
 #include <deal.II/lac/linear_operator_tools.h>
 #include <deal.II/lac/read_write_vector.h>
-#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#if DEAL_II_VERSION_GTE(9, 7, 0) && defined(DEAL_II_TRILINOS_WITH_TPETRA)
 #include <deal.II/lac/trilinos_tpetra_sparse_matrix.h>
 #else
 #include <deal.II/lac/trilinos_sparse_matrix.h>
@@ -604,8 +604,8 @@ void DataAssimilator::update_covariance_sparsity_pattern(
         }
       }
 
-      _covariance_sparsity_pattern.reinit(parallel_partitioning,
-                                          dsp, MPI_COMM_SELF);
+      _covariance_sparsity_pattern.reinit(parallel_partitioning, dsp,
+                                          MPI_COMM_SELF);
     }
   }
 }

--- a/source/DataAssimilator.hh
+++ b/source/DataAssimilator.hh
@@ -13,7 +13,7 @@
 #include <deal.II/lac/la_parallel_block_vector.h>
 #include <deal.II/lac/solver_gmres.h>
 #include <deal.II/lac/sparse_matrix.h>
-#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#if DEAL_II_VERSION_GTE(9, 7, 0) && defined(DEAL_II_TRILINOS_WITH_TPETRA)
 #include <deal.II/lac/trilinos_tpetra_sparse_matrix.h>
 #include <deal.II/lac/trilinos_tpetra_sparsity_pattern.h>
 #else
@@ -178,7 +178,7 @@ private:
    */
   double gaspari_cohn_function(double const r) const;
 
-#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#if DEAL_II_VERSION_GTE(9, 7, 0) && defined(DEAL_II_TRILINOS_WITH_TPETRA)
   using TrilinosMatrixType =
       dealii::LinearAlgebra::TpetraWrappers::SparseMatrix<
           double, dealii::MemorySpace::Host>;
@@ -241,7 +241,7 @@ private:
    */
   unsigned int _expt_size = 0;
 
-#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#if DEAL_II_VERSION_GTE(9, 7, 0) && defined(DEAL_II_TRILINOS_WITH_TPETRA)
   using TrilinosSparsityPattern =
       dealii::LinearAlgebra::TpetraWrappers::SparsityPattern<
           dealii::MemorySpace::Host>;

--- a/source/MechanicalOperator.cc
+++ b/source/MechanicalOperator.cc
@@ -17,7 +17,7 @@
 #include <deal.II/hp/fe_values.h>
 #include <deal.II/hp/q_collection.h>
 #include <deal.II/lac/affine_constraints.h>
-#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#if DEAL_II_VERSION_GTE(9, 7, 0) && defined(DEAL_II_TRILINOS_WITH_TPETRA)
 #include <deal.II/lac/affine_constraints.templates.h>
 #endif
 #include <deal.II/lac/full_matrix.h>

--- a/source/MechanicalOperator.hh
+++ b/source/MechanicalOperator.hh
@@ -14,7 +14,7 @@
 #include <deal.II/hp/q_collection.h>
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/la_parallel_vector.h>
-#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#if DEAL_II_VERSION_GTE(9, 7, 0) && defined(DEAL_II_TRILINOS_WITH_TPETRA)
 #include <deal.II/lac/trilinos_tpetra_sparse_matrix.h>
 #else
 #include <deal.II/lac/trilinos_sparse_matrix.h>
@@ -61,7 +61,7 @@ public:
   dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> const &
   rhs() const;
 
-#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#if DEAL_II_VERSION_GTE(9, 7, 0) && defined(DEAL_II_TRILINOS_WITH_TPETRA)
   using TrilinosMatrixType =
       dealii::LinearAlgebra::TpetraWrappers::SparseMatrix<
           double, dealii::MemorySpace::Default>;

--- a/source/MechanicalPhysics.cc
+++ b/source/MechanicalPhysics.cc
@@ -13,7 +13,7 @@
 #include <deal.II/hp/fe_values.h>
 #include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/solver_cg.h>
-#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#if DEAL_II_VERSION_GTE(9, 7, 0) && defined(DEAL_II_TRILINOS_WITH_TPETRA)
 #include <deal.II/lac/trilinos_tpetra_precondition.h>
 #else
 #include <deal.II/lac/trilinos_precondition.h>
@@ -440,7 +440,7 @@ MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
   dealii::IndexSet locally_owned_dofs = _dof_handler.locally_owned_dofs();
   dealii::IndexSet locally_relevant_dofs =
       dealii::DoFTools::extract_locally_relevant_dofs(_dof_handler);
-#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#if DEAL_II_VERSION_GTE(9, 7, 0) && defined(DEAL_II_TRILINOS_WITH_TPETRA)
   using TrilinosVectorType = dealii::LinearAlgebra::TpetraWrappers::Vector<
       double, dealii::MemorySpace::Default>;
 #else
@@ -464,7 +464,7 @@ MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
   dealii::SolverControl solver_control(max_iter, tol);
   dealii::SolverCG<TrilinosVectorType> cg(solver_control);
   // FIXME Use better preconditioner
-#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#if DEAL_II_VERSION_GTE(9, 7, 0) && defined(DEAL_II_TRILINOS_WITH_TPETRA)
   dealii::LinearAlgebra::TpetraWrappers::PreconditionSSOR<
       double, dealii::MemorySpace::Default>
       preconditioner;

--- a/tests/test_mechanical_operator.cc
+++ b/tests/test_mechanical_operator.cc
@@ -225,7 +225,7 @@ BOOST_AUTO_TEST_CASE(elastostatic, *utf::tolerance(1e-12))
       n_dofs);
 
   dealii::IndexSet index_set = dealii::complete_index_set(n_dofs);
-#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#if DEAL_II_VERSION_GTE(9, 7, 0) && defined(DEAL_II_TRILINOS_WITH_TPETRA)
   dealii::LinearAlgebra::TpetraWrappers::Vector<double,
                                                 dealii::MemorySpace::Default>
       src_device(index_set, MPI_COMM_SELF);


### PR DESCRIPTION
This pull request converts all uses of `Epetra` (i.e., `TrilinosWrappers`) to `Tpetra` (i.e., `TpetraWrappers`) and moving the data to the device.