### PR TITLE
Compatibility with newer ArborX versions

### DIFF
--- a/source/RayTracing.cc
+++ b/source/RayTracing.cc
@@ -65,9 +65,8 @@ struct AccessTraits<adamantine::RayNearestPredicate, PredicatesTag>
     auto const &origin = ray.origin;
     auto const &direction = ray.direction;
     ArborX::Experimental::Ray arborx_ray = {
-        ArborX::Point{(float)origin[0], (float)origin[1], (float)origin[2]},
-        ArborX::Experimental::Vector{(float)direction[0], (float)direction[1],
-                                     (float)direction[2]}};
+        {(float)origin[0], (float)origin[1], (float)origin[2]},
+        {(float)direction[0], (float)direction[1], (float)direction[2]}};
     // When the mesh is unstructured, bounding boxes do not tightly bound the
     // cells and so many of them overlap. A ray may hit a bounding box but may
     // missed the cell. We need to ask for more bounding boxes to increase the


### PR DESCRIPTION
The type for `Point` and `Vector` differ between ArborX versions before 1.7, 1.7, and after 2 but the the constructor for `Ray` isn't templated so we can make the code working by just omitting types that are obvious from the variable names anyway.