### PR TITLE
Reassemble the matrix if the material changed phases

### DIFF
--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -1060,7 +1060,7 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
       if ((rank == 0) && (verbose_output == true))
       {
         std::cout << "n_time_step: " << n_time_step << " time: " << time
-                  << " n_dofs after mesh refinement: "
+                  << " n_dofs (thermal) after mesh refinement: "
                   << thermal_physics->get_dof_handler().n_dofs() << std::endl;
       }
     }
@@ -1193,7 +1193,7 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
           (activation_end - activation_start > 0) && use_thermal_physics)
       {
         std::cout << "n_time_step: " << n_time_step << " time: " << time
-                  << " n_dofs after cell activation: "
+                  << " n_dofs (thermal) after cell activation: "
                   << thermal_physics->get_dof_handler().n_dofs() << std::endl;
       }
     }
@@ -1291,6 +1291,14 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
           mechanical_physics->setup_dofs(
               thermal_physics->get_dof_handler(), temperature_host,
               thermal_physics->get_has_melted_vector(), rebuild_matrix);
+          if ((rank == 0) && (verbose_output == true) &&
+              (rebuild_matrix == true))
+          {
+            std::cout << "n_time_step: " << n_time_step << " time: " << time
+                      << " n_dofs (mechanical): "
+                      << mechanical_physics->get_dof_handler().n_dofs()
+                      << std::endl;
+          }
           rebuild_mechanical_matrix = false;
         }
         else
@@ -1298,6 +1306,13 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
           if (rebuild_mechanical_matrix)
           {
             mechanical_physics->setup_dofs();
+            if ((rank == 0) && (verbose_output == true))
+            {
+              std::cout << "n_time_step: " << n_time_step << " time: " << time
+                        << " n_dofs (mechanical): "
+                        << mechanical_physics->get_dof_handler().n_dofs()
+                        << std::endl;
+            }
             rebuild_mechanical_matrix = false;
           }
           else
