### PR TITLE
Do not rebuild the rotation matrices after every arithmetic operation on quaternion

### DIFF
--- a/source/ElectronBeamHeatSource.cc
+++ b/source/ElectronBeamHeatSource.cc
@@ -183,10 +183,9 @@ ElectronBeamHeatSource<dim>::get_bounding_box(double const time,
     if (this->_scan_path.is_five_axis())
     {
       // We need to rotate the box to match the scan path
-      dealii::Point<3> rotated_max_corner =
-          this->_scan_path.rotate(time, max_corner);
-      dealii::Point<3> rotated_min_corner =
-          this->_scan_path.rotate(time, min_corner);
+      Quaternion quaternion = this->_scan_path.get_quaternion(time);
+      dealii::Point<3> rotated_max_corner = quaternion.rotate(max_corner);
+      dealii::Point<3> rotated_min_corner = quaternion.rotate(min_corner);
 
       // We need to recompute the min and max corners after rotation.
       dealii::Point<3> new_max_corner;

--- a/source/GoldakHeatSource.cc
+++ b/source/GoldakHeatSource.cc
@@ -173,10 +173,9 @@ GoldakHeatSource<dim>::get_bounding_box(double const time,
     if (this->_scan_path.is_five_axis())
     {
       // We need to rotate the box to match the scan path
-      dealii::Point<3> rotated_max_corner =
-          this->_scan_path.rotate(time, max_corner);
-      dealii::Point<3> rotated_min_corner =
-          this->_scan_path.rotate(time, min_corner);
+      Quaternion quaternion = this->_scan_path.get_quaternion(time);
+      dealii::Point<3> rotated_max_corner = quaternion.rotate(max_corner);
+      dealii::Point<3> rotated_min_corner = quaternion.rotate(min_corner);
 
       // We need to recompute the min and max corners after rotation.
       dealii::Point<3> new_max_corner;

--- a/source/Quaternion.cc
+++ b/source/Quaternion.cc
@@ -52,32 +52,19 @@ bool Quaternion::is_valid() const { return _is_valid; }
 
 bool Quaternion::operator==(Quaternion const &other) const
 {
-  ASSERT(_is_valid, "");
-  ASSERT(other.is_valid(), "");
+  ASSERT(_is_valid, "Quaternion is not initialized");
+  ASSERT(other.is_valid(), "Quaternion is not initialized");
 
   return _quaternion == other._quaternion;
 }
 
 Quaternion &Quaternion::operator*=(Quaternion const &other)
 {
-  ASSERT(_is_valid, "");
-  ASSERT(other.is_valid(), "");
+  ASSERT(_is_valid, "Quaternion is not initialized");
+  ASSERT(other.is_valid(), "Quaternion is not initialized");
 
-  double r = _quaternion[0];
-  double i = _quaternion[1];
-  double j = _quaternion[2];
-  double k = _quaternion[3];
-  double other_r = other._quaternion[0];
-  double other_i = other._quaternion[1];
-  double other_j = other._quaternion[2];
-  double other_k = other._quaternion[3];
-
-  _quaternion[0] = r * other_r - i * other_i - j * other_j - k * other_k;
-  _quaternion[1] = r * other_i + i * other_r + j * other_k - k * other_j;
-  _quaternion[2] = r * other_j - i * other_k + j * other_r + k * other_i;
-  _quaternion[3] = r * other_k + i * other_j - j * other_i + k * other_r;
-
-  build_rotation_matrices();
+  mult(other._quaternion[0], other._quaternion[1], other._quaternion[2],
+       other._quaternion[3]);
 
   return *this;
 }
@@ -89,26 +76,24 @@ Quaternion &Quaternion::operator*=(double const &scalar)
     _quaternion[i] *= scalar;
   }
 
-  build_rotation_matrices();
-
   return *this;
 }
 
 Quaternion &Quaternion::operator/=(Quaternion const &other)
 {
-  ASSERT(_is_valid, "");
-  ASSERT(other.is_valid(), "");
+  ASSERT(_is_valid, "Quaternion is not initialized");
+  ASSERT(other.is_valid(), "Quaternion is not initialized");
 
-  // Invert the other quaternion
-  Quaternion inv_other(other._quaternion[0], -other._quaternion[1],
-                       -other._quaternion[2], -other._quaternion[3]);
+  // Multiply by the inverse of the other quaternion
+  mult(other._quaternion[0], -other._quaternion[1], -other._quaternion[2],
+       -other._quaternion[3]);
 
-  return (*this) *= inv_other;
+  return *this;
 }
 
 void Quaternion::pow(double const exp)
 {
-  ASSERT(_is_valid, "");
+  ASSERT(_is_valid, "Quaternion is not initialized");
 
   double const partial_norm = std::sqrt(_quaternion[1] * _quaternion[1] +
                                         _quaternion[2] * _quaternion[2] +
@@ -122,8 +107,6 @@ void Quaternion::pow(double const exp)
   _quaternion[1] = unit_vector[0] * std::sin(exp * theta);
   _quaternion[2] = unit_vector[1] * std::sin(exp * theta);
   _quaternion[3] = unit_vector[2] * std::sin(exp * theta);
-
-  build_rotation_matrices();
 }
 
 void Quaternion::build_rotation_matrices()
@@ -174,6 +157,20 @@ void Quaternion::build_rotation_matrices()
       _vec_inv_rotation_matrix[i][j] = _inv_rotation_matrix[i][j];
     }
   }
+}
+
+void Quaternion::mult(double const other_r, double const other_i,
+                      double const other_j, double const other_k)
+{
+  double r = _quaternion[0];
+  double i = _quaternion[1];
+  double j = _quaternion[2];
+  double k = _quaternion[3];
+
+  _quaternion[0] = r * other_r - i * other_i - j * other_j - k * other_k;
+  _quaternion[1] = r * other_i + i * other_r + j * other_k - k * other_j;
+  _quaternion[2] = r * other_j - i * other_k + j * other_r + k * other_i;
+  _quaternion[3] = r * other_k + i * other_j - j * other_i + k * other_r;
 }
 
 double dot_product(Quaternion const &p, Quaternion const &q)

