### PR TITLE
Fix includes for QGaussLobatto

### DIFF
--- a/application/adamantine.hh
+++ b/application/adamantine.hh
@@ -27,6 +27,7 @@
 #include <deal.II/arborx/bvh.h>
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/mpi.h>
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/symmetric_tensor.h>
 #include <deal.II/base/types.h>
 #include <deal.II/distributed/cell_data_transfer.templates.h>

--- a/source/ThermalOperator.templates.hh
+++ b/source/ThermalOperator.templates.hh
@@ -10,6 +10,7 @@
 
 #include <deal.II/base/aligned_vector.h>
 #include <deal.II/base/index_set.h>
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/types.h>
 #include <deal.II/base/vectorization.h>
 #include <deal.II/dofs/dof_tools.h>

--- a/source/ThermalOperatorDevice.templates.hh
+++ b/source/ThermalOperatorDevice.templates.hh
@@ -10,6 +10,7 @@
 #include <types.hh>
 
 #include <deal.II/base/config.h>
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/types.h>
 #include <deal.II/fe/fe_update_flags.h>
 #include <deal.II/matrix_free/portable_fe_evaluation.h>

--- a/source/instantiation.hh
+++ b/source/instantiation.hh
@@ -4,6 +4,8 @@
 
 #include <boost/preprocessor/seq/for_each_product.hpp>
 
+#include <deal.II/base/quadrature_lib.h>
+
 // clang-format off
 #define ADAMANTINE_DIM (2)(3)
 #define ADAMANTINE_USE_TABLE (true)(false)


### PR DESCRIPTION
I run into a missing header with recent `deal.II` `master` for `QGaussLobatto`. This pull request adds the resepctive header for all files that use that class. 