@@ -1934,7 +1949,7 @@ run_ensemble(MPI_Comm const &global_communicator,
       if ((global_rank == 0) && (verbose_output == true))
       {
         std::cout << "n_time_step: " << n_time_step << " time: " << time
-                  << " n_dofs: "
+                  << " n_dofs (thermal) after mesh refinement: "
                   << thermal_physics_ensemble[0]->get_dof_handler().n_dofs()
                   << std::endl;
       }
@@ -2070,7 +2085,7 @@ run_ensemble(MPI_Comm const &global_communicator,
           (activation_end - activation_start > 0))
       {
         std::cout << "n_time_step: " << n_time_step << " time: " << time
-                  << " n_dofs after cell activation: "
+                  << " n_dofs (thermal) after cell activation: "
                   << thermal_physics_ensemble[0]->get_dof_handler().n_dofs()
                   << std::endl;
       }

--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -942,9 +942,9 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
           temperature_host(temperature.get_partitioner());
       temperature_host.import_elements(temperature,
                                        dealii::VectorOperation::insert);
-      mechanical_physics->setup_dofs(thermal_physics->get_dof_handler(),
-                                     temperature_host,
-                                     thermal_physics->get_has_melted_vector());
+      mechanical_physics->setup_dofs(
+          thermal_physics->get_dof_handler(), temperature_host,
+          thermal_physics->get_has_melted_vector(), true);
     }
     else
     {
@@ -1285,14 +1285,17 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
               temperature_host(temperature.get_partitioner());
           temperature_host.import_elements(temperature,
                                            dealii::VectorOperation::insert);
-          // We need to rebuild the matrix if the mesh has changed or if the
-          // material changed phases. We pass the information about the mesh to
-          // setup_dofs.
+          // We need to rebuild the matrix if the mesh has changed, material was
+          // deposited or if the material changed phases. We pass the
+          // information about the mesh to setup_dofs.
           mechanical_physics->setup_dofs(
               thermal_physics->get_dof_handler(), temperature_host,
-              thermal_physics->get_has_melted_vector(), rebuild_matrix);
+              thermal_physics->get_has_melted_vector(),
+              rebuild_mechanical_matrix);
+          // We only output the number of dofs if the mesh was modified or if
+          // material was deposited.
           if ((rank == 0) && (verbose_output == true) &&
-              (rebuild_matrix == true))
+              (rebuild_mechanical_matrix == true))
           {
             std::cout << "n_time_step: " << n_time_step << " time: " << time
                       << " n_dofs (mechanical): "

--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -1285,19 +1285,13 @@ run(MPI_Comm const &communicator, boost::property_tree::ptree const &database,
               temperature_host(temperature.get_partitioner());
           temperature_host.import_elements(temperature,
                                            dealii::VectorOperation::insert);
-          if (rebuild_mechanical_matrix)
-          {
-            mechanical_physics->setup_dofs(
-                thermal_physics->get_dof_handler(), temperature_host,
-                thermal_physics->get_has_melted_vector());
-            rebuild_mechanical_matrix = false;
-          }
-          else
-          {
-            mechanical_physics->update_rhs(
-                thermal_physics->get_dof_handler(), temperature_host,
-                thermal_physics->get_has_melted_vector());
-          }
+          // We need to rebuild the matrix if the mesh has changed or if the
+          // material changed phases. We pass the information about the mesh to
+          // setup_dofs.
+          mechanical_physics->setup_dofs(
+              thermal_physics->get_dof_handler(), temperature_host,
+              thermal_physics->get_has_melted_vector(), rebuild_matrix);
+          rebuild_mechanical_matrix = false;
         }
         else
         {

--- a/source/MechanicalPhysics.cc
+++ b/source/MechanicalPhysics.cc
@@ -420,8 +420,12 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
                                          _dof_handler.get_communicator()
 #endif
       );
+  // If we do not need to rebuild the matrix. Update the rhs and exit.
   if (!rebuild_matrix)
+  {
+    update_rhs(body_forces);
     return;
+  }
 
   _plastic_internal_variable.swap(tmp_plastic_internal_variable);
   _stress.swap(tmp_stress);

--- a/source/MechanicalPhysics.cc
+++ b/source/MechanicalPhysics.cc
@@ -285,7 +285,7 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
         dealii::DoFHandler<dim> const &thermal_dof_handler,
         dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> const
             &temperature,
-        std::vector<bool> const &has_melted,
+        std::vector<bool> const &has_melted, bool rebuild_matrix,
         std::vector<std::shared_ptr<BodyForce<dim>>> const &body_forces)
 {
   _mechanical_operator->update_temperature(thermal_dof_handler, temperature,
@@ -379,10 +379,16 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
               std::vector<dealii::SymmetricTensor<2, dim>>(n_quad_pts));
 
           cell->set_active_fe_index(updated_fe_index);
+          rebuild_matrix = true;
         }
       }
       else
       {
+        if (current_fe_index == 0)
+        {
+          rebuild_matrix = true;
+        }
+
         // The cell is liquid. We don't need to save the plastic variables.
         cell->set_active_fe_index(1);
         tmp_plastic_internal_variable.push_back(std::vector<double>(
@@ -404,6 +410,19 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
     }
     ++cell_id;
   }
+
+  // Check if we need to rebuild the matrix
+  rebuild_matrix =
+      dealii::Utilities::MPI::logical_or(rebuild_matrix,
+#if DEAL_II_VERSION_GTE(9, 7, 0)
+                                         _dof_handler.get_mpi_communicator()
+#else
+                                         _dof_handler.get_communicator()
+#endif
+      );
+  if (!rebuild_matrix)
+    return;
+
   _plastic_internal_variable.swap(tmp_plastic_internal_variable);
   _stress.swap(tmp_stress);
   _back_stress.swap(tmp_back_stress);

--- a/source/MechanicalPhysics.hh
+++ b/source/MechanicalPhysics.hh
@@ -47,7 +47,7 @@ public:
       dealii::DoFHandler<dim> const &thermal_dof_handler,
       dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host> const
           &temperature,
-      std::vector<bool> const &has_melted,
+      std::vector<bool> const &has_melted, bool rebuild_matrix,
       std::vector<std::shared_ptr<BodyForce<dim>>> const &body_forces =
           std::vector<std::shared_ptr<BodyForce<dim>>>());
 

--- a/tests/test_mechanical_physics.cc
+++ b/tests/test_mechanical_physics.cc
@@ -502,7 +502,7 @@ run_eshelby(std::vector<dealii::Point<dim>> pts, unsigned int refinement_cycles)
   std::vector<bool> has_melted(triangulation.n_active_cells(), false);
 
   mechanical_physics.setup_dofs(thermal_physics.get_dof_handler(), temperature,
-                                has_melted);
+                                has_melted, true);
 
   auto solution = mechanical_physics.solve();
 


### PR DESCRIPTION
I introduced a bug in https://github.com/adamantine-sim/adamantine/pull/456 We need to rebuild the mechanical matrix if the mesh changed or if the material changed phase.

I also improved a few messages we output on the screen