--- a/source/Quaternion.hh
+++ b/source/Quaternion.hh
@@ -94,19 +94,29 @@ public:
   void pow(double const exp);
 
   /**
+   * Update the cached rotation matrices derived from the current quaternion.
+   *
+   * This function must be called after any arithmetic operations modify the
+   * quaternion to ensure that subsequent calls to rotate() or inv_rotate() use
+   * updated data.
+   */
+  void build_rotation_matrices();
+
+  /**
    * Compute the dot product of two quaternions.
    */
   friend double dot_product(Quaternion const &p, Quaternion const &q);
 
 private:
   /**
-   * Build the different rotation matrices.
+   * Multiply the quaternion with an unpacked quaternion.
    */
-  void build_rotation_matrices();
+  void mult(double const other_r, double const other_i, double const other_j,
+            double const other_k);
 
   /**
-   * Flag is false if the default constructor was called and reinit() has not
-   * been called yet.
+   * Flag is false if the default constructor was called and reinit() has
+   * not been called yet.
    */
   bool _is_valid = false;
   /**

--- a/source/ScanPath.cc
+++ b/source/ScanPath.cc
@@ -274,19 +274,6 @@ double ScanPath::get_power_modifier(double const time) const
   return _segment_list[current_segment].power_modifier;
 }
 
-dealii::Point<3> ScanPath::rotate(double const time,
-                                  dealii::Point<3> const &point) const
-{
-  // If the current time is after the scan path data is over, return the point
-  // unchanged
-  if (time > _segment_list.back().end_time)
-  {
-    return point;
-  }
-
-  return get_quaternion(time).rotate(point);
-}
-
 Quaternion ScanPath::get_quaternion(double const time) const
 {
   if (!_five_axis)
@@ -337,6 +324,7 @@ Quaternion ScanPath::get_quaternion(double const time) const
   interpolated_rotation /= segment_start_rotation;
   interpolated_rotation.pow((time - segment_start_time) / duration);
   interpolated_rotation *= segment_start_rotation;
+  interpolated_rotation.build_rotation_matrices();
 
   return interpolated_rotation;
 }

--- a/source/ScanPath.hh
+++ b/source/ScanPath.hh
@@ -90,13 +90,6 @@ public:
   double get_power_modifier(double const time) const;
 
   /**
-   * Return the rotation of the given @p point according to quaternion active at
-   * the given time.
-   */
-  dealii::Point<3> rotate(double const time,
-                          dealii::Point<3> const &point) const;
-
-  /**
    * Return the quaternion at the given @p time. The quaternion is interpolated
    * linearly (Slerp) between the start and the end of the segment.
    */

