### PR TITLE
Ignore FE_INVALID in test_experimental_data for ArborX calls

### DIFF
--- a/tests/test_experimental_data.cc
+++ b/tests/test_experimental_data.cc
@@ -168,14 +168,16 @@ BOOST_AUTO_TEST_CASE(read_experimental_data_ray_tracing_from_file)
   ray_tracing.read_next_frame();
 
   // Since the ArborX implementation relies on NaN comparisons here, we need to
-  // allow FE_INVALID.
+  // allow FE_INVALID. This should be resolved in ArborX 2.0.
 #ifndef __APPLE__
   std::fenv_t envp;
   std::feholdexcept(&envp);
 #endif
   // Compute the intersection points
   auto points_values = ray_tracing.get_points_values();
+#ifndef __APPLE__
   std::fesetenv(&envp);
+#endif
 
   // Reference solution
   std::vector<double> values_ref = {1, 2, 3, 5};
@@ -328,14 +330,16 @@ BOOST_AUTO_TEST_CASE(project_ray_data_on_nonaligned_mesh,
   ray_tracing.read_next_frame();
 
 // Since the ArborX implementation relies on NaN comparisons here, we need to
-// allow FE_INVALID.
+// allow FE_INVALID. This should be resolved in ArborX 2.0.
 #ifndef __APPLE__
   std::fenv_t envp;
   std::feholdexcept(&envp);
 #endif
   // Compute the intersection points
   auto points_values = ray_tracing.get_points_values();
+#ifndef __APPLE__
   std::fesetenv(&envp);
+#endif
 
   // Reference solution
   std::vector<double> values_ref = {4, 5, 6};


### PR DESCRIPTION
Fixes part of #433. Acoording to https://github.com/arborx/ArborX/blob/71f0c9664372631bcd5cb124a0815de1f02528b5/src/geometry/ArborX_Ray.hpp#L84-L157, the box-ray intersection algorithm relies on NaN behavior which we trigger in `test_experimental_data`. Thus, this pull request disables floating point expections for the problematic ArborX calls.