### PR TITLE
Fix mechanical constitutive stress history

### DIFF
--- a/source/MechanicalPhysics.cc
+++ b/source/MechanicalPhysics.cc
@@ -33,6 +33,7 @@ MechanicalPhysics<dim, n_materials, p_order, MaterialStates, MemorySpaceType>::
     : _geometry(geometry), _boundary(boundary),
       _material_properties(material_properties),
       _dof_handler(_geometry.get_triangulation()),
+      _reference_temperatures(reference_temperatures),
       _solution_transfer(_dof_handler),
       _closest_quad_point_adaptation(dealii::QGauss<dim>(fe_degree + 1)),
       _cell_data_transfer(
@@ -110,6 +111,7 @@ MechanicalPhysics<dim, n_materials, p_order, MaterialStates, MemorySpaceType>::
                  std::vector<dealii::SymmetricTensor<2, dim>>(n_quad_pts));
   _back_stress.resize(n_active_cells,
                       std::vector<dealii::SymmetricTensor<2, dim>>(n_quad_pts));
+  _thermal_stress.resize(n_active_cells, std::vector<double>(n_quad_pts));
 }
 
 template <int dim, int n_materials, int p_order, typename MaterialStates,
@@ -162,6 +164,9 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
         std::vector<bool> const &has_melted,
         std::vector<std::shared_ptr<BodyForce<dim>>> const &body_forces)
 {
+  _thermal_dof_handler = &thermal_dof_handler;
+  _temperature = temperature;
+  _has_melted = has_melted;
   _mechanical_operator->update_temperature(thermal_dof_handler, temperature,
                                            has_melted);
   _mechanical_operator->assemble_rhs(body_forces);
@@ -177,12 +182,12 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
 
   _data_to_transfer.clear();
   unsigned int const n_quad_pts = _q_collection.max_n_quadrature_points();
-  unsigned int const n_doubles_per_quad_plastic = 1;
+  unsigned int const n_doubles_per_quad_scalar = 2;
   unsigned int const n_doubles_per_quad_stress =
       dealii::SymmetricTensor<2, dim>::n_independent_components;
 
   unsigned int const n_doubles_per_quad =
-      n_doubles_per_quad_plastic + n_doubles_per_quad_stress * 2;
+      n_doubles_per_quad_scalar + n_doubles_per_quad_stress * 2;
   std::vector<std::vector<double>> dummy_cell_data(
       n_quad_pts, std::vector<double>(n_doubles_per_quad,
                                       std::numeric_limits<double>::infinity()));
@@ -192,14 +197,15 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
   {
     if (cell->is_locally_owned())
     {
-      unsigned int const stress_offset = n_doubles_per_quad_plastic;
+      unsigned int const stress_offset = n_doubles_per_quad_scalar;
       unsigned int const back_stress_offset =
-          n_doubles_per_quad_plastic + n_doubles_per_quad_stress;
+          n_doubles_per_quad_scalar + n_doubles_per_quad_stress;
 
       for (unsigned int quad = 0; quad < n_quad_pts; ++quad)
       {
         std::vector<double> &cell_data_quad = cell_data[quad];
         cell_data_quad[0] = _plastic_internal_variable[cell_id][quad];
+        cell_data_quad[1] = _thermal_stress[cell_id][quad];
         for (unsigned int i = 0; i < n_doubles_per_quad_stress; ++i)
         {
           cell_data_quad[stress_offset + i] =
@@ -243,17 +249,18 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
 
   _plastic_internal_variable.resize(n_active_cells,
                                     std::vector<double>(n_quad_pts));
+  _thermal_stress.resize(n_active_cells, std::vector<double>(n_quad_pts));
   _stress.resize(n_active_cells,
                  std::vector<dealii::SymmetricTensor<2, dim>>(n_quad_pts));
   _back_stress.resize(n_active_cells,
                       std::vector<dealii::SymmetricTensor<2, dim>>(n_quad_pts));
 
-  unsigned int const n_doubles_per_quad_plastic = 1;
+  unsigned int const n_doubles_per_quad_scalar = 2;
   unsigned int const n_doubles_per_quad_stress =
       dealii::SymmetricTensor<2, dim>::n_independent_components;
 
   unsigned int const n_doubles_per_quad =
-      n_doubles_per_quad_plastic + n_doubles_per_quad_stress * 2;
+      n_doubles_per_quad_scalar + n_doubles_per_quad_stress * 2;
   std::vector<std::vector<std::vector<double>>> data_to_unpack(
       n_active_cells, std::vector<std::vector<double>>(
                           n_quad_pts, std::vector<double>(n_doubles_per_quad)));
@@ -264,14 +271,15 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
   {
     if (cell->is_locally_owned())
     {
-      unsigned int const stress_offset = n_doubles_per_quad_plastic;
+      unsigned int const stress_offset = n_doubles_per_quad_scalar;
       unsigned int const back_stress_offset =
-          n_doubles_per_quad_plastic + n_doubles_per_quad_stress;
+          n_doubles_per_quad_scalar + n_doubles_per_quad_stress;
 
       for (unsigned int quad = 0; quad < n_quad_pts; ++quad)
       {
         _plastic_internal_variable[cell_id][quad] =
             data_to_unpack[cell_id][quad][0];
+        _thermal_stress[cell_id][quad] = data_to_unpack[cell_id][quad][1];
         for (unsigned int i = 0; i < n_doubles_per_quad_stress; ++i)
         {
           _stress[cell_id][quad].access_raw_entry(i) =
@@ -296,6 +304,9 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
         std::vector<bool> const &has_melted, bool rebuild_matrix,
         std::vector<std::shared_ptr<BodyForce<dim>>> const &body_forces)
 {
+  _thermal_dof_handler = &thermal_dof_handler;
+  _temperature = temperature;
+  _has_melted = has_melted;
   _mechanical_operator->update_temperature(thermal_dof_handler, temperature,
                                            has_melted);
   // Update the active fe indices, the plastic variables, and the displacement.
@@ -303,6 +314,7 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
   unsigned int cell_id = 0;
   std::vector<std::vector<double>> saved_old_displacement;
   std::vector<std::vector<double>> tmp_plastic_internal_variable;
+  std::vector<std::vector<double>> tmp_thermal_stress;
   std::vector<std::vector<dealii::SymmetricTensor<2, dim>>> tmp_stress;
   std::vector<std::vector<dealii::SymmetricTensor<2, dim>>> tmp_back_stress;
   // The number of cells to activate/deactive should be small, so we can
@@ -312,6 +324,7 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
   std::vector<dealii::types::global_dof_index> global_dof_indices(
       n_dofs_per_cell);
   tmp_plastic_internal_variable.reserve(n_old_active_cells);
+  tmp_thermal_stress.reserve(n_old_active_cells);
   tmp_stress.reserve(n_old_active_cells);
   tmp_back_stress.reserve(_back_stress.size());
   // First we save _old_displacement if it exists
@@ -370,6 +383,7 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
           // The cells is unchanged, we just copy the plastic variables as-is.
           tmp_plastic_internal_variable.push_back(
               _plastic_internal_variable[cell_id]);
+          tmp_thermal_stress.push_back(_thermal_stress[cell_id]);
           tmp_stress.push_back(_stress[cell_id]);
           tmp_back_stress.push_back(_back_stress[cell_id]);
         }
@@ -381,6 +395,7 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
               cell, StateProperty::elastic_limit);
           tmp_plastic_internal_variable.push_back(
               std::vector<double>(n_quad_pts, elastic_limit));
+          tmp_thermal_stress.push_back(std::vector<double>(n_quad_pts));
           tmp_stress.push_back(
               std::vector<dealii::SymmetricTensor<2, dim>>(n_quad_pts));
           tmp_back_stress.push_back(
@@ -401,6 +416,7 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
         cell->set_active_fe_index(1);
         tmp_plastic_internal_variable.push_back(std::vector<double>(
             n_quad_pts, std::numeric_limits<double>::signaling_NaN()));
+        tmp_thermal_stress.push_back(std::vector<double>(n_quad_pts));
         tmp_stress.push_back(
             std::vector<dealii::SymmetricTensor<2, dim>>(n_quad_pts));
         tmp_back_stress.push_back(
@@ -411,6 +427,7 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
     {
       tmp_plastic_internal_variable.push_back(std::vector<double>(
           n_quad_pts, std::numeric_limits<double>::signaling_NaN()));
+      tmp_thermal_stress.push_back(std::vector<double>(n_quad_pts));
       tmp_stress.push_back(
           std::vector<dealii::SymmetricTensor<2, dim>>(n_quad_pts));
       tmp_back_stress.push_back(
@@ -436,6 +453,7 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
   }
 
   _plastic_internal_variable.swap(tmp_plastic_internal_variable);
+  _thermal_stress.swap(tmp_thermal_stress);
   _stress.swap(tmp_stress);
   _back_stress.swap(tmp_back_stress);
 
@@ -561,7 +579,43 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
       _fe_collection, _q_collection, dealii::update_gradients);
   unsigned int const n_q_points = _q_collection.max_n_quadrature_points();
   std::vector<dealii::SymmetricTensor<2, dim>> strain_tensor(n_q_points);
+  std::vector<double> temperature_values(n_q_points);
   const dealii::FEValuesExtractors::Vector displacement_extr(0);
+  std::unique_ptr<dealii::hp::FEValues<dim>> temperature_hp_fe_values;
+  std::vector<unsigned int> cell_indices;
+  // When solving a thermomechanical problem, we create mapping between the
+  // active cells of the mechanical problem and the active cells of the thermal
+  // problem. Liquid cells are active in the thermal problem but not in the
+  // mechanical problem.
+  if (!_reference_temperatures.empty())
+  {
+    _temperature.update_ghost_values();
+    temperature_hp_fe_values = std::make_unique<dealii::hp::FEValues<dim>>(
+        _thermal_dof_handler->get_fe_collection(), _q_collection,
+        dealii::update_values);
+
+    auto &triangulation = _dof_handler.get_triangulation();
+    cell_indices.resize(triangulation.n_active_cells());
+    unsigned int thermal_cell_index = 0;
+    for (auto const &tria_cell :
+         triangulation.active_cell_iterators() |
+             dealii::IteratorFilters::LocallyOwnedCell())
+    {
+      dealii::TriaIterator<dealii::DoFCellAccessor<dim, dim, false>>
+          temperature_cell(&triangulation, tria_cell->level(),
+                           tria_cell->index(), _thermal_dof_handler);
+      if (temperature_cell->active_fe_index() == 0)
+      {
+        dealii::TriaIterator<dealii::DoFCellAccessor<dim, dim, false>>
+            displacement_cell(&triangulation, tria_cell->level(),
+                              tria_cell->index(), &_dof_handler);
+        if (displacement_cell->active_fe_index() == 0)
+          cell_indices[displacement_cell->active_cell_index()] =
+              thermal_cell_index;
+        ++thermal_cell_index;
+      }
+    }
+  }
   unsigned int cell_id = 0;
   for (auto const &cell : _dof_handler.active_cell_iterators())
   {
@@ -579,6 +633,24 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
       fe_values[displacement_extr].get_function_symmetric_gradients(
           displacement, strain_tensor);
 
+      double reference_temperature = 0.;
+      if (!_reference_temperatures.empty())
+      {
+        auto &triangulation = _dof_handler.get_triangulation();
+        dealii::TriaIterator<dealii::DoFCellAccessor<dim, dim, false>>
+            temperature_cell(&triangulation, cell->level(), cell->index(),
+                             _thermal_dof_handler);
+        temperature_hp_fe_values->reinit(temperature_cell);
+        auto const &temperature_fe_values =
+            temperature_hp_fe_values->get_present_fe_values();
+        temperature_fe_values.get_function_values(_temperature,
+                                                  temperature_values);
+        reference_temperature =
+            _has_melted[cell_indices[cell->active_cell_index()]]
+                ? _reference_temperatures[temperature_cell->material_id()]
+                : _reference_temperatures.back();
+      }
+
       double const lambda = _material_properties.get_mechanical_property(
           cell, StateProperty::lame_first_parameter);
       double const mu = _material_properties.get_mechanical_property(
@@ -589,6 +661,9 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
       double const iso_hardening_coef =
           _material_properties.get_mechanical_property(
               cell, StateProperty::isotropic_hardening);
+      double const alpha = _material_properties.get_mechanical_property(
+          cell, StateProperty::thermal_expansion_coef);
+      double const beta = (3. * lambda + 2. * mu) * alpha;
       dealii::SymmetricTensor<4, dim> stiffness_tensor =
           lambda * dealii::outer_product(dealii::unit_symmetric_tensor<dim>(),
                                          dealii::unit_symmetric_tensor<dim>()) +
@@ -599,11 +674,23 @@ void MechanicalPhysics<dim, n_materials, p_order, MaterialStates,
         // Compute the trial elastic stress.
         dealii::SymmetricTensor<2, dim> elastic_stress = _stress[cell_id][q];
         elastic_stress += stiffness_tensor * strain_tensor[q];
+        if (!_reference_temperatures.empty())
+        {
+          // Compute the thermal stress due to temperature change since the last
+          // time step. The rest of the termal stress in already included in the
+          // previous strees.
+          double const current_thermal_stress =
+              beta * (temperature_values[q] - reference_temperature);
+          elastic_stress -=
+              (current_thermal_stress - _thermal_stress[cell_id][q]) *
+              dealii::unit_symmetric_tensor<dim>();
+          _thermal_stress[cell_id][q] = current_thermal_stress;
+        }
 
         auto stress_deviator = dealii::deviator(elastic_stress);
         auto effective_stress = stress_deviator - _back_stress[cell_id][q];
         double const effective_stress_norm = effective_stress.norm();
-        if (effective_stress_norm < _plastic_internal_variable[cell_id][q])
+        if (effective_stress_norm <= _plastic_internal_variable[cell_id][q])
         {
           // The deformation is elastic. We just update the stress with the
           // elastic stress.

--- a/source/MechanicalPhysics.hh
+++ b/source/MechanicalPhysics.hh
@@ -147,6 +147,25 @@ private:
                                      MemorySpaceType>>
       _mechanical_operator;
   /**
+   * Reference temperature for each material followed by the initial
+   * temperature of the substrate. An empty vector denotes a mechanical-only
+   * simulation.
+   */
+  std::vector<double> _reference_temperatures;
+  /**
+   * Non-owning pointer to the thermal DoFHandler.
+   */
+  dealii::DoFHandler<dim> const *_thermal_dof_handler = nullptr;
+  /**
+   * Current temperature field.
+   */
+  dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host>
+      _temperature;
+  /**
+   * Indicator for cells that have melted at least once.
+   */
+  std::vector<bool> _has_melted;
+  /**
    * Whether to include a gravitional body force in the calculation.
    */
   bool _include_gravity;
@@ -161,6 +180,11 @@ private:
    * Plastic internal variable related to the strain
    */
   std::vector<std::vector<double>> _plastic_internal_variable;
+
+  /**
+   * Hydrostatic thermal stress at the previous mechanical solve.
+   */
+  std::vector<std::vector<double>> _thermal_stress;
 
   /**
    * Stress tensor at each (cell, quadrature point).
@@ -193,8 +217,8 @@ private:
 
   /**
    * Cell data transfer object used for updating _plastic_internal_variable,
-   * _stress, and _back_stress when the triangulation is updated when adding
-   * material
+   * _thermal_stress, _stress, and _back_stress when the triangulation is
+   * updated when adding material
    */
   dealii::parallel::distributed::CellDataTransfer<
       dim, dim, std::vector<std::vector<std::vector<double>>>>

--- a/tests/test_mechanical_physics.cc
+++ b/tests/test_mechanical_physics.cc
@@ -1,4 +1,4 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2022 - 2025, the adamantine authors.
+/* SPDX-FileCopyrightText: Copyright (c) 2022 - 2026, the adamantine authors.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
@@ -32,6 +32,7 @@
 #include <deal.II/numerics/matrix_tools.h>
 #include <deal.II/numerics/vector_tools.h>
 
+#include <cmath>
 #include <fstream>
 #include <iostream>
 
@@ -366,16 +367,18 @@ public:
 namespace utf = boost::unit_test;
 
 /*
- * This test case uses the analytic solution for the displacement around a
- * spherical inclusion as a test case. As a result of the boundary conditions
- * (fixed on one face) and the need to keep the test computationally
- * inexpensive, a loose tolerance has been chosen. Also for simplicity, the
- * analytic solution is being calculated externally and the values at only two
- * points are being checked.
+ * This test uses Eshelby's analytical solution for a spherical inclusion with
+ * uniform isotropic eigenstrain. For equal elastic properties inside and
+ * outside the sphere, u = A r inside and u = A a^3 r/|r|^3 outside, where
+ * A = 3 K alpha DeltaT / (3 K + 4 mu).
  *
- int constexpr dim = 3;* Less than 5% deviation from analytic solution achieved
- with
- * refinement_cyles=5.
+ * Reference: J. D. Eshelby, "The Determination of the Elastic Field of an
+ * Ellipsoidal Inclusion, and Related Problems", Proc. Royal Soc. A 241
+ * (1957), 376-396, DOI: 10.1098/rspa.1957.0133.
+ *
+ * The finite domain is clamped on one face and kept deliberately coarse, so
+ * the two sampled displacements use a loose tolerance. Less than 5% deviation
+ * is obtained with five refinement cycles.
  */
 template <unsigned int dim>
 std::vector<dealii::Vector<double>>
@@ -556,21 +559,19 @@ BOOST_AUTO_TEST_CASE(thermoelastic_eshelby, *utf::tolerance(0.16))
   }
 }
 
-BOOST_AUTO_TEST_CASE(elastoplastic)
+BOOST_AUTO_TEST_CASE(elastoplastic_radial_return)
 {
   MPI_Comm communicator = MPI_COMM_WORLD;
 
-  // Geometry database
   boost::property_tree::ptree geometry_database;
   geometry_database.put("import_mesh", false);
-  geometry_database.put("length", 12);
-  geometry_database.put("length_divisions", 6);
-  geometry_database.put("height", 6);
-  geometry_database.put("height_divisions", 3);
-  geometry_database.put("width", 6);
-  geometry_database.put("width_divisions", 3);
+  geometry_database.put("length", 1.);
+  geometry_database.put("length_divisions", 2);
+  geometry_database.put("height", 1.);
+  geometry_database.put("height_divisions", 2);
+  geometry_database.put("width", 1.);
+  geometry_database.put("width_divisions", 2);
   boost::optional<boost::property_tree::ptree const &> units_optional_database;
-  // Build Geometry
   adamantine::Geometry<3> geometry(communicator, geometry_database,
                                    units_optional_database);
   auto const &triangulation = geometry.get_triangulation();
@@ -580,43 +581,89 @@ BOOST_AUTO_TEST_CASE(elastoplastic)
     cell->set_user_index(
         static_cast<int>(adamantine::SolidLiquidPowder::State::solid));
   }
-  // Create the MaterialProperty
+
+  double constexpr mu = 3.;
+  double constexpr plastic_modulus = 1.5;
+  double constexpr isotropic_hardening = 0.25;
   boost::property_tree::ptree material_database;
   material_database.put("property_format", "polynomial");
   material_database.put("n_materials", 1);
-  material_database.put("material_0.solid.density", 1.);
   material_database.put("material_0.solid.lame_first_parameter", 2.);
-  material_database.put("material_0.solid.lame_second_parameter", 3.);
-  material_database.put("material_0.solid.plastic_modulus", 1.5);
-  material_database.put("material_0.solid.isotropic_hardening", 0.5);
-  material_database.put("material_0.solid.elastic_limit", 0.1);
+  material_database.put("material_0.solid.lame_second_parameter", mu);
+  material_database.put("material_0.solid.plastic_modulus", plastic_modulus);
+  material_database.put("material_0.solid.isotropic_hardening",
+                        isotropic_hardening);
+  material_database.put("material_0.solid.elastic_limit", 0.);
   adamantine::MaterialProperty<3, 1, 4, adamantine::SolidLiquidPowder,
                                dealii::MemorySpace::Host>
       material_properties(communicator, triangulation, material_database);
-  // Create the Boundary
+
   boost::property_tree::ptree boundary_database;
-  boundary_database.put("boundary_4.type", "clamped");
+  for (unsigned int id = 0; id < 6; ++id)
+    boundary_database.put("boundary_" + std::to_string(id) + ".type",
+                          "clamped");
   adamantine::Boundary boundary(
       boundary_database, geometry.get_triangulation().get_boundary_ids());
-  // Build MechanicalPhysics
-  unsigned int const fe_degree = 1;
-  std::vector<double> empty_vector;
+
+  std::vector<double> no_reference_temperatures;
   adamantine::MechanicalPhysics<3, 1, 4, adamantine::SolidLiquidPowder,
                                 dealii::MemorySpace::Host>
-      mechanical_physics(communicator, fe_degree, geometry, boundary,
-                         material_properties, empty_vector);
-  std::vector<std::shared_ptr<adamantine::BodyForce<3>>> body_forces;
-  auto gravity_force = std::make_shared<adamantine::GravityForce<
-      3, 1, 4, adamantine::SolidLiquidPowder, dealii::MemorySpace::Host>>(
-      material_properties);
-  body_forces.push_back(gravity_force);
-  mechanical_physics.setup_dofs(body_forces);
-  mechanical_physics.solve();
-  [[maybe_unused]] auto stress_tensor = mechanical_physics.get_stress_tensor();
-  // TODO check stress tensor
-}
+      mechanical_physics(communicator, 1, geometry, boundary,
+                         material_properties, no_reference_temperatures);
+  mechanical_physics.setup_dofs();
 
-// TODO thermo-elasto-plastic problem
+  // The documented elastic branch is chi <= kappa. In particular, chi =
+  // kappa = 0 must not enter the plastic branch and form the undefined 0/0
+  // flow direction.
+  mechanical_physics.solve();
+  auto &stress = mechanical_physics.get_stress_tensor();
+  for (auto const &cell_stress : stress)
+    for (auto const &value : cell_stress)
+    {
+      BOOST_CHECK_SMALL(value.norm(), 1.e-14);
+      for (unsigned int i = 0; i < value.n_independent_components; ++i)
+        BOOST_TEST(std::isfinite(value.access_raw_entry(i)));
+    }
+
+  // Combined isotropic-kinematic hardening radial return, following R. I.
+  // Borja, Plasticity: Modeling & Computation, Springer, 2013, Chapter 3,
+  // DOI: 10.1007/978-3-642-38547-6.
+  dealii::SymmetricTensor<2, 3> trial_stress;
+  trial_stress[0][0] = 1.;
+  trial_stress[1][1] = -1.;
+  double const trial_norm = trial_stress.norm();
+  auto const flow_direction = trial_stress / trial_norm;
+  for (auto &cell_stress : stress)
+    for (auto &value : cell_stress)
+      value = trial_stress;
+
+  mechanical_physics.solve();
+  double const plastic_increment_1 = trial_norm / (2. * mu + plastic_modulus);
+  double const returned_stress_norm =
+      trial_norm - 2. * mu * plastic_increment_1;
+  auto const expected_stress_1 = returned_stress_norm * flow_direction;
+  for (auto const &cell_stress : stress)
+    for (auto const &value : cell_stress)
+      BOOST_CHECK_SMALL((value - expected_stress_1).norm(), 1.e-12);
+
+  // A second collinear increment exercises the stored back stress. This is a
+  // regression for accidentally multiplying the kinematic update by H twice
+  // and omitting Delta eta.
+  double constexpr stress_increment = 0.2;
+  for (auto &cell_stress : stress)
+    for (auto &value : cell_stress)
+      value += stress_increment * flow_direction;
+
+  mechanical_physics.solve();
+  double const plastic_increment_2 =
+      stress_increment / (2. * mu + plastic_modulus);
+  double const expected_stress_norm =
+      returned_stress_norm + stress_increment - 2. * mu * plastic_increment_2;
+  auto const expected_stress_2 = expected_stress_norm * flow_direction;
+  for (auto const &cell_stress : stress)
+    for (auto const &value : cell_stress)
+      BOOST_CHECK_SMALL((value - expected_stress_2).norm(), 1.e-12);
+}
 
 BOOST_AUTO_TEST_CASE(cell_data_transfer_refine_coarsen)
 {
@@ -725,4 +772,93 @@ BOOST_AUTO_TEST_CASE(cell_data_transfer_refine_coarsen)
       }
     }
   }
+}
+
+BOOST_AUTO_TEST_CASE(thermoelastic_stress_uniform_heating)
+{
+  MPI_Comm communicator = MPI_COMM_WORLD;
+
+  boost::property_tree::ptree geometry_database;
+  geometry_database.put("import_mesh", false);
+  geometry_database.put("length", 1.);
+  geometry_database.put("length_divisions", 2);
+  geometry_database.put("height", 1.);
+  geometry_database.put("height_divisions", 2);
+  geometry_database.put("width", 1.);
+  geometry_database.put("width_divisions", 2);
+  boost::optional<boost::property_tree::ptree const &> units_optional_database;
+  adamantine::Geometry<3> geometry(communicator, geometry_database,
+                                   units_optional_database);
+  auto const &triangulation = geometry.get_triangulation();
+  for (auto cell : triangulation.cell_iterators())
+  {
+    cell->set_material_id(0);
+    cell->set_user_index(
+        static_cast<int>(adamantine::SolidLiquidPowder::State::solid));
+  }
+
+  double constexpr lambda = 2.;
+  double constexpr mu = 3.;
+  double constexpr alpha = 0.01;
+  boost::property_tree::ptree material_database;
+  material_database.put("property_format", "polynomial");
+  material_database.put("n_materials", 1);
+  material_database.put("material_0.solid.lame_first_parameter", lambda);
+  material_database.put("material_0.solid.lame_second_parameter", mu);
+  material_database.put("material_0.solid.thermal_expansion_coef", alpha);
+  adamantine::MaterialProperty<3, 1, 4, adamantine::SolidLiquidPowder,
+                               dealii::MemorySpace::Host>
+      material_properties(communicator, triangulation, material_database);
+
+  boost::property_tree::ptree boundary_database;
+  for (unsigned int id = 0; id < 6; ++id)
+    boundary_database.put("boundary_" + std::to_string(id) + ".type",
+                          "clamped");
+  adamantine::Boundary boundary(
+      boundary_database, geometry.get_triangulation().get_boundary_ids());
+
+  dealii::hp::FECollection<3> thermal_fe_collection;
+  thermal_fe_collection.push_back(dealii::FE_Q<3>(1));
+  thermal_fe_collection.push_back(dealii::FE_Nothing<3>());
+  dealii::DoFHandler<3> thermal_dof_handler(geometry.get_triangulation());
+  thermal_dof_handler.distribute_dofs(thermal_fe_collection);
+  dealii::LA::distributed::Vector<double, dealii::MemorySpace::Host>
+      temperature(thermal_dof_handler.locally_owned_dofs(), communicator);
+  temperature = 350.;
+
+  // For an unmelted substrate the last entry is the reference temperature.
+  std::vector<double> reference_temperatures = {1000., 300.};
+  std::vector<bool> has_melted(triangulation.n_active_cells(), false);
+  adamantine::MechanicalPhysics<3, 1, 4, adamantine::SolidLiquidPowder,
+                                dealii::MemorySpace::Host>
+      mechanical_physics(communicator, 1, geometry, boundary,
+                         material_properties, reference_temperatures);
+  mechanical_physics.setup_dofs(thermal_dof_handler, temperature, has_melted,
+                                true);
+  auto displacement = mechanical_physics.solve();
+  BOOST_CHECK_SMALL(displacement.l2_norm(), 1.e-12);
+
+  // A uniformly heated, fully constrained isotropic solid has u = 0 and
+  // sigma = -(3 lambda + 2 mu) alpha (T-T_ref) I. See Y. C. Fung and
+  // Pin Tong, Classical and Computational Solid Mechanics, World Scientific,
+  // 2001, Chapter 14, DOI: 10.1142/4362.
+  auto check_stress = [&](double temperature_value)
+  {
+    double const expected_normal_stress =
+        -(3. * lambda + 2. * mu) * alpha * (temperature_value - 300.);
+    auto const expected_stress =
+        expected_normal_stress * dealii::unit_symmetric_tensor<3>();
+    for (auto const &cell_stress : mechanical_physics.get_stress_tensor())
+      for (auto const &value : cell_stress)
+        BOOST_CHECK_SMALL((value - expected_stress).norm(), 1.e-12);
+  };
+  check_stress(350.);
+
+  // Updating the temperature must apply only the thermal stress increment, not
+  // the total thermal stress a second time.
+  temperature = 360.;
+  mechanical_physics.update_rhs(thermal_dof_handler, temperature, has_melted);
+  displacement = mechanical_physics.solve();
+  BOOST_CHECK_SMALL(displacement.l2_norm(), 1.e-12);
+  check_stress(360.);
 }


### PR DESCRIPTION
Similar to https://github.com/adamantine-sim/adamantine/pull/489, I asked chatGPT 5.6 Sol to check `MechanicalPhysics`. It found two bugs:

 1. In `MechanicalPhysics::compute_stress()` , we had
```cpp
if (effective_stress_norm < plastic_internal_variable)
```
even though the documented elastic condition is $\chi\leq\kappa$. For a stress-free material whose initial elastic
limit is zero, $\chi=\kappa=0$. The strict comparison sent that state to the plastic branch, which formed $\boldsymbol{n}=\frac{\boldsymbol{0}}{0}.$
In practice, we would never hit that bug but it's good to have the implementation match the algorithm in the documentation.

 2. This is more serious bug. `MechanicalPhysics::compute_stress()` updated the stored stress using only the displacement-strain increment:
```math
\boldsymbol{\sigma}_{n+1}
=\boldsymbol{\sigma}_n+\mathbb{C}:\Delta\boldsymbol{\varepsilon}.
```
The term $-\beta(T-T_{\mathrm{ref}})\boldsymbol{I}$ was absent. A uniformly heated cube constrained on every boundary has $\boldsymbol{u}=0$. The old postprocessing therefore stored zero stress, whereas the analytical solution is
```math
\boldsymbol{\sigma}
=-\beta(T-T_{\mathrm{ref}})\boldsymbol{I}.
```
This PR fixes the issue by storing the previous hydrostatic thermal-stress scalar at every cell quadrature point:
```math
b_n=\beta_n(T_n-T_{\mathrm{ref},n}).
```
The trial stress update is
```math
\boldsymbol{\sigma}^{\mathrm{trial}}_{n+1}
=\boldsymbol{\sigma}_n
+\mathbb{C}:\Delta\boldsymbol{\varepsilon}
-(b_{n+1}-b_n)\boldsymbol{I}.
```
Using the increment $b_{n+1}-b_n$ is important: adding the total thermal stress on every mechanical solve would count previous heating repeatedly. It also handles changes in material properties and changes from the initial substrate
reference temperature to the material-specific reference temperature after a cell melts.

I am now pretty confident that the thermoelasticity is correct.