### PR TITLE
Jenkins CI: do not pull Docker image every time because we reach the rate limit

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -6,6 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+    continue-on-error: ${{ matrix.os == 'macos-latest' }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/ci/jenkins_config
+++ b/ci/jenkins_config
@@ -21,7 +21,7 @@ pipeline {
           agent {
             docker {
               image "rombur/adamantine-stack:no_gpu-latest"
-                alwaysPull true
+                alwaysPull false
                 label 'nvidia-docker || rocm-docker'
             }
           }
@@ -56,7 +56,7 @@ pipeline {
           agent {
             docker {
               image "rombur/adamantine-stack:latest"
-                alwaysPull true
+                alwaysPull false
                 label 'nvidia-docker && ampere'
             }
           }


### PR DESCRIPTION
The CI does not pass anymore because we reach the rate limit. Since we update the image once or twice a year, I'll just go on the different machines and update the images manually.

Second change: according to copilot the failure on the nix macos build is due to a problem upstream. I changed the CI, so that nix ubuntu runs even if nix macos fails