### PR TITLE
Address dealii::parallel::distributed::SolutionTransfer being deprecated ind deal.II 9.7

### DIFF
--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -336,7 +336,11 @@ void refine_and_transfer(
   thermal_physics->set_state_to_material_properties();
 
   // Transfer of the solution
+#if DEAL_II_VERSION_GTE(9, 7, 0)
+  dealii::SolutionTransfer<
+#else
   dealii::parallel::distributed::SolutionTransfer<
+#endif
       dim, dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host>>
       solution_transfer(dof_handler);
 

--- a/source/MechanicalPhysics.hh
+++ b/source/MechanicalPhysics.hh
@@ -157,7 +157,11 @@ private:
    * Solution transfer object used for updating _old_displacement when the
    * triangulation is updated when adding material
    */
+#if DEAL_II_VERSION_GTE(9, 7, 0)
+  dealii::SolutionTransfer<
+#else
   dealii::parallel::distributed::SolutionTransfer<
+#endif
       dim, dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host>>
       _solution_transfer;
 

--- a/source/ThermalPhysics.templates.hh
+++ b/source/ThermalPhysics.templates.hh
@@ -1055,7 +1055,11 @@ void ThermalPhysics<dim, n_materials, p_order, fe_degree, MaterialStates,
   get_state_from_material_properties();
 
   // Deserialize the temperature
+#if DEAL_II_VERSION_GTE(9, 7, 0)
+  dealii::SolutionTransfer<
+#else
   dealii::parallel::distributed::SolutionTransfer<
+#endif
       dim, dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host>>
       solution_transfer(_dof_handler);
   initialize_dof_vector(0., temperature);
@@ -1163,7 +1167,11 @@ void ThermalPhysics<dim, n_materials, p_order, fe_degree, MaterialStates,
     ghosted_temperature = temperature_host;
   }
   ghosted_temperature.update_ghost_values();
+#if DEAL_II_VERSION_GTE(9, 7, 0)
+  dealii::SolutionTransfer<
+#else
   dealii::parallel::distributed::SolutionTransfer<
+#endif
       dim, dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host>>
       solution_transfer(_dof_handler);
   solution_transfer.prepare_for_serialization(ghosted_temperature);


### PR DESCRIPTION
With this I don't get any warnings coming from deal.II anymore.