### PR TITLE
Add Caliper instrumentation in evolve_one_time_step

### DIFF
--- a/source/ThermalPhysics.templates.hh
+++ b/source/ThermalPhysics.templates.hh
@@ -1,4 +1,4 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2025, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2016 - 2026, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -861,8 +861,12 @@ double ThermalPhysics<dim, n_materials, p_order, fe_degree, MaterialStates,
         dealii::LA::distributed::Vector<double, MemorySpaceType> &solution,
         std::vector<Timer> &timers)
 {
+#ifdef ADAMANTINE_WITH_CALIPER
+  CALI_CXX_MARK_FUNCTION;
+#endif
+
   // For very small time steps (e.g., less than 1e-4 second), using deal.II to
-  // perform a forward steps becomes costly. In that case, we just peform the
+  // perform a forward step becomes costly. In that case, we just perform the
   // forward euler ourselves.
   if (_forward_euler)
   {


### PR DESCRIPTION
Currently, we only instrument the operator evaluation `evaluate_thermal_physics`. While this captures the bulk of the workload in large-scale simulations, the `sadd` function in the forward Euler step become non-negligible in smaller cases. In certain scenarios, approximately 10%–20% of total execution time is currently unaccounted for in our profiling. 