### PR TITLE
Fix bug in mechanical constitutive law

### DIFF
--- a/source/MechanicalPhysics.cc
+++ b/source/MechanicalPhysics.cc
@@ -618,9 +618,9 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
           _plastic_internal_variable[cell_id][q] +=
               iso_hardening_coef * plastic_modulus * plastic_strain_increment;
           // Update back stress
-          _back_stress[cell_id][q] += (1. - iso_hardening_coef) *
-                                      plastic_modulus * plastic_modulus *
-                                      plastic_flow_direction;
+          _back_stress[cell_id][q] +=
+              (1. - iso_hardening_coef) * plastic_modulus *
+              plastic_strain_increment * plastic_flow_direction;
         }
       }
     }


### PR DESCRIPTION
One `plastic_modulus` in the constitutive law should be `plastic_strain_increment`  (see [here](https://adamantine-sim.github.io/adamantine/doc/governing_equations.html#elastoplasticity) for the equation).