--- a/tests/test_scan_path.cc
+++ b/tests/test_scan_path.cc
@@ -111,42 +111,48 @@ BOOST_AUTO_TEST_CASE(five_axis, *utf::tolerance(1e-9))
 
   double time = 0.5;
   auto p = scan_path.value(time);
-  auto rotated_p = scan_path.rotate(time, p);
+  auto quaternion = scan_path.get_quaternion(time);
+  auto rotated_p = quaternion.rotate(p);
   BOOST_TEST(rotated_p[0] == 0.2222222222);
   BOOST_TEST(rotated_p[1] == 0.0);
   BOOST_TEST(rotated_p[2] == 0.0);
 
   time = 1.0;
   p = scan_path.value(time);
-  rotated_p = scan_path.rotate(time, p);
+  quaternion = scan_path.get_quaternion(time);
+  rotated_p = quaternion.rotate(p);
   BOOST_TEST(rotated_p[0] == 0.5);
   BOOST_TEST(rotated_p[1] == 0.0);
   BOOST_TEST(rotated_p[2] == 0.0);
 
   time = 1.5;
   p = scan_path.value(time);
-  rotated_p = scan_path.rotate(time, p);
+  quaternion = scan_path.get_quaternion(time);
+  rotated_p = quaternion.rotate(p);
   BOOST_TEST(rotated_p[0] == 0.35355339059327373);
   BOOST_TEST(rotated_p[1] == 0.0);
   BOOST_TEST(rotated_p[2] == -0.35355339059327373);
 
   time = 2.0;
   p = scan_path.value(time);
-  rotated_p = scan_path.rotate(time, p);
+  quaternion = scan_path.get_quaternion(time);
+  rotated_p = quaternion.rotate(p);
   BOOST_TEST(rotated_p[0] == 0.0);
   BOOST_TEST(rotated_p[1] == 0.0);
   BOOST_TEST(rotated_p[2] == -0.5);
 
   time = 2.5;
   p = scan_path.value(time);
-  rotated_p = scan_path.rotate(time, p);
+  quaternion = scan_path.get_quaternion(time);
+  rotated_p = quaternion.rotate(p);
   BOOST_TEST(rotated_p[0] == 0.5);
   BOOST_TEST(rotated_p[1] == 0.25);
   BOOST_TEST(rotated_p[2] == -0.5);
 
   time = 3.0;
   p = scan_path.value(time);
-  rotated_p = scan_path.rotate(time, p);
+  quaternion = scan_path.get_quaternion(time);
+  rotated_p = quaternion.rotate(p);
   BOOST_TEST(rotated_p[0] == 1.0);
   BOOST_TEST(rotated_p[1] == 0.0);
   BOOST_TEST(rotated_p[2] == 0.0);


### PR DESCRIPTION
Currently we are rebuilding the rotation matrices after every arithmetic operation on quaternion. This was fine because we were doing very few arithmetic operations. This changed with #479, where we do lots of operations. With this PR, we have to explicitly build the matrices which is done at most once every time step.

Drive-by change: remove `ScanPath::rotate`. There is already a function to rotate a `Point` when the quaternion is known and so, this is basically a duplicate.