### PR TITLE
Ensure _covariance_sparsity_pattern is compressed

### DIFF
--- a/source/DataAssimilator.cc
+++ b/source/DataAssimilator.cc
@@ -606,6 +606,7 @@ void DataAssimilator::update_covariance_sparsity_pattern(
 
       _covariance_sparsity_pattern.reinit(parallel_partitioning, dsp,
                                           MPI_COMM_SELF);
+      _covariance_sparsity_pattern.compress();
     }
   }
 }


### PR DESCRIPTION
`TpetraWrappers::reinit` copies the entries but doesn't call `compress` since we might add more entries.
The deal.II version I used previously also called `compress` but it seems more reasonable to do that in user code.
This makes it work with deal.II `master`.