### PR TITLE
Only assemble the mechanical system matrix when necessary

### DIFF
--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -1,4 +1,4 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2025, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2026, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -1032,6 +1032,8 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
         communicator, microstructure_filename);
   }
 
+  bool rebuild_mechanical_matrix = true;
+
 #ifdef ADAMANTINE_WITH_CALIPER
   CALI_CXX_MARK_LOOP_BEGIN(main_loop_id, "main_loop");
 #endif
@@ -1054,6 +1056,7 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
                   temperature, heat_sources, time, next_refinement_time,
                   time_steps_refinement, refinement_database);
       timers[adamantine::refine].stop();
+      rebuild_mechanical_matrix = true;
       if ((rank == 0) && (verbose_output == true))
       {
         std::cout << "n_time_step: " << n_time_step << " time: " << time
@@ -1174,6 +1177,7 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
           if (use_mechanical_physics)
           {
             mechanical_physics->complete_transfer_mpi();
+            rebuild_mechanical_matrix = true;
           }
 
 #ifdef ADAMANTINE_WITH_CALIPER
@@ -1278,13 +1282,31 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
               temperature_host(temperature.get_partitioner());
           temperature_host.import_elements(temperature,
                                            dealii::VectorOperation::insert);
-          mechanical_physics->setup_dofs(
-              thermal_physics->get_dof_handler(), temperature_host,
-              thermal_physics->get_has_melted_vector());
+          if (rebuild_mechanical_matrix)
+          {
+            mechanical_physics->setup_dofs(
+                thermal_physics->get_dof_handler(), temperature_host,
+                thermal_physics->get_has_melted_vector());
+            rebuild_mechanical_matrix = false;
+          }
+          else
+          {
+            mechanical_physics->update_rhs(
+                thermal_physics->get_dof_handler(), temperature_host,
+                thermal_physics->get_has_melted_vector());
+          }
         }
         else
         {
-          mechanical_physics->setup_dofs();
+          if (rebuild_mechanical_matrix)
+          {
+            mechanical_physics->setup_dofs();
+            rebuild_mechanical_matrix = false;
+          }
+          else
+          {
+            mechanical_physics->update_rhs();
+          }
         }
         displacement = mechanical_physics->solve();
       }

--- a/source/MechanicalOperator.hh
+++ b/source/MechanicalOperator.hh
@@ -73,12 +73,17 @@ public:
 
 private:
   /**
-   * Assemble the matrix and the right-hand-side.
+   * Assemble the sparse matrix of the system.
    * @note The 2D case does not represent any physical model but it is
    * convenient for testing.
    */
-  void assemble_system(
-      std::vector<std::shared_ptr<BodyForce<dim>>> const &body_forces);
+  void assemble_matrix();
+
+  /**
+   * Assemble the right-hand-side.
+   */
+  void
+  assemble_rhs(std::vector<std::shared_ptr<BodyForce<dim>>> const &body_forces);
 
   /**
    * MPI communicator.

--- a/source/MechanicalPhysics.cc
+++ b/source/MechanicalPhysics.cc
@@ -136,6 +136,31 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
 template <int dim, int n_materials, int p_order, typename MaterialStates,
           typename MemorySpaceType>
 void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
+                       MemorySpaceType>::
+    update_rhs(std::vector<std::shared_ptr<BodyForce<dim>>> const &body_forces)
+{
+  _mechanical_operator->assemble_rhs(body_forces);
+}
+
+template <int dim, int n_materials, int p_order, typename MaterialStates,
+          typename MemorySpaceType>
+void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
+                       MemorySpaceType>::
+    update_rhs(
+        dealii::DoFHandler<dim> const &thermal_dof_handler,
+        dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> const
+            &temperature,
+        std::vector<bool> const &has_melted,
+        std::vector<std::shared_ptr<BodyForce<dim>>> const &body_forces)
+{
+  _mechanical_operator->update_temperature(thermal_dof_handler, temperature,
+                                           has_melted);
+  _mechanical_operator->assemble_rhs(body_forces);
+}
+
+template <int dim, int n_materials, int p_order, typename MaterialStates,
+          typename MemorySpaceType>
+void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
                        MemorySpaceType>::prepare_transfer_mpi()
 {
   _old_displacement.update_ghost_values();

--- a/source/MechanicalPhysics.hh
+++ b/source/MechanicalPhysics.hh
@@ -52,6 +52,24 @@ public:
           std::vector<std::shared_ptr<BodyForce<dim>>>());
 
   /**
+   * Recompute the right-hand-side.
+   */
+  void
+  update_rhs(std::vector<std::shared_ptr<BodyForce<dim>>> const &body_forces =
+                 std::vector<std::shared_ptr<BodyForce<dim>>>());
+
+  /**
+   * Same as above when solving a thermo-mechanical problem
+   */
+  void update_rhs(
+      dealii::DoFHandler<dim> const &thermal_dof_handler,
+      dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> const
+          &temperature,
+      std::vector<bool> const &has_melted,
+      std::vector<std::shared_ptr<BodyForce<dim>>> const &body_forces =
+          std::vector<std::shared_ptr<BodyForce<dim>>>());
+
+  /**
    * Prepare displacement and stresses to be communicated when activating cells
    * or refining the mesh.
    */

--- a/source/MechanicalPhysics.hh
+++ b/source/MechanicalPhysics.hh
@@ -1,4 +1,4 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2022 - 2025, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2022 - 2026, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 


### PR DESCRIPTION
This PR split `assemble_system` in two: `assemble_matrix` and `assemble_rhs`. `assemble_rhs` is called every time steps while `assemble_matrix` is only called when the mesh or the dof indices are changed.

Alternative to https://github.com/adamantine-sim/adamantine/pull/444